### PR TITLE
Added build task for creating jar of exoplayer library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.10.+'
+        classpath 'com.android.tools.build:gradle:0.12.+'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 10 20:02:28 BST 2014
+#Mon Aug 04 10:23:32 EDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -32,6 +32,19 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    // Remove the created jar file.
+    task cleanJar(type: Delete) {
+        delete 'build/libs/exoplayer.jar'
+    }
+
+    // Create a jar file of the library. Put it into build/libs/exoplayer.jar.
+    task makeJar(type: Copy) {
+        from('build/intermediates/bundles/release/')
+        into('build/libs/')
+        include('classes.jar')
+        rename ('classes.jar', 'exoplayer.jar')
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Since it may be convenient to use a JAR of the Exoplayer library instead of as a library project (or Android Archive - aar), I've added a build task which creates a JAR of the library.

I've also updated the build system to use Gradle 0.12 instead of Gradle 0.10. This was done because the latest version of Android Studio (which is 0.8.2, at the time of writing) is not backward compatible with Gradle 0.10 anymore.
