### PR TITLE
Fix AES decryption of HLS streams.

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
@@ -24,7 +24,7 @@ import com.google.android.exoplayer.MediaCodecVideoTrackRenderer;
 import com.google.android.exoplayer.TrackRenderer;
 import com.google.android.exoplayer.audio.AudioTrack;
 import com.google.android.exoplayer.chunk.ChunkSampleSource;
-import com.google.android.exoplayer.chunk.MultiTrackChunkSource;
+import com.google.android.exoplayer.MultiTrackSource;
 import com.google.android.exoplayer.drm.StreamingDrmSessionManager;
 import com.google.android.exoplayer.metadata.MetadataTrackRenderer;
 import com.google.android.exoplayer.text.TextRenderer;
@@ -79,7 +79,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
      * @param renderers Renderers indexed by {@link DemoPlayer} TYPE_* constants. An individual
      *     element may be null if there do not exist tracks of the corresponding type.
      */
-    void onRenderers(String[][] trackNames, MultiTrackChunkSource[] multiTrackSources,
+    void onRenderers(String[][] trackNames, MultiTrackSource[] multiTrackSources,
         TrackRenderer[] renderers);
     /**
      * Invoked if a {@link RendererBuilder} encounters an error.
@@ -180,7 +180,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
   private TrackRenderer videoRenderer;
   private int videoTrackToRestore;
 
-  private MultiTrackChunkSource[] multiTrackSources;
+  private MultiTrackSource[] multiTrackSources;
   private String[][] trackNames;
   private int[] selectedTracks;
   private boolean backgrounded;
@@ -293,14 +293,14 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
   }
 
   /* package */ void onRenderers(String[][] trackNames,
-      MultiTrackChunkSource[] multiTrackSources, TrackRenderer[] renderers) {
+      MultiTrackSource[] multiTrackSources, TrackRenderer[] renderers) {
     builderCallback = null;
     // Normalize the results.
     if (trackNames == null) {
       trackNames = new String[RENDERER_COUNT][];
     }
     if (multiTrackSources == null) {
-      multiTrackSources = new MultiTrackChunkSource[RENDERER_COUNT];
+      multiTrackSources = new MultiTrackSource[RENDERER_COUNT];
     }
     for (int i = 0; i < RENDERER_COUNT; i++) {
       if (renderers[i] == null) {
@@ -590,8 +590,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
       boolean playWhenReady = player.getPlayWhenReady();
       player.setPlayWhenReady(false);
       player.setRendererEnabled(type, false);
-      player.sendMessage(multiTrackSources[type], MultiTrackChunkSource.MSG_SELECT_TRACK,
-          trackIndex);
+      multiTrackSources[type].selectTrack(player, trackIndex);
       player.setRendererEnabled(type, allowRendererEnable);
       player.setPlayWhenReady(playWhenReady);
     }
@@ -613,7 +612,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
     }
 
     @Override
-    public void onRenderers(String[][] trackNames, MultiTrackChunkSource[] multiTrackSources,
+    public void onRenderers(String[][] trackNames, MultiTrackSource[] multiTrackSources,
         TrackRenderer[] renderers) {
       if (!canceled) {
         DemoPlayer.this.onRenderers(trackNames, multiTrackSources, renderers);

--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
@@ -21,22 +21,32 @@ import com.google.android.exoplayer.TrackRenderer;
 import com.google.android.exoplayer.demo.player.DemoPlayer.RendererBuilder;
 import com.google.android.exoplayer.demo.player.DemoPlayer.RendererBuilderCallback;
 import com.google.android.exoplayer.hls.HlsChunkSource;
+import com.google.android.exoplayer.hls.HlsChunkSourceImpl;
+import com.google.android.exoplayer.hls.MultiTrackHlsChunkSource;
 import com.google.android.exoplayer.hls.HlsPlaylist;
+import com.google.android.exoplayer.hls.HlsMasterPlaylist;
+import com.google.android.exoplayer.hls.HlsMediaPlaylist;
 import com.google.android.exoplayer.hls.HlsPlaylistParser;
 import com.google.android.exoplayer.hls.HlsSampleSource;
+import com.google.android.exoplayer.hls.AlternateMedia;
 import com.google.android.exoplayer.metadata.Id3Parser;
 import com.google.android.exoplayer.metadata.MetadataTrackRenderer;
 import com.google.android.exoplayer.text.eia608.Eia608TrackRenderer;
 import com.google.android.exoplayer.upstream.DataSource;
 import com.google.android.exoplayer.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer.upstream.UriDataSource;
+import com.google.android.exoplayer.util.Util;
 import com.google.android.exoplayer.util.ManifestFetcher;
 import com.google.android.exoplayer.util.ManifestFetcher.ManifestCallback;
 
 import android.media.MediaCodec;
+import android.net.Uri;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * A {@link RendererBuilder} for HLS.
@@ -46,6 +56,9 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
   private final String userAgent;
   private final String url;
   private final String contentId;
+  private HlsMediaPlaylist[] alternatePlaylists;
+  private HlsMasterPlaylist master;
+  private int toFetch;
 
   private DemoPlayer player;
   private RendererBuilderCallback callback;
@@ -73,6 +86,34 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
 
   @Override
   public void onManifest(String contentId, HlsPlaylist manifest) {
+    if (manifest.type == HlsPlaylist.TYPE_MASTER) {
+      master = (HlsMasterPlaylist) manifest;
+      if (master.alternateMedias.size() > 0 && alternatePlaylists == null) {
+        toFetch = master.alternateMedias.size();
+        alternatePlaylists = new HlsMediaPlaylist[toFetch];
+        for (AlternateMedia i: master.alternateMedias) {
+          HlsPlaylistParser parser = new HlsPlaylistParser();
+          String url = Util.getMergedUri(master.baseUri, i.url).toString();
+          ManifestFetcher<HlsPlaylist> playlistFetcher =
+            new ManifestFetcher<HlsPlaylist>(parser, url, url, userAgent);
+          playlistFetcher.singleLoad(player.getMainHandler().getLooper(), this);
+        }
+      }
+    } else if (alternatePlaylists != null) {
+      toFetch--;
+      for (AlternateMedia i: master.alternateMedias) {
+        if (contentId.equals(Util.getMergedUri(master.baseUri, i.url).toString())) {
+          alternatePlaylists[i.index] = (HlsMediaPlaylist) manifest;
+          break;
+        }
+      }
+    }
+
+    if (toFetch > 0)
+      return;
+
+    manifest = master;
+
     DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
 
     DataSource dataSource = new UriDataSource(userAgent, bandwidthMeter);
@@ -81,7 +122,40 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
     HlsSampleSource sampleSource = new HlsSampleSource(chunkSource, true, 3);
     MediaCodecVideoTrackRenderer videoRenderer = new MediaCodecVideoTrackRenderer(sampleSource,
         MediaCodec.VIDEO_SCALING_MODE_SCALE_TO_FIT, 5000, player.getMainHandler(), player, 50);
-    MediaCodecAudioTrackRenderer audioRenderer = new MediaCodecAudioTrackRenderer(sampleSource);
+
+    MediaCodecAudioTrackRenderer audioRenderer;
+    // Build the audio chunk sources.
+    String[] audioTrackNames = null;
+    MultiTrackHlsChunkSource audioChunkSource = null;
+
+    if (manifest.type == HlsPlaylist.TYPE_MASTER) {
+      DataSource audioDataSource = new UriDataSource(userAgent, bandwidthMeter);
+      List<HlsChunkSource> audioChunkSourceList = new ArrayList<HlsChunkSource>();
+      List<String> audioTrackNameList = new ArrayList<String>();
+      for (AlternateMedia i: master.alternateMedias) {
+        if (i.type != AlternateMedia.TYPE_AUDIO)
+          return;
+
+        audioChunkSourceList.add(new HlsChunkSourceImpl(audioDataSource, Util.getMergedUri(master.baseUri, i.url).toString(), alternatePlaylists[i.index], bandwidthMeter, null, HlsChunkSourceImpl.ADAPTIVE_MODE_NONE));
+        audioTrackNameList.add(i.name);
+      }
+
+      // Build the audio renderer.
+      if (audioChunkSourceList.isEmpty()) {
+        audioTrackNames = null;
+        audioChunkSource = null;
+        audioRenderer = null;
+      } else {
+        audioTrackNames = new String[audioTrackNameList.size()];
+        audioTrackNameList.toArray(audioTrackNames);
+        audioChunkSource = new MultiTrackHlsChunkSource(audioChunkSourceList);
+        HlsSampleSource audioSampleSource = new HlsSampleSource(audioChunkSource, true, 3);
+        audioRenderer = new MediaCodecAudioTrackRenderer(audioSampleSource, null, true,
+                                                         player.getMainHandler(), player);
+      }
+    } else {
+      audioRenderer = new MediaCodecAudioTrackRenderer(sampleSource);
+    }
 
     MetadataTrackRenderer<Map<String, Object>> id3Renderer =
         new MetadataTrackRenderer<Map<String, Object>>(sampleSource, new Id3Parser(),
@@ -90,12 +164,19 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
     Eia608TrackRenderer closedCaptionRenderer = new Eia608TrackRenderer(sampleSource, player,
         player.getMainHandler().getLooper());
 
+    String[][] trackNames = new String[DemoPlayer.RENDERER_COUNT][];
+    trackNames[DemoPlayer.TYPE_AUDIO] = audioTrackNames;
+
+    MultiTrackHlsChunkSource[] multiTrackChunkSources =
+      new MultiTrackHlsChunkSource[DemoPlayer.RENDERER_COUNT];
+    multiTrackChunkSources[DemoPlayer.TYPE_AUDIO] = audioChunkSource;
+
     TrackRenderer[] renderers = new TrackRenderer[DemoPlayer.RENDERER_COUNT];
     renderers[DemoPlayer.TYPE_VIDEO] = videoRenderer;
     renderers[DemoPlayer.TYPE_AUDIO] = audioRenderer;
     renderers[DemoPlayer.TYPE_TIMED_METADATA] = id3Renderer;
     renderers[DemoPlayer.TYPE_TEXT] = closedCaptionRenderer;
-    callback.onRenderers(null, null, renderers);
+    callback.onRenderers(trackNames, multiTrackChunkSources, renderers);
   }
 
 }

--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
@@ -76,8 +76,8 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
     DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
 
     DataSource dataSource = new UriDataSource(userAgent, bandwidthMeter);
-    HlsChunkSource chunkSource = new HlsChunkSource(dataSource, url, manifest, bandwidthMeter, null,
-        HlsChunkSource.ADAPTIVE_MODE_SPLICE);
+    HlsChunkSource chunkSource = new HlsChunkSourceImpl(dataSource, url, manifest, bandwidthMeter, null,
+        HlsChunkSourceImpl.ADAPTIVE_MODE_SPLICE);
     HlsSampleSource sampleSource = new HlsSampleSource(chunkSource, true, 3);
     MediaCodecVideoTrackRenderer videoRenderer = new MediaCodecVideoTrackRenderer(sampleSource,
         MediaCodec.VIDEO_SCALING_MODE_SCALE_TO_FIT, 5000, player.getMainHandler(), player, 50);

--- a/library/src/main/java/com/google/android/exoplayer/MultiTrackSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/MultiTrackSource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer;
+
+import com.google.android.exoplayer.ExoPlayer;
+
+public interface MultiTrackSource {
+  /**
+   * A message to indicate a source selection. Source selection can only be performed when the
+   * source is disabled.
+   */
+  public void selectTrack(ExoPlayer player, int index);
+
+  /**
+   * Gets the number of tracks that this source can switch between. May be called safely from any
+   * thread.
+   *
+   * @return The number of tracks.
+   */
+  public int getTrackCount();
+}

--- a/library/src/main/java/com/google/android/exoplayer/hls/AlternateMedia.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/AlternateMedia.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer.hls;
+
+public class AlternateMedia {
+  public static final int TYPE_VIDEO = 0;
+  public static final int TYPE_AUDIO = 1;
+
+  public final int index;
+  public final int type;
+  public final String groupID;
+  public final String language;
+  public final String name;
+  public final boolean deflt;
+  public final boolean autoSelect;
+  public final String url;
+
+  public AlternateMedia(int index, int type, String groupID, String name,
+                        boolean deflt, boolean autoSelect, String language,
+                        String url) {
+    this.index = index;
+    this.type = type;
+    this.groupID = groupID;
+    this.name = name;
+    this.autoSelect = autoSelect;
+    this.deflt = deflt;
+    this.language = language;
+    this.url = url;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -179,7 +179,7 @@ public class HlsChunkSource {
     bufferPool = new BufferPool(256 * 1024);
 
     if (playlist.type == HlsPlaylist.TYPE_MEDIA) {
-      enabledVariants = new Variant[] {new Variant(0, playlistUrl, 0, null, -1, -1)};
+      enabledVariants = new Variant[] {new Variant(0, playlistUrl, 0, null, -1, -1, null)};
       mediaPlaylists = new HlsMediaPlaylist[1];
       mediaPlaylistBlacklistFlags = new boolean[1];
       lastMediaPlaylistLoadTimesMs = new long[1];

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer.hls;
+
+import com.google.android.exoplayer.MediaFormat;
+import java.io.IOException;
+
+/**
+ * A temporary test source of HLS chunks.
+ * <p>
+ * TODO: Figure out whether this should merge with the chunk package, or whether the hls
+ * implementation is going to naturally diverge.
+ */
+public interface HlsChunkSource {
+
+
+  public long getDurationUs();
+
+  /**
+   * Adaptive implementations must set the maximum video dimensions on the supplied
+   * {@link MediaFormat}. Other implementations do nothing.
+   * <p>
+   * Only called when the source is enabled.
+   *
+   * @param out The {@link MediaFormat} on which the maximum video dimensions should be set.
+   */
+  public void getMaxVideoDimensions(MediaFormat out);
+
+  /**
+   * Returns the next {@link HlsChunk} that should be loaded.
+   *
+   * @param previousTsChunk The previously loaded chunk that the next chunk should follow.
+   * @param seekPositionUs If there is no previous chunk, this parameter must specify the seek
+   *     position. If there is a previous chunk then this parameter is ignored.
+   * @param playbackPositionUs The current playback position.
+   * @return The next chunk to load.
+   */
+  public HlsChunk getChunkOperation(TsChunk previousTsChunk, long seekPositionUs,
+                                    long playbackPositionUs);
+  /**
+   * Invoked when an error occurs loading a chunk.
+   *
+   * @param chunk The chunk whose load failed.
+   * @param e The failure.
+   * @return True if the error was handled by the source. False otherwise.
+   */
+  public boolean onLoadError(HlsChunk chunk, IOException e);
+}

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSourceImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSourceImpl.java
@@ -48,7 +48,7 @@ import java.util.Locale;
  * TODO: Figure out whether this should merge with the chunk package, or whether the hls
  * implementation is going to naturally diverge.
  */
-public class HlsChunkSourceImpl {
+public class HlsChunkSourceImpl implements HlsChunkSource {
 
   /**
    * Adaptive switching is disabled.
@@ -106,7 +106,7 @@ public class HlsChunkSourceImpl {
    */
   public static final long DEFAULT_MAX_BUFFER_TO_SWITCH_DOWN_MS = 20000;
 
-  private static final String TAG = "HlsChunkSourceImpl";
+  private static final String TAG = "HlsChunkSource";
   private static final String AAC_FILE_EXTENSION = ".aac";
   private static final float BANDWIDTH_FRACTION = 0.8f;
 
@@ -209,31 +209,17 @@ public class HlsChunkSourceImpl {
     this.maxHeight = maxHeight > 0 ? maxHeight : 1080;
   }
 
+  @Override
   public long getDurationUs() {
     return live ? C.UNKNOWN_TIME_US : durationUs;
   }
 
-  /**
-   * Adaptive implementations must set the maximum video dimensions on the supplied
-   * {@link MediaFormat}. Other implementations do nothing.
-   * <p>
-   * Only called when the source is enabled.
-   *
-   * @param out The {@link MediaFormat} on which the maximum video dimensions should be set.
-   */
+  @Override
   public void getMaxVideoDimensions(MediaFormat out) {
     out.setMaxVideoDimensions(maxWidth, maxHeight);
   }
 
-  /**
-   * Returns the next {@link HlsChunk} that should be loaded.
-   *
-   * @param previousTsChunk The previously loaded chunk that the next chunk should follow.
-   * @param seekPositionUs If there is no previous chunk, this parameter must specify the seek
-   *     position. If there is a previous chunk then this parameter is ignored.
-   * @param playbackPositionUs The current playback position.
-   * @return The next chunk to load.
-   */
+  @Override
   public HlsChunk getChunkOperation(TsChunk previousTsChunk, long seekPositionUs,
       long playbackPositionUs) {
     if (previousTsChunk != null && (previousTsChunk.isLastChunk
@@ -348,13 +334,7 @@ public class HlsChunkSourceImpl {
         startTimeUs, endTimeUs, chunkMediaSequence, isLastChunk);
   }
 
-  /**
-   * Invoked when an error occurs loading a chunk.
-   *
-   * @param chunk The chunk whose load failed.
-   * @param e The failure.
-   * @return True if the error was handled by the source. False otherwise.
-   */
+  @Override
   public boolean onLoadError(HlsChunk chunk, IOException e) {
     if ((chunk instanceof MediaPlaylistChunk) && (e instanceof InvalidResponseCodeException)) {
       InvalidResponseCodeException responseCodeException = (InvalidResponseCodeException) e;

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSourceImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSourceImpl.java
@@ -48,7 +48,7 @@ import java.util.Locale;
  * TODO: Figure out whether this should merge with the chunk package, or whether the hls
  * implementation is going to naturally diverge.
  */
-public class HlsChunkSource {
+public class HlsChunkSourceImpl {
 
   /**
    * Adaptive switching is disabled.
@@ -106,7 +106,7 @@ public class HlsChunkSource {
    */
   public static final long DEFAULT_MAX_BUFFER_TO_SWITCH_DOWN_MS = 20000;
 
-  private static final String TAG = "HlsChunkSource";
+  private static final String TAG = "HlsChunkSourceImpl";
   private static final String AAC_FILE_EXTENSION = ".aac";
   private static final float BANDWIDTH_FRACTION = 0.8f;
 
@@ -137,7 +137,7 @@ public class HlsChunkSource {
   private String encryptedDataSourceIv;
   private byte[] encryptedDataSourceSecretKey;
 
-  public HlsChunkSource(DataSource dataSource, String playlistUrl, HlsPlaylist playlist,
+  public HlsChunkSourceImpl(DataSource dataSource, String playlistUrl, HlsPlaylist playlist,
       BandwidthMeter bandwidthMeter, int[] variantIndices, int adaptiveMode) {
     this(dataSource, playlistUrl, playlist, bandwidthMeter, variantIndices, adaptiveMode,
         DEFAULT_TARGET_BUFFER_SIZE, DEFAULT_TARGET_BUFFER_DURATION_MS,
@@ -163,7 +163,7 @@ public class HlsChunkSource {
    * @param maxBufferDurationToSwitchDownMs The maximum duration of media that needs to be buffered
    *     for a switch to a lower quality variant to be considered.
    */
-  public HlsChunkSource(DataSource dataSource, String playlistUrl, HlsPlaylist playlist,
+  public HlsChunkSourceImpl(DataSource dataSource, String playlistUrl, HlsPlaylist playlist,
       BandwidthMeter bandwidthMeter, int[] variantIndices, int adaptiveMode,
       int targetBufferSize, long targetBufferDurationMs, long minBufferDurationToSwitchUpMs,
       long maxBufferDurationToSwitchDownMs) {

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsMasterPlaylist.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsMasterPlaylist.java
@@ -18,6 +18,7 @@ package com.google.android.exoplayer.hls;
 import android.net.Uri;
 
 import java.util.List;
+import java.util.ArrayList;
 
 /**
  * Represents an HLS master playlist.
@@ -25,10 +26,22 @@ import java.util.List;
 public final class HlsMasterPlaylist extends HlsPlaylist {
 
   public final List<Variant> variants;
+  public final List<AlternateMedia> alternateMedias;
 
-  public HlsMasterPlaylist(Uri baseUri, List<Variant> variants) {
+  public HlsMasterPlaylist(Uri baseUri, List<Variant> variants, List<AlternateMedia> alternateMedias) {
     super(baseUri, HlsPlaylist.TYPE_MASTER);
     this.variants = variants;
-  }
+    this.alternateMedias = alternateMedias;
 
+    // Setup variant alternate medias
+    for (Variant v: variants) {
+      if (v.audio != null) {
+        for (AlternateMedia a: alternateMedias) {
+          if (a.groupID != null && v.audio.equals(a.groupID)) {
+            v.alternateMedias.add(a);
+          }
+        }
+      }
+    }
+  }
 }

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsParserUtil.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsParserUtil.java
@@ -54,4 +54,10 @@ import java.util.regex.Pattern;
     return Double.parseDouble(parseStringAttr(line, pattern, tag));
   }
 
+  public static boolean parseBooleanAttr(String line, Pattern pattern, String tag)
+      throws ParserException {
+    String val = parseStringAttr(line, pattern, tag);
+    return ("YES".equals(val));
+  }
+
 }

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -42,8 +42,17 @@ public final class HlsPlaylistParser implements ManifestParser<HlsPlaylist> {
 
   private static final String STREAM_INF_TAG = "#EXT-X-STREAM-INF";
   private static final String BANDWIDTH_ATTR = "BANDWIDTH";
+  private static final String AUDIO_ATTR = "AUDIO";
   private static final String CODECS_ATTR = "CODECS";
   private static final String RESOLUTION_ATTR = "RESOLUTION";
+
+  private static final String MEDIA_TAG = "#EXT-X-MEDIA";
+  private static final String TYPE_ATTR = "TYPE";
+  private static final String GROUP_ID_ATTR = "GROUP-ID";
+  private static final String NAME_ATTR = "NAME";
+  private static final String DEFAULT_ATTR = "DEFAULT";
+  private static final String AUTOSELECT_ATTR = "AUTOSELECT";
+  private static final String LANGUAGE_ATTR = "LANGUAGE";
 
   private static final String DISCONTINUITY_TAG = "#EXT-X-DISCONTINUITY";
   private static final String MEDIA_DURATION_TAG = "#EXTINF";
@@ -63,6 +72,21 @@ public final class HlsPlaylistParser implements ManifestParser<HlsPlaylist> {
       Pattern.compile(CODECS_ATTR + "=\"(.+?)\"");
   private static final Pattern RESOLUTION_ATTR_REGEX =
       Pattern.compile(RESOLUTION_ATTR + "=(\\d+x\\d+)");
+  private static final Pattern AUDIO_ATTR_REGEX =
+    Pattern.compile(AUDIO_ATTR + "=\"(.+)\"");
+
+  private static final Pattern TYPE_ATTR_REGEX =
+    Pattern.compile(TYPE_ATTR + "=(AUDIO|VIDEO)");
+  private static final Pattern GROUP_ID_ATTR_REGEX =
+    Pattern.compile(GROUP_ID_ATTR + "=\"([^\"]+)\"");
+  private static final Pattern NAME_ATTR_REGEX =
+    Pattern.compile(NAME_ATTR + "=\"([^\"]+)\"");
+  private static final Pattern DEFAULT_ATTR_REGEX =
+    Pattern.compile(DEFAULT_ATTR + "=(YES|NO)");
+  private static final Pattern AUTOSELECT_ATTR_REGEX =
+    Pattern.compile(AUTOSELECT_ATTR + "=(YES|NO)");
+  private static final Pattern LANGUAGE_ATTR_REGEX =
+    Pattern.compile(LANGUAGE_ATTR + "=\"([^\"]+)\"");
 
   private static final Pattern MEDIA_DURATION_REGEX =
       Pattern.compile(MEDIA_DURATION_TAG + ":([\\d.]+),");
@@ -94,7 +118,10 @@ public final class HlsPlaylistParser implements ManifestParser<HlsPlaylist> {
         line = line.trim();
         if (line.isEmpty()) {
           // Do nothing.
-        } else if (line.startsWith(STREAM_INF_TAG)) {
+        } else if (line.startsWith(STREAM_INF_TAG) || line.startsWith(MEDIA_TAG + ":")) {
+          extraLines.add(line);
+          return parseMasterPlaylist(new LineIterator(extraLines, reader), baseUri);
+        } else if (line.startsWith(MEDIA_TAG)) {
           extraLines.add(line);
           return parseMasterPlaylist(new LineIterator(extraLines, reader), baseUri);
         } else if (line.startsWith(TARGET_DURATION_TAG)
@@ -121,11 +148,14 @@ public final class HlsPlaylistParser implements ManifestParser<HlsPlaylist> {
   private static HlsMasterPlaylist parseMasterPlaylist(LineIterator iterator, Uri baseUri)
       throws IOException {
     List<Variant> variants = new ArrayList<Variant>();
+    List<AlternateMedia> alternateMedias = new ArrayList<AlternateMedia>();
     int bandwidth = 0;
     String[] codecs = null;
     int width = -1;
     int height = -1;
     int variantIndex = 0;
+    int alternateIndex = 0;
+    String audio = null;
 
     String line;
     while (iterator.hasNext()) {
@@ -148,15 +178,31 @@ public final class HlsPlaylistParser implements ManifestParser<HlsPlaylist> {
           width = -1;
           height = -1;
         }
+        audio = HlsParserUtil.parseOptionalStringAttr(line, AUDIO_ATTR_REGEX);
+
+      } else if (line.startsWith(MEDIA_TAG)) {
+        int type = ("AUDIO".equals(HlsParserUtil.parseStringAttr(line, TYPE_ATTR_REGEX, TYPE_ATTR)) ?
+                    AlternateMedia.TYPE_AUDIO : AlternateMedia.TYPE_VIDEO);
+        String groupID =  HlsParserUtil.parseStringAttr(line, GROUP_ID_ATTR_REGEX, GROUP_ID_ATTR);
+        String name = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
+        boolean deflt = HlsParserUtil.parseBooleanAttr(line, DEFAULT_ATTR_REGEX, DEFAULT_ATTR);
+        boolean autoSelect = HlsParserUtil.parseBooleanAttr(line, AUTOSELECT_ATTR_REGEX, AUTOSELECT_ATTR);
+        String language = HlsParserUtil.parseStringAttr(line, LANGUAGE_ATTR_REGEX, LANGUAGE_ATTR);
+        String uri = HlsParserUtil.parseStringAttr(line, URI_ATTR_REGEX, URI_ATTR);
+
+        AlternateMedia media =
+          new AlternateMedia(alternateIndex++, type, groupID, name, deflt, autoSelect, language, uri);
+        alternateMedias.add(media);
       } else if (!line.startsWith("#")) {
-        variants.add(new Variant(variantIndex++, line, bandwidth, codecs, width, height));
+        variants.add(new Variant(variantIndex++, line, bandwidth, codecs, width, height, audio));
         bandwidth = 0;
         codecs = null;
         width = -1;
         height = -1;
       }
     }
-    return new HlsMasterPlaylist(baseUri, Collections.unmodifiableList(variants));
+    return new HlsMasterPlaylist(baseUri, Collections.unmodifiableList(variants),
+                                 Collections.unmodifiableList(alternateMedias));
   }
 
   private static HlsMediaPlaylist parseMediaPlaylist(LineIterator iterator, Uri baseUri)

--- a/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
@@ -16,6 +16,8 @@
 package com.google.android.exoplayer.hls;
 
 import java.util.Comparator;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Variant stream reference.
@@ -43,14 +45,19 @@ public final class Variant {
   public final String[] codecs;
   public final int width;
   public final int height;
+  public final List<AlternateMedia> alternateMedias;
+  public final String audio;
 
-  public Variant(int index, String url, int bandwidth, String[] codecs, int width, int height) {
+  public Variant(int index, String url, int bandwidth, String[] codecs, int width, int height, String audio) {
     this.index = index;
     this.bandwidth = bandwidth;
     this.url = url;
     this.codecs = codecs;
     this.width = width;
     this.height = height;
+    this.audio = audio;
+    this.alternateMedias = new ArrayList<AlternateMedia>();
+
   }
 
 }


### PR DESCRIPTION
As per http://tools.ietf.org/html/draft-pantos-http-live-streaming-04#section-5.2,
the initializaton vector (IV) of the AES decryption algorithm should be set to:
- the IV attribute value if present,
- the sequence number otherwise.

Currently, the IV is set once and use over all next media sequences
where the IV attribute is not set. The fix is to reset the initial
vector value for each media sequence so that it is correctly set to the
IV attribute value or the current media sequence number.

This is commit  9a302d4.

Apprently I messed up this pull request (first time using pull requests), I did not use multiple branches so it also has a temptative fix for issue 73 in the other commits.