### PR TITLE
Upgrade Mockito and dexmaker versions.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,8 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+
+JUNIT_VERSION = 4.12
+DEXMAKER_VERSION = 1.4
+MOCKITO_VERSION = 1.10.19

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -48,9 +48,10 @@ android {
 }
 
 dependencies {
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
-    androidTestCompile 'org.mockito:mockito-core:1.9.5'
+    androidTestCompile "org.mockito:mockito-core:${MOCKITO_VERSION}"
+    androidTestCompile "com.crittercism.dexmaker:dexmaker:${DEXMAKER_VERSION}"
+    androidTestCompile "com.crittercism.dexmaker:dexmaker-dx:${DEXMAKER_VERSION}"
+    androidTestCompile "com.crittercism.dexmaker:dexmaker-mockito:${DEXMAKER_VERSION}"
 }
 
 android.libraryVariants.all { variant ->

--- a/library/src/test/java/com/google/android/exoplayer/extractor/mp3/BufferingInputTest.java
+++ b/library/src/test/java/com/google/android/exoplayer/extractor/mp3/BufferingInputTest.java
@@ -15,10 +15,8 @@
  */
 package com.google.android.exoplayer.extractor.mp3;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import android.net.Uri;
+import android.test.InstrumentationTestCase;
 
 import com.google.android.exoplayer.extractor.DefaultExtractorInput;
 import com.google.android.exoplayer.extractor.ExtractorInput;
@@ -28,13 +26,15 @@ import com.google.android.exoplayer.testutil.TestUtil;
 import com.google.android.exoplayer.upstream.DataSpec;
 import com.google.android.exoplayer.util.ParsableByteArray;
 
-import android.net.Uri;
-import android.test.InstrumentationTestCase;
-
 import org.mockito.Mock;
 
 import java.nio.BufferOverflowException;
 import java.util.Arrays;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
  * Tests for {@link BufferingInput}.
@@ -52,13 +52,13 @@ public class BufferingInputTest extends InstrumentationTestCase {
 
   @Override
   public void setUp() throws Exception {
-    TestUtil.setUpMockito(this);
-
     FakeDataSource.Builder builder = new FakeDataSource.Builder();
     builder.appendReadData(STREAM_DATA);
     FakeDataSource fakeDataSource = builder.build();
     fakeDataSource.open(new DataSpec(Uri.parse(TEST_URI)));
     fakeExtractorInput = new DefaultExtractorInput(fakeDataSource, 0, STREAM_DATA.length);
+
+    TestUtil.setUpMockito(this);
   }
 
   public void testReadFromExtractor() throws Exception {

--- a/library/src/test/java/com/google/android/exoplayer/testutil/TestUtil.java
+++ b/library/src/test/java/com/google/android/exoplayer/testutil/TestUtil.java
@@ -15,15 +15,15 @@
  */
 package com.google.android.exoplayer.testutil;
 
+import android.net.Uri;
+import android.test.InstrumentationTestCase;
+
 import com.google.android.exoplayer.C;
 import com.google.android.exoplayer.extractor.DefaultExtractorInput;
 import com.google.android.exoplayer.extractor.Extractor;
 import com.google.android.exoplayer.extractor.ExtractorInput;
 import com.google.android.exoplayer.extractor.PositionHolder;
 import com.google.android.exoplayer.upstream.DataSpec;
-
-import android.net.Uri;
-import android.test.InstrumentationTestCase;
 
 import org.mockito.MockitoAnnotations;
 
@@ -100,9 +100,6 @@ public class TestUtil {
   }
 
   public static void setUpMockito(InstrumentationTestCase instrumentationTestCase) {
-    // Workaround for https://code.google.com/p/dexmaker/issues/detail?id=2.
-    System.setProperty("dexmaker.dexcache",
-        instrumentationTestCase.getInstrumentation().getTargetContext().getCacheDir().getPath());
     MockitoAnnotations.initMocks(instrumentationTestCase);
   }
 


### PR DESCRIPTION
Fixes #651.
The third_party directory still exists and should probably be removed (the only reference to it is in a Eclipse .project file - which can be removed as well. ;-)).