### PR TITLE
Fixing issue with getSampleQueue

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/parser/TsExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/parser/TsExtractor.java
@@ -196,7 +196,7 @@ public final class TsExtractor extends HlsExtractor {
 
   @Override
   protected SampleQueue getSampleQueue(int track) {
-    Assertions.checkState(track == 0);
+    //Assertions.checkState(track == 0);
     return sampleQueues.valueAt(track);
   }
 


### PR DESCRIPTION
As far as I see, doesn’t make sense that track parameter received by
getSampleQueue method is always set to 0. It could vary depending on
the number of tracks defined in each TS segment and typically has at
least 2 (one for video, one for audio).

This is breaking HLS playback for any stream containing more than 1
track so I am commenting out this method (this line should be removed).