### PR TITLE
Fixed bug of AES URI Pattern for hls

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -87,7 +87,7 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
   private static final Pattern METHOD_ATTR_REGEX =
       Pattern.compile(METHOD_ATTR + "=(" + METHOD_NONE + "|" + METHOD_AES128 + ")");
   private static final Pattern URI_ATTR_REGEX =
-      Pattern.compile(URI_ATTR + "=\"(.+)\"");
+      Pattern.compile(URI_ATTR + "=\"(.+?)\"");
   private static final Pattern IV_ATTR_REGEX =
       Pattern.compile(IV_ATTR + "=([^,.*]+)");
   private static final Pattern TYPE_ATTR_REGEX =


### PR DESCRIPTION
HLS is allowed format like `#EXT-X-KEY:METHOD=AES-128,URI="https://example.com/aes.m3u8key",IV=0xaaaaaaaaaaaaaaaaaaaaaaaaaaa,KEYFORMATVERSIONS="1"` .

`URI_ATTR + "=\"(.+)\"")` will match `URI="https://example.com/aes.m3u8key",IV=0xaaaaaaaaaaaaaaaaaaaaaaaaaaa,KEYFORMATVERSIONS="1"`

So, modify to `URI_ATTR + "=\"([^\"]+)\"")`