### PR TITLE
Fix readDescriptors function to read all the descriptors.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/parser/ts/TsExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer/parser/ts/TsExtractor.java
@@ -375,7 +375,8 @@ public final class TsExtractor {
           // Skip entire descriptor data.
           tsBuffer.skipBytes(descriptorsLength);
         }
-        descriptorsSize -= descriptorsSize + 2;
+        descriptorsSize -= descriptorsLength + 2; //        descriptorsSize -= descriptorsSize + 2; if you subtract it with descriptor size you will only skip the first descriptor.
+
       }
     }
 


### PR DESCRIPTION
Hi,
 I found an issue with the readdescriptos function bacically at the below line, this won't work if there are multiple descriptors. 

 descriptorsSize -= descriptorsSize + 2; if you subtract it with descriptor size you will only skip the first descriptor.

regards
Krishna
