### PR TITLE
Added support for new types of ID3 frames

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer/demo/Samples.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/Samples.java
@@ -123,6 +123,9 @@ import java.util.Locale;
     new Sample("Apple AAC media playlist",
         "https://devimages.apple.com.edgekey.net/streaming/examples/bipbop_4x3/gear0/"
         + "prog_index.m3u8", DemoUtil.TYPE_HLS),
+    new Sample("Apple ID3 metadata",
+        "http://devimages.apple.com/samplecode/adDemo/"
+        + "ad.m3u8", DemoUtil.TYPE_HLS),
   };
 
   public static final Sample[] MISC = new Sample[] {

--- a/library/src/main/java/com/google/android/exoplayer/metadata/GeobMetadata.java
+++ b/library/src/main/java/com/google/android/exoplayer/metadata/GeobMetadata.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer.metadata;
+
+/**
+ * A metadata that contains parsed ID3 GEOB (General Encapsulated Object) frame data associated
+ * with time indices.
+ */
+public class GeobMetadata {
+
+  public static final String TYPE = "GEOB";
+
+  public final String mimeType;
+  public final String filename;
+  public final String description;
+  public final byte[] data;
+
+  public GeobMetadata(String mimeType, String filename, String description, byte[] data) {
+    this.mimeType = mimeType;
+    this.filename = filename;
+    this.description = description;
+    this.data = data;
+  }
+
+}

--- a/library/src/main/java/com/google/android/exoplayer/metadata/Id3Parser.java
+++ b/library/src/main/java/com/google/android/exoplayer/metadata/Id3Parser.java
@@ -70,7 +70,7 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
         int valueStartIndex = firstZeroIndex + delimiterLength(encoding);
         int valueEndIndex = indexOfEOS(frame, valueStartIndex, encoding);
         String value = new String(frame, valueStartIndex, valueEndIndex - valueStartIndex,
-            charset);
+                                  charset);
         metadata.put(TxxxMetadata.TYPE, new TxxxMetadata(description, value));
       } else if (frameId0 == 'P' && frameId1 == 'R' && frameId2 == 'I' && frameId3 == 'V') {
         // Check frame ID == PRIV
@@ -98,7 +98,7 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
         int descriptionStartIndex = filenameEndIndex + delimiterLength(encoding);
         int descriptionEndIndex = indexOfEOS(frame, descriptionStartIndex, encoding);
         String description = new String(frame, descriptionStartIndex,
-                descriptionEndIndex - descriptionStartIndex, charset);
+                                        descriptionEndIndex - descriptionStartIndex, charset);
 
         byte[] objectData = new byte[frameSize - descriptionEndIndex - 2];
         System.arraycopy(frame, descriptionEndIndex + delimiterLength(encoding), objectData, 0,
@@ -121,15 +121,6 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
   private static int indexOf(byte[] data, int fromIndex, byte key) {
     for (int i = fromIndex; i < data.length; i++) {
       if (data[i] == key) {
-        return i;
-      }
-    }
-    return data.length;
-  }
-
-  private static int indexOfNot(byte[] data, int fromIndex, byte key) {
-    for (int i = fromIndex; i < data.length; i++) {
-      if (data[i] != key) {
         return i;
       }
     }

--- a/library/src/main/java/com/google/android/exoplayer/metadata/Id3Parser.java
+++ b/library/src/main/java/com/google/android/exoplayer/metadata/Id3Parser.java
@@ -70,7 +70,7 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
         int valueStartIndex = firstZeroIndex + delimiterLength(encoding);
         int valueEndIndex = indexOfEOS(frame, valueStartIndex, encoding);
         String value = new String(frame, valueStartIndex, valueEndIndex - valueStartIndex,
-                                  charset);
+            charset);
         metadata.put(TxxxMetadata.TYPE, new TxxxMetadata(description, value));
       } else if (frameId0 == 'P' && frameId1 == 'R' && frameId2 == 'I' && frameId3 == 'V') {
         // Check frame ID == PRIV
@@ -94,17 +94,19 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
         int filenameStartIndex = firstZeroIndex + delimiterLength(encoding);
         int filenameEndIndex = indexOfEOS(frame, filenameStartIndex, encoding);
         String filename = new String(frame, filenameStartIndex,
-                                     filenameEndIndex - filenameStartIndex, charset);
+            filenameEndIndex - filenameStartIndex, charset);
         int descriptionStartIndex = filenameEndIndex + delimiterLength(encoding);
         int descriptionEndIndex = indexOfEOS(frame, descriptionStartIndex, encoding);
         String description = new String(frame, descriptionStartIndex,
-                                        descriptionEndIndex - descriptionStartIndex, charset);
+            descriptionEndIndex - descriptionStartIndex, charset);
 
