### PR TITLE
Better management of blacklisted playlists

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -258,7 +258,6 @@ public class HlsChunkSource {
     if (adaptiveMode == ADAPTIVE_MODE_NONE) {
       // Do nothing.
     } else {
-      clearStaleBlacklistedPlaylists();
       nextVariantIndex = getNextVariantIndex(previousTsChunk, playbackPositionUs);
       switchingVariant = nextVariantIndex != variantIndex;
       switchingVariantSpliced = switchingVariant && adaptiveMode == ADAPTIVE_MODE_SPLICE;
@@ -392,6 +391,7 @@ public class HlsChunkSource {
   }
 
   private int getNextVariantIndex(TsChunk previousTsChunk, long playbackPositionUs) {
+    clearStaleBlacklistedPlaylists();
     int idealVariantIndex = getVariantIndexForBandwdith(
         (int) (bandwidthMeter.getBitrateEstimate() * BANDWIDTH_FRACTION));
     if (idealVariantIndex == variantIndex) {

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -372,7 +372,7 @@ public class HlsChunkSource {
         MediaPlaylistChunk playlistChunk = (MediaPlaylistChunk) chunk;
         mediaPlaylistBlacklistFlags[playlistChunk.variantIndex] = true;
         mediaPlaylistBlacklistedTimeMs[playlistChunk.variantIndex] = SystemClock.elapsedRealtime();
-        evaluatePlaylistBlacklistedTimestamps();
+        clearStaleBlacklistedPlaylists();
         if (!allPlaylistsBlacklisted()) {
           // We've handled the 404/410 by blacklisting the playlist.
           Log.w(TAG, "Blacklisted playlist (" + responseCode + "): "
@@ -553,11 +553,11 @@ public class HlsChunkSource {
     return true;
   }
 
-  private void evaluatePlaylistBlacklistedTimestamps()
-  {
+  private void clearStaleBlacklistedPlaylists() {
     long currentTime = SystemClock.elapsedRealtime();
     for (int i = 0; i < mediaPlaylistBlacklistFlags.length; i++) {
-      if (mediaPlaylistBlacklistFlags[i] && currentTime - mediaPlaylistBlacklistedTimeMs[i] > DEFAULT_MAX_TIME_MEDIA_PLAYLIST_BLACKLISTED_MS) {
+      if (mediaPlaylistBlacklistFlags[i] &&
+          currentTime - mediaPlaylistBlacklistedTimeMs[i] > DEFAULT_MAX_TIME_MEDIA_PLAYLIST_BLACKLISTED_MS) {
         mediaPlaylistBlacklistFlags[i] = false;
         mediaPlaylistBlacklistedTimeMs[i] = 0;
       }

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -258,6 +258,7 @@ public class HlsChunkSource {
     if (adaptiveMode == ADAPTIVE_MODE_NONE) {
       // Do nothing.
     } else {
+      clearStaleBlacklistedPlaylists();
       nextVariantIndex = getNextVariantIndex(previousTsChunk, playbackPositionUs);
       switchingVariant = nextVariantIndex != variantIndex;
       switchingVariantSpliced = switchingVariant && adaptiveMode == ADAPTIVE_MODE_SPLICE;
@@ -372,7 +373,6 @@ public class HlsChunkSource {
         MediaPlaylistChunk playlistChunk = (MediaPlaylistChunk) chunk;
         mediaPlaylistBlacklistFlags[playlistChunk.variantIndex] = true;
         mediaPlaylistBlacklistedTimeMs[playlistChunk.variantIndex] = SystemClock.elapsedRealtime();
-        clearStaleBlacklistedPlaylists();
         if (!allPlaylistsBlacklisted()) {
           // We've handled the 404/410 by blacklisting the playlist.
           Log.w(TAG, "Blacklisted playlist (" + responseCode + "): "


### PR DESCRIPTION
Added an expiration time field to playlists blacklisted to allow
Exoplayer to continue playback when playlists that failed were
recovered from a bad state.

In live environments, some times occur that primary encoder stop
working for a while. In that cases, HLS failover mechanism in the
player should detect the situation and “switch” to playlists served by
the backup encoder (in case a backup encoder exists). This was well
managed before these changes.

However, and to ensure a playback experience that can recover itself
from temporary issues, we cannot blacklist a playlist forever. When
streaming live events using HLS, it is quite typical that the player
needs to switch from primary to backup playlists, and from backup to
primary ones, from time to time to have playback working when temporary
issues in the network/encoder are happening. Most of the issues are
recoverable, so what I have implemented is a mechanism that makes
blacklisted playlists to be available again after a while (60 seconds).

Evaluation of this algorithm should happen just when something fails.
If player is working with a backup playlist, it shouldn’t switch to the
primary one at least something fail.