### PR TITLE
HLS AAC fix

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsExtractorWrapper.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsExtractorWrapper.java
@@ -61,7 +61,6 @@ public final class HlsExtractorWrapper implements ExtractorOutput {
     this.extractor = extractor;
     this.shouldSpliceIn = shouldSpliceIn;
     sampleQueues = new SparseArray<DefaultTrackOutput>();
-    extractor.init(this);
   }
 
   /**
@@ -71,6 +70,7 @@ public final class HlsExtractorWrapper implements ExtractorOutput {
    */
   public void init(Allocator allocator) {
     this.allocator = allocator;
+    this.extractor.init(this);
   }
 
   /**


### PR DESCRIPTION
Fixes issue where an NPE occurs when RollingSampleBuffer is created
with a null Allocator.