### PR TITLE
  ensure that player do not release at ui thread to avoid ANR in some rom

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayerImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayerImpl.java
@@ -141,7 +141,19 @@ import java.util.concurrent.CopyOnWriteArraySet;
 
   @Override
   public void release() {
-    internalPlayer.release();
+    //ensure that player do not release at ui thread to avoid ANR in some rom
+    if(Looper.myLooper()==Looper.getMainLooper()){
+        new Thread(){
+            @Override
+            public void run() {
+                if(internalPlayer!=null) {
+                    internalPlayer.release();
+                }
+            }
+        }.start();
+    }else {
+        internalPlayer.release();
+    }
     eventHandler.removeCallbacksAndMessages(null);
   }
 


### PR DESCRIPTION
```
public synchronized void release() {
    if (!released) {
      handler.sendEmptyMessage(MSG_RELEASE);
      while (!released) {
        try {
          wait();
        } catch (InterruptedException e) {
          Thread.currentThread().interrupt();
        }
      }
      internalPlaybackThread.quit();
    }
  }
```

when execute at main thread,'wait();' may cause ANR in some rom.
