### PR TITLE
Fix a signed right shift issue in BitArray.readUnsignedByte()

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/util/BitArray.java
+++ b/library/src/main/java/com/google/android/exoplayer/util/BitArray.java
@@ -151,7 +151,7 @@ public final class BitArray {
     byte b;
     if (bitOffset != 0) {
       b = (byte) ((data[byteOffset] << bitOffset)
-          | (data[byteOffset + 1] >> (8 - bitOffset)));
+          | ((data[byteOffset + 1] & 0xFF) >> (8 - bitOffset)));
     } else {
       b = data[byteOffset];
     }

--- a/library/src/main/java/com/google/android/exoplayer/util/BitArray.java
+++ b/library/src/main/java/com/google/android/exoplayer/util/BitArray.java
@@ -148,16 +148,15 @@ public final class BitArray {
    * @return The value of the parsed byte.
    */
   public int readUnsignedByte() {
-    byte b;
+    int value;
     if (bitOffset != 0) {
-      b = (byte) ((data[byteOffset] << bitOffset)
-          | ((data[byteOffset + 1] & 0xFF) >> (8 - bitOffset)));
+      value = (data[byteOffset] << bitOffset)
+          | ((data[byteOffset + 1] & 0xFF) >>> (8 - bitOffset));
     } else {
-      b = data[byteOffset];
+      value = data[byteOffset];
     }
     byteOffset++;
-    // Converting a signed byte into unsigned.
-    return b & 0xFF;
+    return value & 0xFF;
   }
 
   /**


### PR DESCRIPTION
To reproduce the issue, you can use the data: `0x00 0x01 0xe1 0x90` to create the BitArray, then:
```java
buffer.skipBits(19);
int value = buffer.readBits(13);
```
The expected value is `400 (0x0190)`, but the returned value is `8080 (0x1F90)`

The root cause is in `BitArray.readUnsignedByte()`, it uses signed right shift, so the high bits are all 1 if the byte is a negative value.
The fix is simply to make it unsigned right shift.

