### PR TITLE
Fix DataSourceInputStream.read() for EOF cases

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/upstream/DataSourceInputStream.java
+++ b/library/src/main/java/com/google/android/exoplayer/upstream/DataSourceInputStream.java
@@ -58,8 +58,11 @@ public class DataSourceInputStream extends InputStream {
 
   @Override
   public int read() throws IOException {
-    read(singleByteArray);
-    return singleByteArray[0] & 0xFF;
+    int length = read(singleByteArray);
+    if(length != -1) {
+      return singleByteArray[0] & 0xFF;
+    }
+    return length;
   }
 
   @Override


### PR DESCRIPTION
Currently, read() returns garbage data when EOF is reached. Ideally it should return -1 if EOF is reached.