### PR TITLE
Fix infinite loop in the case where an output buffer of size 0 is return...

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/MediaCodecTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaCodecTrackRenderer.java
@@ -737,6 +737,11 @@ public abstract class MediaCodecTrackRenderer extends TrackRenderer {
       return false;
     }
 
+    if (outputBufferInfo.size == 0) {
+        outputIndex = -1;
+        return true;
+    }
+
     int decodeOnlyIndex = getDecodeOnlyIndex(outputBufferInfo.presentationTimeUs);
     if (processOutputBuffer(positionUs, elapsedRealtimeUs, codec, outputBuffers[outputIndex],
         outputBufferInfo, outputIndex, decodeOnlyIndex != -1)) {


### PR DESCRIPTION
There exists a case where dequeueOutputBuffer will return an outputIndex >= 0 with an outputBufferInfo.size == 0. When this happens, processOutputBuffer will return false so the method will exist without reseting outputIndex to -1. This effectively causes an infinite loop because subsequent calls to drainOutputBuffer will never attempt to dequeueOutputBuffer so the stream will not progress.

Not sure if my fix is the correct one but it fixes the problem for me.

Repros for me attempting to stream:
http://feeds.thisamericanlife.org/~r/talpodcast/~5/3LflCztSswE/544.mp3
