### PR TITLE
Issue with regular expression for CODEC attribute

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -60,7 +60,7 @@ public final class HlsPlaylistParser implements ManifestParser<HlsPlaylist> {
   private static final Pattern BANDWIDTH_ATTR_REGEX =
       Pattern.compile(BANDWIDTH_ATTR + "=(\\d+)\\b");
   private static final Pattern CODECS_ATTR_REGEX =
-      Pattern.compile(CODECS_ATTR + "=\"(.+)\"");
+      Pattern.compile(CODECS_ATTR + "=\"(.+?)\"");
   private static final Pattern RESOLUTION_ATTR_REGEX =
       Pattern.compile(RESOLUTION_ATTR + "=(\\d+x\\d+)");
 


### PR DESCRIPTION
Previous regular expression for extracting codec information was wrong,
given a line that defines a variant it added information from “CODEC=“
text to the end of the line (including also information about
RESOLUTION or alternate rendition groups as part of the CODEC field).

This is not causing a functional problem (at least known by me)
although is making codecs field storing information that is not related
with the codec.