-        byte[] objectData = new byte[frameSize - descriptionEndIndex - 2];
+        int objectDataSize = frameSize - 1 /* encoding byte */ - descriptionEndIndex -
+            delimiterLength(encoding);
+        byte[] objectData = new byte[objectDataSize];
         System.arraycopy(frame, descriptionEndIndex + delimiterLength(encoding), objectData, 0,
-                         frameSize - descriptionEndIndex - 2);
+            objectDataSize);
         metadata.put(GeobMetadata.TYPE, new GeobMetadata(mimeType, filename,
-                                                         description, objectData));
+            description, objectData));
       } else {
         String type = String.format("%c%c%c%c", frameId0, frameId1, frameId2, frameId3);
         byte[] frame = new byte[frameSize];

--- a/library/src/main/java/com/google/android/exoplayer/metadata/Id3Parser.java
+++ b/library/src/main/java/com/google/android/exoplayer/metadata/Id3Parser.java
@@ -67,7 +67,7 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
 
         int firstZeroIndex = indexOfEOS(frame, 0, encoding);
         String description = new String(frame, 0, firstZeroIndex, charset);
-        int valueStartIndex = firstZeroIndex + 1;
+        int valueStartIndex = firstZeroIndex + delimiterLength(encoding);
         int valueEndIndex = indexOfEOS(frame, valueStartIndex, encoding);
         String value = new String(frame, valueStartIndex, valueEndIndex - valueStartIndex,
             charset);
@@ -91,17 +91,17 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
 
         int firstZeroIndex = indexOf(frame, 0, (byte) 0);
         String mimeType = new String(frame, 0, firstZeroIndex, "ISO-8859-1");
-        int filenameStartIndex = firstZeroIndex + 1;
+        int filenameStartIndex = firstZeroIndex + delimiterLength(encoding);
         int filenameEndIndex = indexOfEOS(frame, filenameStartIndex, encoding);
         String filename = new String(frame, filenameStartIndex,
                                      filenameEndIndex - filenameStartIndex, charset);
-        int descriptionStartIndex = filenameEndIndex + 1;
+        int descriptionStartIndex = filenameEndIndex + delimiterLength(encoding);
         int descriptionEndIndex = indexOfEOS(frame, descriptionStartIndex, encoding);
         String description = new String(frame, descriptionStartIndex,
                 descriptionEndIndex - descriptionStartIndex, charset);
 
         byte[] objectData = new byte[frameSize - descriptionEndIndex - 2];
-        System.arraycopy(frame, descriptionEndIndex + 1, objectData, 0,
+        System.arraycopy(frame, descriptionEndIndex + delimiterLength(encoding), objectData, 0,
                          frameSize - descriptionEndIndex - 2);
         metadata.put(GeobMetadata.TYPE, new GeobMetadata(mimeType, filename,
                                                          description, objectData));
@@ -147,12 +147,17 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
     // Otherwise, look for a two zero bytes
     while(terminationPos < data.length - 1) {
       if(data[terminationPos + 1] == (byte) 0) {
-        return terminationPos + 1;
+        return terminationPos;
       }
       terminationPos = indexOf(data, terminationPos + 1, (byte) 0);
     }
 
     return data.length;
+  }
+
+  private static int delimiterLength(int encodingByte) {
+    return (encodingByte == ID3_TEXT_ENCODING_ISO_8859_1 ||
+            encodingByte == ID3_TEXT_ENCODING_UTF_8) ? 1 : 2;
   }
 
   /**

--- a/library/src/main/java/com/google/android/exoplayer/metadata/Id3Parser.java
+++ b/library/src/main/java/com/google/android/exoplayer/metadata/Id3Parser.java
@@ -91,7 +91,7 @@ public class Id3Parser implements MetadataParser<Map<String, Object>> {
 
         int firstZeroIndex = indexOf(frame, 0, (byte) 0);
         String mimeType = new String(frame, 0, firstZeroIndex, "ISO-8859-1");
-        int filenameStartIndex = firstZeroIndex + delimiterLength(encoding);
+        int filenameStartIndex = firstZeroIndex + 1;
         int filenameEndIndex = indexOfEOS(frame, filenameStartIndex, encoding);
         String filename = new String(frame, filenameStartIndex,
             filenameEndIndex - filenameStartIndex, charset);

--- a/library/src/main/java/com/google/android/exoplayer/metadata/PrivMetadata.java
+++ b/library/src/main/java/com/google/android/exoplayer/metadata/PrivMetadata.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer.metadata;
+
+/**
+ * A metadata that contains parsed ID3 PRIV (Private) frame data associated
+ * with time indices.
+ */
+public class PrivMetadata {
+
+  public static final String TYPE = "PRIV";
+
+  public final String owner;
+  public final byte[] privateData;
+
+  public PrivMetadata(String owner, byte [] privateData) {
+    this.owner = owner;
+    this.privateData = privateData;
+  }
+
+}

--- a/library/src/main/java/com/google/android/exoplayer/metadata/PrivMetadata.java
+++ b/library/src/main/java/com/google/android/exoplayer/metadata/PrivMetadata.java
@@ -26,7 +26,7 @@ public class PrivMetadata {
   public final String owner;
   public final byte[] privateData;
 
-  public PrivMetadata(String owner, byte [] privateData) {
+  public PrivMetadata(String owner, byte[] privateData) {
     this.owner = owner;
     this.privateData = privateData;
   }


### PR DESCRIPTION
- Added support for ID3 frames of types GEOB and PRIV.
 - GEOB type is commonly used by dynamic ads providers to include in the
stream information about the ads to be played.
 - PRIV type is commonly used for time synchronization (example:
synchronizing playback of a live stream and its webvtt captions) and
also by analytics companies to include tracking information in the
stream.

- Added a sample stream from Apple that contains ID3 metadata.