### PR TITLE
Fixed wrong calculation of last segment number when using segment templa...

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/dash/mpd/SegmentBase.java
+++ b/library/src/main/java/com/google/android/exoplayer/dash/mpd/SegmentBase.java
@@ -301,7 +301,7 @@ public abstract class SegmentBase {
         return DashSegmentIndex.INDEX_UNBOUNDED;
       } else {
         long durationMs = (duration * 1000) / timescale;
-        return startNumber + (int) (periodDurationMs / durationMs);
+        return startNumber + (int) (periodDurationMs / durationMs) - 1;
       }
     }
 


### PR DESCRIPTION
There was a mistake in method getLastSegmentNum() of SegmentTemplate class. For segment templates without segment timeline last segment number was calculated as start segment number + segment count, so calculated last segment number was larger than actual last segment number by 1.
As a result of this bug the next exception was occurring when playing MPD file using segment templates without segment timeline:

01-25 18:26:00.660  30209-30209/com.google.android.exoplayer.demo E/EventLogger﹕ internalError [11.50, upstreamError]
    com.google.android.exoplayer.upstream.HttpDataSource$InvalidResponseCodeException: Response code: 404
            at com.google.android.exoplayer.upstream.HttpDataSource.open(HttpDataSource.java:264)
            at com.google.android.exoplayer.upstream.UriDataSource.open(UriDataSource.java:66)
            at com.google.android.exoplayer.upstream.DataSourceStream.load(DataSourceStream.java:223)
            at com.google.android.exoplayer.chunk.Chunk.load(Chunk.java:179)
            at com.google.android.exoplayer.upstream.Loader$LoadTask.run(Loader.java:206)
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:422)
            at java.util.concurrent.FutureTask.run(FutureTask.java:237)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
            at java.lang.Thread.run(Thread.java:841)

As ExoPlayer was trying to get segment which didn't exist. Example MPD file: 
http://dash.edgesuite.net/dash264/TestCases/5a/1/manifest.mpd

Also if such MPD file contained next period with appropriate segment file name, one segment from next period was playing in current period. Example MPD file: 
http://dash.edgesuite.net/dash264/TestCases/5b/1/manifest.mpd