### PR TITLE
The value of AUTOSELECT, DEFAULT attributes of subtitles in HLS playist doesn't include ' " ' character

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -98,9 +98,9 @@ public final class HlsPlaylistParser implements NetworkLoadable.Parser<HlsPlayli
   private static final Pattern NAME_ATTR_REGEX =
       Pattern.compile(NAME_ATTR + "=\"(.+?)\"");
   private static final Pattern AUTOSELECT_ATTR_REGEX =
-      Pattern.compile(AUTOSELECT_ATTR + "=\"(.+?)\"");
+      Pattern.compile(AUTOSELECT_ATTR + "=([A-Z]+)", Pattern.CASE_INSENSITIVE);
   private static final Pattern DEFAULT_ATTR_REGEX =
-      Pattern.compile(DEFAULT_ATTR + "=\"(.+?)\"");
+      Pattern.compile(DEFAULT_ATTR + "=([A-Z]+)", Pattern.CASE_INSENSITIVE);
 
   @Override
   public HlsPlaylist parse(String connectionUrl, InputStream inputStream)


### PR DESCRIPTION
They are represented as these and takes only YES / NO values:
  AUTOSELECT=YES,DEFAULT=YES