### PR TITLE
Fix: made HttpDataSource compatible with servers that do not support range requests

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/upstream/DefaultHttpDataSource.java.orig
+++ b/library/src/main/java/com/google/android/exoplayer/upstream/DefaultHttpDataSource.java.orig
@@ -56,7 +56,6 @@ public class DefaultHttpDataSource implements HttpDataSource {
   private HttpURLConnection connection;
   private InputStream inputStream;
   private boolean opened;
-  private long skipBytes;
 
   private long dataLength;
   private long bytesRead;
@@ -166,22 +165,8 @@ public class DefaultHttpDataSource implements HttpDataSource {
       throw new InvalidContentTypeException(contentType, dataSpec);
     }
 
-    // only used if gzip not used
-    long contentLength = getContentLength(connection);
-
-    if (responseCode == 200 && dataSpec.position != 0) {
-      // We requested a range, but server did not comply.
-
-      Log.i(TAG, "Server does not support partial requests");
-      skipBytes = dataSpec.position;
-
-      if (dataSpec.length != C.LENGTH_UNBOUNDED) {
-        // Avoid UnexpectedLengthException
-        contentLength = dataSpec.length;
-      }
-    }
-
     if ((dataSpec.flags & DataSpec.FLAG_ALLOW_GZIP) == 0) {
+      long contentLength = getContentLength(connection);
       dataLength = dataSpec.length == C.LENGTH_UNBOUNDED ? contentLength : dataSpec.length;
       if (dataSpec.length != C.LENGTH_UNBOUNDED && contentLength != C.LENGTH_UNBOUNDED
           && contentLength != dataSpec.length) {
@@ -217,24 +202,16 @@ public class DefaultHttpDataSource implements HttpDataSource {
   @Override
   public int read(byte[] buffer, int offset, int readLength) throws HttpDataSourceException {
     int read = 0;
-    int skipped = 0;
-
     try {
-      while (skipBytes > 0) {
-        long currentSkip = inputStream.skip(skipBytes);
-        skipBytes -= currentSkip;
-        skipped += currentSkip;
-      }
-
       read = inputStream.read(buffer, offset, readLength);
     } catch (IOException e) {
       throw new HttpDataSourceException(e, dataSpec);
     }
 
-    if (read + skipped > 0) {
-      bytesRead += read;  // only take the requested bytes, not the skipped
+    if (read > 0) {
+      bytesRead += read;
       if (listener != null) {
-        listener.onBytesTransferred(read + skipped);
+        listener.onBytesTransferred(read);
       }
     } else if (dataLength != C.LENGTH_UNBOUNDED && dataLength != bytesRead) {
       // Check for cases where the server closed the connection having not sent the correct amount

--- a/library/src/main/java/com/google/android/exoplayer/upstream/DefaultHttpDataSource.java.rej
+++ b/library/src/main/java/com/google/android/exoplayer/upstream/DefaultHttpDataSource.java.rej
@@ -1,0 +1,21 @@
+--- library/src/main/java/com/google/android/exoplayer/upstream/DefaultHttpDataSource.java
++++ library/src/main/java/com/google/android/exoplayer/upstream/DefaultHttpDataSource.java
+@@ -273,6 +274,18 @@
+     }
+ 
+     long contentLength = getContentLength(connection);
++
++    if (responseCode == 200 && dataSpec.position != 0) {
++      // We requested a range, but server did not comply.
++      skipBytes = dataSpec.position;
++      Log.i(TAG, "Server does not support partial requests");
++
++      if (dataSpec.length != C.LENGTH_UNBOUNDED) {
++        // Avoid UnexpectedLengthException
++        contentLength = dataSpec.length;
++      }
++    }
++
+     dataLength = dataSpec.length == C.LENGTH_UNBOUNDED ? contentLength : dataSpec.length;
+ 
+     if (dataSpec.length != C.LENGTH_UNBOUNDED && contentLength != C.LENGTH_UNBOUNDED


### PR DESCRIPTION
When a http request is re-requested, a Range request is used. If the server returns a full response (200 OK), ExoPlayer would throw an UnexpectedLengthException exception.