### PR TITLE
Refine logic for determining AudioTrack size.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/Ac3PassthroughAudioTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/Ac3PassthroughAudioTrackRenderer.java
@@ -73,9 +73,6 @@ public final class Ac3PassthroughAudioTrackRenderer extends TrackRenderer {
   /** Default buffer size for AC-3 packets from the sample source */
   private static final int DEFAULT_BUFFER_SIZE = 16384 * 2;
 
-  /** Multiplication factor for the audio track's buffer size. */
-  private static final int MIN_BUFFER_MULTIPLICATION_FACTOR = 3;
-
   private final Handler eventHandler;
   private final EventListener eventListener;
 
@@ -103,15 +100,15 @@ public final class Ac3PassthroughAudioTrackRenderer extends TrackRenderer {
    *     null if delivery of events is not required.
    * @param eventListener A listener of events. May be null if delivery of events is not required.
    */
-  public Ac3PassthroughAudioTrackRenderer(
-      SampleSource source, Handler eventHandler, EventListener eventListener) {
+  public Ac3PassthroughAudioTrackRenderer(SampleSource source, Handler eventHandler,
+      EventListener eventListener) {
     this.source = Assertions.checkNotNull(source);
     this.eventHandler = eventHandler;
     this.eventListener = eventListener;
     sampleHolder = new SampleHolder(SampleHolder.BUFFER_REPLACEMENT_MODE_NORMAL);
     sampleHolder.data = ByteBuffer.allocateDirect(DEFAULT_BUFFER_SIZE);
     formatHolder = new MediaFormatHolder();
-    audioTrack = new AudioTrack(MIN_BUFFER_MULTIPLICATION_FACTOR);
+    audioTrack = new AudioTrack();
     shouldReadInputBuffer = true;
   }
 

--- a/library/src/main/java/com/google/android/exoplayer/MediaCodecAudioTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaCodecAudioTrackRenderer.java
@@ -17,7 +17,6 @@ package com.google.android.exoplayer;
 
 import com.google.android.exoplayer.audio.AudioTrack;
 import com.google.android.exoplayer.drm.DrmSessionManager;
-import com.google.android.exoplayer.util.Assertions;
 import com.google.android.exoplayer.util.MimeTypes;
 
 import android.annotation.TargetApi;
@@ -64,10 +63,9 @@ public class MediaCodecAudioTrackRenderer extends MediaCodecTrackRenderer {
   public static final int MSG_SET_VOLUME = 1;
 
   private final EventListener eventListener;
-
   private final AudioTrack audioTrack;
-  private int audioSessionId;
 
+  private int audioSessionId;
   private long currentPositionUs;
 
   /**
@@ -118,72 +116,10 @@ public class MediaCodecAudioTrackRenderer extends MediaCodecTrackRenderer {
    */
   public MediaCodecAudioTrackRenderer(SampleSource source, DrmSessionManager drmSessionManager,
       boolean playClearSamplesWithoutKeys, Handler eventHandler, EventListener eventListener) {
-    this(source, drmSessionManager, playClearSamplesWithoutKeys, eventHandler, eventListener,
-        new AudioTrack());
-  }
-
-  /**
-   * @param source The upstream source from which the renderer obtains samples.
-   * @param minBufferMultiplicationFactor When instantiating an underlying
-   *     {@link android.media.AudioTrack}, the size of the track is calculated as this value
-   *     multiplied by the minimum buffer size obtained from
-   *     {@link android.media.AudioTrack#getMinBufferSize(int, int, int)}. The multiplication
-   *     factor must be greater than or equal to 1.
-   * @param eventHandler A handler to use when delivering events to {@code eventListener}. May be
-   *     null if delivery of events is not required.
-   * @param eventListener A listener of events. May be null if delivery of events is not required.
-   */
-  public MediaCodecAudioTrackRenderer(SampleSource source, float minBufferMultiplicationFactor,
-      Handler eventHandler, EventListener eventListener) {
-    this(source, null, true, minBufferMultiplicationFactor, eventHandler, eventListener);
-  }
-
-  /**
-   * @param source The upstream source from which the renderer obtains samples.
-   * @param drmSessionManager For use with encrypted content. May be null if support for encrypted
-   *     content is not required.
-   * @param playClearSamplesWithoutKeys Encrypted media may contain clear (un-encrypted) regions.
-   *     For example a media file may start with a short clear region so as to allow playback to
-   *     begin in parallel with key acquisision. This parameter specifies whether the renderer is
-   *     permitted to play clear regions of encrypted media files before {@code drmSessionManager}
-   *     has obtained the keys necessary to decrypt encrypted regions of the media.
-   * @param minBufferMultiplicationFactor When instantiating an underlying
-   *     {@link android.media.AudioTrack}, the size of the track is calculated as this value
-   *     multiplied by the minimum buffer size obtained from
-   *     {@link android.media.AudioTrack#getMinBufferSize(int, int, int)}. The multiplication
-   *     factor must be greater than or equal to 1.
-   * @param eventHandler A handler to use when delivering events to {@code eventListener}. May be
-   *     null if delivery of events is not required.
-   * @param eventListener A listener of events. May be null if delivery of events is not required.
-   */
-  public MediaCodecAudioTrackRenderer(SampleSource source, DrmSessionManager drmSessionManager,
-      boolean playClearSamplesWithoutKeys, float minBufferMultiplicationFactor,
-      Handler eventHandler, EventListener eventListener) {
-    this(source, drmSessionManager, playClearSamplesWithoutKeys, eventHandler, eventListener,
-        new AudioTrack(minBufferMultiplicationFactor));
-  }
-
-  /**
-   * @param source The upstream source from which the renderer obtains samples.
-   * @param drmSessionManager For use with encrypted content. May be null if support for encrypted
-   *     content is not required.
-   * @param playClearSamplesWithoutKeys Encrypted media may contain clear (un-encrypted) regions.
-   *     For example a media file may start with a short clear region so as to allow playback to
-   *     begin in parallel with key acquisision. This parameter specifies whether the renderer is
-   *     permitted to play clear regions of encrypted media files before {@code drmSessionManager}
-   *     has obtained the keys necessary to decrypt encrypted regions of the media.
-   * @param eventHandler A handler to use when delivering events to {@code eventListener}. May be
-   *     null if delivery of events is not required.
-   * @param eventListener A listener of events. May be null if delivery of events is not required.
-   * @param audioTrack Used for playing back decoded audio samples.
-   */
-  public MediaCodecAudioTrackRenderer(SampleSource source, DrmSessionManager drmSessionManager,
-      boolean playClearSamplesWithoutKeys, Handler eventHandler, EventListener eventListener,
-      AudioTrack audioTrack) {
     super(source, drmSessionManager, playClearSamplesWithoutKeys, eventHandler, eventListener);
     this.eventListener = eventListener;
-    this.audioTrack = Assertions.checkNotNull(audioTrack);
     this.audioSessionId = AudioTrack.SESSION_ID_NOT_SET;
+    this.audioTrack = new AudioTrack();
   }
 
   @Override


### PR DESCRIPTION
- Target 4x the minimum specified by the framework.
- Impose a minimum duration (250ms).
- Impose a maximum duration (750ms, or the minimum
  specified by the framework if that's larger).

I've removed the ability to specify the multiplication
factor, since the underlying implementation is getting more
complicated, and we should really be able to figure this out
internally.