### PR TITLE
Hls alternate audio

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
@@ -25,7 +25,7 @@ import com.google.android.exoplayer.MediaCodecVideoTrackRenderer;
 import com.google.android.exoplayer.TrackRenderer;
 import com.google.android.exoplayer.audio.AudioTrack;
 import com.google.android.exoplayer.chunk.ChunkSampleSource;
-import com.google.android.exoplayer.chunk.MultiTrackChunkSource;
+import com.google.android.exoplayer.MultiTrackSource;
 import com.google.android.exoplayer.drm.StreamingDrmSessionManager;
 import com.google.android.exoplayer.metadata.MetadataTrackRenderer;
 import com.google.android.exoplayer.text.TextRenderer;
@@ -80,7 +80,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
      * @param renderers Renderers indexed by {@link DemoPlayer} TYPE_* constants. An individual
      *     element may be null if there do not exist tracks of the corresponding type.
      */
-    void onRenderers(String[][] trackNames, MultiTrackChunkSource[] multiTrackSources,
+    void onRenderers(String[][] trackNames, MultiTrackSource[] multiTrackSources,
         TrackRenderer[] renderers);
     /**
      * Invoked if a {@link RendererBuilder} encounters an error.
@@ -181,7 +181,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
   private TrackRenderer videoRenderer;
   private int videoTrackToRestore;
 
-  private MultiTrackChunkSource[] multiTrackSources;
+  private MultiTrackSource[] multiTrackSources;
   private String[][] trackNames;
   private int[] selectedTracks;
   private boolean backgrounded;
@@ -294,14 +294,14 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
   }
 
   /* package */ void onRenderers(String[][] trackNames,
-      MultiTrackChunkSource[] multiTrackSources, TrackRenderer[] renderers) {
+      MultiTrackSource[] multiTrackSources, TrackRenderer[] renderers) {
     builderCallback = null;
     // Normalize the results.
     if (trackNames == null) {
       trackNames = new String[RENDERER_COUNT][];
     }
     if (multiTrackSources == null) {
-      multiTrackSources = new MultiTrackChunkSource[RENDERER_COUNT];
+      multiTrackSources = new MultiTrackSource[RENDERER_COUNT];
     }
     for (int i = 0; i < RENDERER_COUNT; i++) {
       if (renderers[i] == null) {
@@ -591,8 +591,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
       boolean playWhenReady = player.getPlayWhenReady();
       player.setPlayWhenReady(false);
       player.setRendererEnabled(type, false);
-      player.sendMessage(multiTrackSources[type], MultiTrackChunkSource.MSG_SELECT_TRACK,
-          trackIndex);
+      multiTrackSources[type].selectTrack(player, trackIndex);
       player.setRendererEnabled(type, allowRendererEnable);
       player.setPlayWhenReady(playWhenReady);
     }
@@ -614,7 +613,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
     }
 
     @Override
-    public void onRenderers(String[][] trackNames, MultiTrackChunkSource[] multiTrackSources,
+    public void onRenderers(String[][] trackNames, MultiTrackSource[] multiTrackSources,
         TrackRenderer[] renderers) {
       if (!canceled) {
         DemoPlayer.this.onRenderers(trackNames, multiTrackSources, renderers);

--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
@@ -21,9 +21,14 @@ import com.google.android.exoplayer.TrackRenderer;
 import com.google.android.exoplayer.demo.player.DemoPlayer.RendererBuilder;
 import com.google.android.exoplayer.demo.player.DemoPlayer.RendererBuilderCallback;
 import com.google.android.exoplayer.hls.HlsChunkSource;
+import com.google.android.exoplayer.hls.HlsChunkSourceImpl;
+import com.google.android.exoplayer.hls.MultiTrackHlsChunkSource;
 import com.google.android.exoplayer.hls.HlsPlaylist;
+import com.google.android.exoplayer.hls.HlsMasterPlaylist;
+import com.google.android.exoplayer.hls.HlsMediaPlaylist;
 import com.google.android.exoplayer.hls.HlsPlaylistParser;
 import com.google.android.exoplayer.hls.HlsSampleSource;
+import com.google.android.exoplayer.hls.AlternateMedia;
 import com.google.android.exoplayer.metadata.Id3Parser;
 import com.google.android.exoplayer.metadata.MetadataTrackRenderer;
 import com.google.android.exoplayer.text.eia608.Eia608TrackRenderer;
@@ -31,13 +36,18 @@ import com.google.android.exoplayer.upstream.DataSource;
 import com.google.android.exoplayer.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer.upstream.UriDataSource;
+import com.google.android.exoplayer.util.UriUtil;
 import com.google.android.exoplayer.util.ManifestFetcher;
 import com.google.android.exoplayer.util.ManifestFetcher.ManifestCallback;
 
 import android.media.MediaCodec;
+import android.net.Uri;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * A {@link RendererBuilder} for HLS.
@@ -46,6 +56,9 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
 
   private final String userAgent;
   private final String url;
+  private HlsMediaPlaylist[] alternatePlaylists;
+  private HlsMasterPlaylist master;
+  private int toFetch;
 
   private DemoPlayer player;
   private RendererBuilderCallback callback;
@@ -72,6 +85,46 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
 
   @Override
   public void onSingleManifest(HlsPlaylist manifest) {
+
+    // Try to load alternate audio media
+    if (manifest.type == HlsPlaylist.TYPE_MASTER) {
+      master = (HlsMasterPlaylist) manifest;
+      if (master.alternateAudio.size() > 0 && alternatePlaylists == null) {
+        toFetch = master.alternateAudio.size();
+        alternatePlaylists = new HlsMediaPlaylist[toFetch];
+        for (AlternateMedia i: master.alternateAudio) {
+          // Multiple audio track with one audio in the TS stream is
+          // not supported
+          if (i.uri == null) {
+            toFetch--;
+            continue;
+          }
+          HlsPlaylistParser parser = new HlsPlaylistParser();
+          String url = UriUtil.resolveToUri(master.baseUri, i.uri).toString();
+          ManifestFetcher<HlsPlaylist> playlistFetcher =
+            new ManifestFetcher<HlsPlaylist>(url, new DefaultHttpDataSource(userAgent, null), parser);
+          playlistFetcher.singleLoad(player.getMainHandler().getLooper(), this);
+        }
+      }
+    } else if (alternatePlaylists != null) {
+      toFetch--;
+      for (AlternateMedia i: master.alternateAudio) {
+        if (manifest.baseUri.equals(UriUtil.resolveToUri(master.baseUri, i.uri).toString())) {
+          alternatePlaylists[i.index] = (HlsMediaPlaylist) manifest;
+          break;
+        }
+      }
+    }
+
+    if (toFetch > 0)
+      return;
+
+    // if we do not have a master playlist it means we are trying to
+    // directly play a media list.
+    everythingLoaded(master != null ? master : manifest);
+  }
+
+  private void everythingLoaded(HlsPlaylist manifest) {
     DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
 
     DataSource dataSource = new UriDataSource(userAgent, bandwidthMeter);
@@ -80,7 +133,51 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
     HlsSampleSource sampleSource = new HlsSampleSource(chunkSource, true, 3);
     MediaCodecVideoTrackRenderer videoRenderer = new MediaCodecVideoTrackRenderer(sampleSource,
         MediaCodec.VIDEO_SCALING_MODE_SCALE_TO_FIT, 5000, player.getMainHandler(), player, 50);
-    MediaCodecAudioTrackRenderer audioRenderer = new MediaCodecAudioTrackRenderer(sampleSource);
+
+    MediaCodecAudioTrackRenderer audioRenderer;
+    // Build the audio chunk sources.
+    String[] audioTrackNames = null;
+    MultiTrackHlsChunkSource audioChunkSource = null;
+
+
+    boolean canUseAlternate = false;
+    if (manifest.type == HlsPlaylist.TYPE_MASTER) {
+      if (master.alternateAudio.size() > 0)
+          canUseAlternate = true;
+      for (AlternateMedia i: master.alternateAudio) {
+        // We do not support alternate media in TS stream
+        if (i.uri == null) {
+          canUseAlternate = false;
+          break;
+        }
+      }
+    }
+
+    if (canUseAlternate) {
+      DataSource audioDataSource = new UriDataSource(userAgent, bandwidthMeter);
+      List<HlsChunkSource> audioChunkSourceList = new ArrayList<HlsChunkSource>();
+      List<String> audioTrackNameList = new ArrayList<String>();
+      for (AlternateMedia i: master.alternateAudio) {
+        audioChunkSourceList.add(new HlsChunkSourceImpl(audioDataSource, UriUtil.resolveToUri(master.baseUri, i.uri).toString(), alternatePlaylists[i.index], bandwidthMeter, null, HlsChunkSourceImpl.ADAPTIVE_MODE_NONE));
+        audioTrackNameList.add(i.name);
+      }
+
+      // Build the audio renderer.
+      if (audioChunkSourceList.isEmpty()) {
+        audioTrackNames = null;
+        audioChunkSource = null;
+        audioRenderer = null;
+      } else {
+        audioTrackNames = new String[audioTrackNameList.size()];
+        audioTrackNameList.toArray(audioTrackNames);
+        audioChunkSource = new MultiTrackHlsChunkSource(audioChunkSourceList);
+        HlsSampleSource audioSampleSource = new HlsSampleSource(audioChunkSource, true, 3);
+        audioRenderer = new MediaCodecAudioTrackRenderer(audioSampleSource, null, true,
+                                                         player.getMainHandler(), player);
+      }
+    } else {
+      audioRenderer = new MediaCodecAudioTrackRenderer(sampleSource);
+    }
 
     MetadataTrackRenderer<Map<String, Object>> id3Renderer =
         new MetadataTrackRenderer<Map<String, Object>>(sampleSource, new Id3Parser(),
@@ -89,12 +186,19 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
     Eia608TrackRenderer closedCaptionRenderer = new Eia608TrackRenderer(sampleSource, player,
         player.getMainHandler().getLooper());
 
+    String[][] trackNames = new String[DemoPlayer.RENDERER_COUNT][];
+    trackNames[DemoPlayer.TYPE_AUDIO] = audioTrackNames;
+
+    MultiTrackHlsChunkSource[] multiTrackChunkSources =
+      new MultiTrackHlsChunkSource[DemoPlayer.RENDERER_COUNT];
+    multiTrackChunkSources[DemoPlayer.TYPE_AUDIO] = audioChunkSource;
+
     TrackRenderer[] renderers = new TrackRenderer[DemoPlayer.RENDERER_COUNT];
     renderers[DemoPlayer.TYPE_VIDEO] = videoRenderer;
     renderers[DemoPlayer.TYPE_AUDIO] = audioRenderer;
     renderers[DemoPlayer.TYPE_TIMED_METADATA] = id3Renderer;
     renderers[DemoPlayer.TYPE_TEXT] = closedCaptionRenderer;
-    callback.onRenderers(null, null, renderers);
+    callback.onRenderers(trackNames, multiTrackChunkSources, renderers);
   }
 
 }

--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
@@ -75,8 +75,8 @@ public class HlsRendererBuilder implements RendererBuilder, ManifestCallback<Hls
     DefaultBandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
 
     DataSource dataSource = new UriDataSource(userAgent, bandwidthMeter);
-    HlsChunkSource chunkSource = new HlsChunkSource(dataSource, url, manifest, bandwidthMeter, null,
-        HlsChunkSource.ADAPTIVE_MODE_SPLICE);
+    HlsChunkSource chunkSource = new HlsChunkSourceImpl(dataSource, url, manifest, bandwidthMeter, null,
+        HlsChunkSourceImpl.ADAPTIVE_MODE_SPLICE);
     HlsSampleSource sampleSource = new HlsSampleSource(chunkSource, true, 3);
     MediaCodecVideoTrackRenderer videoRenderer = new MediaCodecVideoTrackRenderer(sampleSource,
         MediaCodec.VIDEO_SCALING_MODE_SCALE_TO_FIT, 5000, player.getMainHandler(), player, 50);

--- a/library/src/main/java/com/google/android/exoplayer/MultiTrackSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/MultiTrackSource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer;
+
+import com.google.android.exoplayer.ExoPlayer;
+
+public interface MultiTrackSource {
+  /**
+   * A message to indicate a source selection. Source selection can only be performed when the
+   * source is disabled.
+   */
+  public void selectTrack(ExoPlayer player, int index);
+
+  /**
+   * Gets the number of tracks that this source can switch between. May be called safely from any
+   * thread.
+   *
+   * @return The number of tracks.
+   */
+  public int getTrackCount();
+}

--- a/library/src/main/java/com/google/android/exoplayer/hls/AlternateMedia.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/AlternateMedia.java
@@ -16,22 +16,31 @@
 package com.google.android.exoplayer.hls;
 
 /**
- * Subtitle media tag.
+ * Alternate media tag.
  */
-public final class Subtitle {
+public final class AlternateMedia {
+  public static final int TYPE_VIDEO = 0;
+  public static final int TYPE_AUDIO = 1;
+  public static final int TYPE_SUBTITLES = 2;
+  public static final int TYPE_CLOSED_CAPTIONS = 3;
 
+  public final int index;
+  public final int type;
   public final String name;
   public final String uri;
+  public final String groupID;
   public final String language;
   public final boolean isDefault;
   public final boolean autoSelect;
 
-  public Subtitle(String name, String uri, String language, boolean isDefault, boolean autoSelect) {
+  public AlternateMedia(int index, int type, String name, String uri, String groupID, String language, boolean isDefault, boolean autoSelect) {
+    this.index = index;
+    this.type = type;
     this.name = name;
     this.uri = uri;
+    this.groupID = groupID;
     this.language = language;
     this.autoSelect = autoSelect;
     this.isDefault = isDefault;
   }
-
 }

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -186,7 +186,8 @@ public class HlsChunkSource {
     bufferPool = new BufferPool(256 * 1024);
 
     if (playlist.type == HlsPlaylist.TYPE_MEDIA) {
-      enabledVariants = new Variant[] {new Variant(0, playlistUrl, 0, null, -1, -1)};
+      enabledVariants = new Variant[] {new Variant(0, playlistUrl, 0, null, -1, -1,
+                                                   null, null, null, null)};
       mediaPlaylists = new HlsMediaPlaylist[1];
       mediaPlaylistBlacklistTimesMs = new long[1];
       lastMediaPlaylistLoadTimesMs = new long[1];

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer.hls;
+
+import com.google.android.exoplayer.MediaFormat;
+import java.io.IOException;
+
+/**
+ * A temporary test source of HLS chunks.
+ * <p>
+ * TODO: Figure out whether this should merge with the chunk package, or whether the hls
+ * implementation is going to naturally diverge.
+ */
+public interface HlsChunkSource {
+
+
+  public long getDurationUs();
+
+  /**
+   * Adaptive implementations must set the maximum video dimensions on the supplied
+   * {@link MediaFormat}. Other implementations do nothing.
+   * <p>
+   * Only called when the source is enabled.
+   *
+   * @param out The {@link MediaFormat} on which the maximum video dimensions should be set.
+   */
+  public void getMaxVideoDimensions(MediaFormat out);
+
+  /**
+   * Returns the next {@link HlsChunk} that should be loaded.
+   *
+   * @param previousTsChunk The previously loaded chunk that the next chunk should follow.
+   * @param seekPositionUs If there is no previous chunk, this parameter must specify the seek
+   *     position. If there is a previous chunk then this parameter is ignored.
+   * @param playbackPositionUs The current playback position.
+   * @return The next chunk to load.
+   */
+  public HlsChunk getChunkOperation(TsChunk previousTsChunk, long seekPositionUs,
+                                    long playbackPositionUs);
+  /**
+   * Invoked when an error occurs loading a chunk.
+   *
+   * @param chunk The chunk whose load failed.
+   * @param e The failure.
+   * @return True if the error was handled by the source. False otherwise.
+   */
+  public boolean onLoadError(HlsChunk chunk, IOException e);
+}

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSourceImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSourceImpl.java
@@ -50,7 +50,7 @@ import java.util.Locale;
  * TODO: Figure out whether this should merge with the chunk package, or whether the hls
  * implementation is going to naturally diverge.
  */
-public class HlsChunkSource {
+public class HlsChunkSourceImpl {
 
   /**
    * Adaptive switching is disabled.
@@ -113,7 +113,7 @@ public class HlsChunkSource {
    */
   public static final long DEFAULT_PLAYLIST_BLACKLIST_MS = 60000;
 
-  private static final String TAG = "HlsChunkSource";
+  private static final String TAG = "HlsChunkSourceImpl";
   private static final String AAC_FILE_EXTENSION = ".aac";
   private static final float BANDWIDTH_FRACTION = 0.8f;
 
@@ -144,7 +144,7 @@ public class HlsChunkSource {
   private String encryptedDataSourceIv;
   private byte[] encryptedDataSourceSecretKey;
 
-  public HlsChunkSource(DataSource dataSource, String playlistUrl, HlsPlaylist playlist,
+  public HlsChunkSourceImpl(DataSource dataSource, String playlistUrl, HlsPlaylist playlist,
       BandwidthMeter bandwidthMeter, int[] variantIndices, int adaptiveMode) {
     this(dataSource, playlistUrl, playlist, bandwidthMeter, variantIndices, adaptiveMode,
         DEFAULT_TARGET_BUFFER_SIZE, DEFAULT_TARGET_BUFFER_DURATION_MS,
@@ -170,7 +170,7 @@ public class HlsChunkSource {
    * @param maxBufferDurationToSwitchDownMs The maximum duration of media that needs to be buffered
    *     for a switch to a lower quality variant to be considered.
    */
-  public HlsChunkSource(DataSource dataSource, String playlistUrl, HlsPlaylist playlist,
+  public HlsChunkSourceImpl(DataSource dataSource, String playlistUrl, HlsPlaylist playlist,
       BandwidthMeter bandwidthMeter, int[] variantIndices, int adaptiveMode,
       int targetBufferSize, long targetBufferDurationMs, long minBufferDurationToSwitchUpMs,
       long maxBufferDurationToSwitchDownMs) {

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSourceImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSourceImpl.java
@@ -50,7 +50,7 @@ import java.util.Locale;
  * TODO: Figure out whether this should merge with the chunk package, or whether the hls
  * implementation is going to naturally diverge.
  */
-public class HlsChunkSourceImpl {
+public class HlsChunkSourceImpl implements HlsChunkSource {
 
   /**
    * Adaptive switching is disabled.
@@ -217,31 +217,17 @@ public class HlsChunkSourceImpl {
     this.maxHeight = maxHeight > 0 ? maxHeight : 1080;
   }
 
+  @Override
   public long getDurationUs() {
     return live ? C.UNKNOWN_TIME_US : durationUs;
   }
 
-  /**
-   * Adaptive implementations must set the maximum video dimensions on the supplied
-   * {@link MediaFormat}. Other implementations do nothing.
-   * <p>
-   * Only called when the source is enabled.
-   *
-   * @param out The {@link MediaFormat} on which the maximum video dimensions should be set.
-   */
+  @Override
   public void getMaxVideoDimensions(MediaFormat out) {
     out.setMaxVideoDimensions(maxWidth, maxHeight);
   }
 
-  /**
-   * Returns the next {@link HlsChunk} that should be loaded.
-   *
-   * @param previousTsChunk The previously loaded chunk that the next chunk should follow.
-   * @param seekPositionUs If there is no previous chunk, this parameter must specify the seek
-   *     position. If there is a previous chunk then this parameter is ignored.
-   * @param playbackPositionUs The current playback position.
-   * @return The next chunk to load.
-   */
+  @Override
   public HlsChunk getChunkOperation(TsChunk previousTsChunk, long seekPositionUs,
       long playbackPositionUs) {
     if (previousTsChunk != null && (previousTsChunk.isLastChunk
@@ -357,13 +343,7 @@ public class HlsChunkSourceImpl {
         startTimeUs, endTimeUs, chunkMediaSequence, isLastChunk);
   }
 
-  /**
-   * Invoked when an error occurs loading a chunk.
-   *
-   * @param chunk The chunk whose load failed.
-   * @param e The failure.
-   * @return True if the error was handled by the source. False otherwise.
-   */
+  @Override
   public boolean onLoadError(HlsChunk chunk, IOException e) {
     if ((chunk instanceof MediaPlaylistChunk) && (e instanceof InvalidResponseCodeException)) {
       InvalidResponseCodeException responseCodeException = (InvalidResponseCodeException) e;

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsMasterPlaylist.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsMasterPlaylist.java
@@ -16,6 +16,7 @@
 package com.google.android.exoplayer.hls;
 
 import java.util.List;
+import java.util.ArrayList;
 
 /**
  * Represents an HLS master playlist.
@@ -23,12 +24,64 @@ import java.util.List;
 public final class HlsMasterPlaylist extends HlsPlaylist {
 
   public final List<Variant> variants;
-  public final List<Subtitle> subtitles;
+  public final List<AlternateMedia> subtitles = new ArrayList<AlternateMedia>();
+  public final List<AlternateMedia> closedCaptions = new ArrayList<AlternateMedia>();
+  public final List<AlternateMedia> alternateAudio = new ArrayList<AlternateMedia>();
+  public final List<AlternateMedia> alternateVideo = new ArrayList<AlternateMedia>();
 
-  public HlsMasterPlaylist(String baseUri, List<Variant> variants, List<Subtitle> subtitles) {
+  public HlsMasterPlaylist(String baseUri, List<Variant> variants, List<AlternateMedia> alternateMedias) {
     super(baseUri, HlsPlaylist.TYPE_MASTER);
     this.variants = variants;
-    this.subtitles = subtitles;
-  }
 
+    for (AlternateMedia a: alternateMedias) {
+      if (a.type == AlternateMedia.TYPE_AUDIO) {
+        alternateAudio.add(a);
+        continue;
+      }
+      if (a.type == AlternateMedia.TYPE_VIDEO) {
+        alternateVideo.add(a);
+        continue;
+      }
+      if (a.type == AlternateMedia.TYPE_SUBTITLES) {
+        subtitles.add(a);
+        continue;
+      }
+      if (a.type == AlternateMedia.TYPE_CLOSED_CAPTIONS) {
+        closedCaptions.add(a);
+        continue;
+      }
+    }
+
+    for (Variant v: variants) {
+      for (AlternateMedia a: alternateMedias) {
+        if (a.type == AlternateMedia.TYPE_AUDIO &&
+            v.audioGroup != null && a.groupID != null &&
+            v.audioGroup.equals(a.groupID)) {
+          v.alternateAudio.add(a);
+          continue;
+        }
+
+        if (a.type == AlternateMedia.TYPE_VIDEO &&
+            v.videoGroup != null && a.groupID != null &&
+            v.videoGroup.equals(a.groupID)) {
+          v.alternateVideo.add(a);
+          continue;
+        }
+
+        if (a.type == AlternateMedia.TYPE_SUBTITLES &&
+            v.subtitlesGroup != null && a.groupID != null &&
+            v.subtitlesGroup.equals(a.groupID)) {
+          v.subtitles.add(a);
+          continue;
+        }
+
+        if (a.type == AlternateMedia.TYPE_CLOSED_CAPTIONS &&
+            v.closedCaptionsGroup != null && a.groupID != null &&
+            v.closedCaptionsGroup.equals(a.groupID)) {
+          v.closedCaptions.add(a);
+          continue;
+        }
+      }
+    }
+  }
 }

--- a/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
@@ -16,6 +16,8 @@
 package com.google.android.exoplayer.hls;
 
 import java.util.Comparator;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * Variant stream reference.
@@ -43,14 +45,29 @@ public final class Variant {
   public final String[] codecs;
   public final int width;
   public final int height;
+  public final String audioGroup;
+  public final String videoGroup;
+  public final String closedCaptionsGroup;
+  public final String subtitlesGroup;
 
-  public Variant(int index, String url, int bandwidth, String[] codecs, int width, int height) {
+  public final List<AlternateMedia> subtitles = new ArrayList<AlternateMedia>();
+  public final List<AlternateMedia> closedCaptions = new ArrayList<AlternateMedia>();
+  public final List<AlternateMedia> alternateAudio = new ArrayList<AlternateMedia>();
+  public final List<AlternateMedia> alternateVideo = new ArrayList<AlternateMedia>();
+
+
+  public Variant(int index, String url, int bandwidth, String[] codecs, int width, int height,
+                 String videoGroup, String audioGroup, String subtitlesGroup, String closedCaptionsGroup) {
     this.index = index;
     this.bandwidth = bandwidth;
     this.url = url;
     this.codecs = codecs;
     this.width = width;
     this.height = height;
+    this.videoGroup = videoGroup;
+    this.audioGroup = audioGroup;
+    this.closedCaptionsGroup = closedCaptionsGroup;
+    this.subtitlesGroup = subtitlesGroup;
   }
 
 }


### PR DESCRIPTION
This is a tentative fix for the audio part of issue 73 . It is loosely based on the multi track support for Dash. It only support one audio group for all the streams and completely bypass the TS audio. I think this is the basic use case for alternative audio as mentioned by @perchrh and @johanlindquist.

It has problem with audio synchronisation. Any idea what's the problem? When switching audio tracks, it gets synchronised but it's quickly drifting after.

I updated the parser so that it parses all alternate media types and not only the subtitles.

Also there is no load control as mentioned in the comment by @ojw28.

I tried to split the change in a way that make sense so please do a per commit review. Also I'm new to ExoPlayer and media players so please forgive me if I made stupid assumptions ;-)
