### PR TITLE
AudioTrack will mark 0-size buffers as consumed

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/audio/AudioTrack.java
+++ b/library/src/main/java/com/google/android/exoplayer/audio/AudioTrack.java
@@ -399,6 +399,7 @@ public final class AudioTrack {
     }
 
     if (size == 0) {
+      result |= RESULT_BUFFER_CONSUMED;
       return result;
     }
 


### PR DESCRIPTION
This can happen in the first, non-codec-config output buffer
from MediaCodec, while decoding MP3 data.

This issue was discovered on Nexus 5's running both KitKat
Lollippop.
