### PR TITLE
Explicitly state 16 bits per sample for media format

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/MediaFormat.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaFormat.java
@@ -258,6 +258,7 @@ public final class MediaFormat {
       maybeSetIntegerV16(format, android.media.MediaFormat.KEY_MAX_HEIGHT, maxHeight);
       maybeSetIntegerV16(format, android.media.MediaFormat.KEY_CHANNEL_COUNT, channelCount);
       maybeSetIntegerV16(format, android.media.MediaFormat.KEY_SAMPLE_RATE, sampleRate);
+      maybeSetIntegerV16(format, "bits-per-sample", 16);
       for (int i = 0; i < initializationData.size(); i++) {
         format.setByteBuffer("csd-" + i, ByteBuffer.wrap(initializationData.get(i)));
       }


### PR DESCRIPTION
I acknowledge this might be a hard sell, but... :)

I have been testing the E/AC3 decoding of audio out on number of devices. One of these is a OnePlus One running CM12 (I know). The resulting audio was static. After a bit of digging, I found that CM12 supports 24bit audio which it attempts to default to. I'm not suggesting at all that ExoPlayer might want to support this. However, this change makes it explicit what the expected MediaFormat should be and therefore "fixes" the compatibility issue here. Arguably, I did have to read through the CM12 source code to work this out... but if there was ever a "fix" for this, this one seems the most sensible.