### PR TITLE
Enabled Multi Adaption sets for Type in Manifest (Dash)

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/dash/mpd/Period.java
+++ b/library/src/main/java/com/google/android/exoplayer/dash/mpd/Period.java
@@ -15,6 +15,7 @@
  */
 package com.google.android.exoplayer.dash.mpd;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -72,5 +73,26 @@ public class Period {
     }
     return -1;
   }
+
+
+    /**
+     * Returns the indices of all adaptations sets for a given type, or an empty List<Integer> if no adaptation set of
+     * the specified type exists.
+     *
+     * @param type An adaptation set type.
+     * @return List<Integer> with all indices of adaptation sets for the specified type, List can be Empty.
+     */
+    public List<Integer> getAdaptationSetIndices(int type) {
+        List<Integer> foundIndices = new ArrayList<>();
+
+        int adaptationCount = adaptationSets.size();
+        for (int i = 0; i < adaptationCount; i++) {
+            if (adaptationSets.get(i).type == type) {
+                foundIndices.add(i);
+            }
+        }
+        return foundIndices;
+    }
+
 
 }


### PR DESCRIPTION
This Applies to Manifests Having Multiple Audio Adaptions in Manifest (For Example on Multi Language Content)

Example for Multi Language Manifest File:

```
<MPD ... >
...
  <Period>
   ...
    <AdaptationSet
      group="1"
      lang="de"
      minBandwidth="1536000"
      maxBandwidth="1536000"
      segmentAlignment="true"
      audioSamplingRate="48000"
      mimeType="audio/mp4"
      codecs="mp4a.40.2">
      <AudioChannelConfiguration
        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
        value="2">
      </AudioChannelConfiguration>
      ...
      <Representation
        id="audio_deu=1536000"
        bandwidth="1536000">
      </Representation>
    </AdaptationSet>
    <AdaptationSet
      group="1"
      lang="en"
      minBandwidth="1536000"
      maxBandwidth="1536000"
      segmentAlignment="true"
      audioSamplingRate="48000"
      mimeType="audio/mp4"
      codecs="mp4a.40.2">
      <AudioChannelConfiguration
        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
        value="2">
      </AudioChannelConfiguration>
     ... 
      <Representation
        id="audio_eng=1536000"
        bandwidth="1536000">
      </Representation>
    </AdaptationSet>
   ...
  </Period>
</MPD
```

This Also Applies to Video Sources (For Example Different Aspect Ratios)

I only Extended the Dash Renderer for Multi Audio Files