### PR TITLE
Ignore extra returns in Subrip parsing

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/text/subrip/SubripParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/subrip/SubripParser.java
@@ -58,6 +58,10 @@ public final class SubripParser implements SubtitleParser {
     String currentLine;
 
     while ((currentLine = reader.readLine()) != null) {
+      // Skip blank lines.
+      if (currentLine.length() == 0)
+        continue;
+
       // Parse the numeric counter as a sanity check.
       try {
         Integer.parseInt(currentLine);


### PR DESCRIPTION
I was testing SRT support when I found that a number of my test files didn't parse. It turned out the reason was that they contained additional empty lines before the next numeric counter. I don't think this is uncommon, and fairly easy to handle.

Here's an example of an SRT which includes this:

```
1
00:00:34,160 --> 00:00:35,366
Start simple.


2
00:00:35,440 --> 00:00:36,965
Start with what you know is true.
```