### PR TITLE
Fix AES decryption of HLS streams.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -233,9 +233,6 @@ public final class HlsPlaylistParser implements NetworkLoadable.Parser<HlsPlayli
           segmentEncryptionKeyUri = HlsParserUtil.parseStringAttr(line, URI_ATTR_REGEX,
               URI_ATTR);
           segmentEncryptionIV = HlsParserUtil.parseOptionalStringAttr(line, IV_ATTR_REGEX);
-          if (segmentEncryptionIV == null) {
-            segmentEncryptionIV = Integer.toHexString(segmentMediaSequence);
-          }
         }
       } else if (line.startsWith(BYTERANGE_TAG)) {
         String byteRange = HlsParserUtil.parseStringAttr(line, BYTERANGE_REGEX, BYTERANGE_TAG);
@@ -247,13 +244,21 @@ public final class HlsPlaylistParser implements NetworkLoadable.Parser<HlsPlayli
       } else if (line.equals(DISCONTINUITY_TAG)) {
         segmentDiscontinuity = true;
       } else if (!line.startsWith("#")) {
+        String thisSegmentEncryptionIV;
+        if (segmentEncryptionIV != null) {
+          thisSegmentEncryptionIV = segmentEncryptionIV;
+        } else if (HlsMediaPlaylist.ENCRYPTION_METHOD_AES_128.equals(segmentEncryptionMethod)) {
+          thisSegmentEncryptionIV = Integer.toHexString(segmentMediaSequence);
+        } else {
+          thisSegmentEncryptionIV = null;
+        }
         segmentMediaSequence++;
         if (segmentByterangeLength == C.LENGTH_UNBOUNDED) {
           segmentByterangeOffset = 0;
         }
         segments.add(new Segment(line, segmentDurationSecs, segmentDiscontinuity,
             segmentStartTimeUs, segmentEncryptionMethod, segmentEncryptionKeyUri,
-            segmentEncryptionIV, segmentByterangeOffset, segmentByterangeLength));
+            thisSegmentEncryptionIV, segmentByterangeOffset, segmentByterangeLength));
         segmentStartTimeUs += (long) (segmentDurationSecs * C.MICROS_PER_SECOND);
         segmentDiscontinuity = false;
         segmentDurationSecs = 0.0;


### PR DESCRIPTION
As per http://tools.ietf.org/html/draft-pantos-http-live-streaming-04#section-5.2,
the initializaton vector (IV) of the AES decryption algorithm should be set to:
- the IV attribute value if present,
- the sequence number otherwise.

Currently, the IV is set once and use over all next media sequences
where the IV attribute is not set. The fix is to use the provided IV if
given or use the current media sequence number.