### PR TITLE
Enable override of open/close in StreamingDrmSessionManager

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/drm/StreamingDrmSessionManager.java
+++ b/library/src/main/java/com/google/android/exoplayer/drm/StreamingDrmSessionManager.java
@@ -259,7 +259,7 @@ public class StreamingDrmSessionManager implements DrmSessionManager {
   }
 
   @Override
-  public final void open(DrmInitData drmInitData) {
+  public void open(DrmInitData drmInitData) {
     if (++openCount != 1) {
       return;
     }
@@ -290,7 +290,7 @@ public class StreamingDrmSessionManager implements DrmSessionManager {
   }
 
   @Override
-  public final void close() {
+  public void close() {
     if (--openCount != 0) {
       return;
     }


### PR DESCRIPTION
Make it so that extensions of StreamingDrmSessionManager may override open/close.

I'm raising this concern as a PR. We are currently extending StreamingDrmSessionManager for the purpose of enabling preparations of drm sessions. I.e. opening sessions before they are actually used. This speeds up playback since license keys are fetched during this early stage. To do this, we were overriding open/close in StreamingDrmSessionManager (open in particular) to be able to close our prepare reference since open/close are counted. While bumping our version of ExoPlayer I realized these methods are now final. Unless there's a good reason to keep them final I would suggest making them overridable again.