### PR TITLE
Allow decoders with AML prefixes in their names

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/MediaCodecUtil.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaCodecUtil.java
@@ -173,7 +173,7 @@ public final class MediaCodecUtil {
    */
   private static boolean isCodecUsableDecoder(MediaCodecInfo info, String name,
       boolean secureDecodersExplicit) {
-    if (info.isEncoder() || !name.startsWith("OMX.")
+    if (info.isEncoder() || !(name.startsWith("OMX.") || name.startsWith("AML."))
         || (!secureDecodersExplicit && name.endsWith(".secure"))) {
       return false;
     }


### PR DESCRIPTION
I was testing E/AC3 playback on one of these devices (http://www.minix.com.hk/Products/NEO-X8-H-Plus-Android-TV.html) and found that E/AC3 decoding wasn't supported. It turned out to be because the MediaCodec's that it listed for decoding these audio formats had names prefixed with "AML.". I don't know the reason for only whitelisting "OMX" based ones, but after making the attached change, the device played back these audio formats fine. I thought best to raise a PR to allow discussion.

Here's the full `media_codec.xml` of this device, if useful:

```
<MediaCodecs>                                                                    
    <Decoders>                                                                   
        <MediaCodec name="OMX.amlogic.avc.decoder.awesome" type="video/hevc" />  
        <MediaCodec name="OMX.amlogic.avc.decoder.awesome" type="video/avc" />   
        <MediaCodec name="OMX.google.amrnb.decoder" type="audio/3gpp" />         
        <MediaCodec name="OMX.google.amrwb.decoder" type="audio/amr-wb" />       
        <MediaCodec name="OMX.google.aac.decoder" type="audio/mp4a-latm" />      
        <MediaCodec name="OMX.google.adif.decoder" type="audio/aac-adif" />      
        <MediaCodec name="OMX.google.latm.decoder" type="audio/aac-latm" />      
        <MediaCodec name="OMX.google.adts.decoder" type="audio/adts" />          
        <MediaCodec name="OMX.google.g711.alaw.decoder" type="audio/g711-alaw" />
        <MediaCodec name="OMX.google.g711.mlaw.decoder" type="audio/g711-mlaw" />
        <MediaCodec name="OMX.google.adpcm.ima.decoder" type="audio/adpcm-ima" />
        <MediaCodec name="OMX.google.adpcm.ms.decoder" type="audio/adpcm-ms" />  
        <MediaCodec name="OMX.google.vorbis.decoder" type="audio/vorbis" />      
        <MediaCodec name="OMX.google.alac.decoder" type="audio/alac" />          
        <MediaCodec name="OMX.google.wma.decoder" type="audio/wma" />            
        <MediaCodec name="OMX.google.wmapro.decoder" type="audio/wmapro" />      
        <MediaCodec name="OMX.google.ape.decoder" type="audio/ape" />            
        <MediaCodec name="OMX.google.truehd.decoder" type="audio/truehd" />      
        <MediaCodec name="OMX.google.cook.decoder" type="audio/cook" />          
        <MediaCodec name="OMX.google.flac.decoder" type="audio/flac" />          
                                                                                 
        <MediaCodec name="OMX.google.mpeg4.decoder" type="video/mp4v-es" />      
        <MediaCodec name="OMX.google.h263.decoder" type="video/3gpp" />          
        <MediaCodec name="OMX.google.h264.decoder" type="video/avc" />           
        <MediaCodec name="OMX.google.vp8.decoder" type="video/x-vnd.on2.vp8" />  
        <MediaCodec name="OMX.google.vp9.decoder" type="video/x-vnd.on2.vp9" />  
        <MediaCodec name="OMX.google.rm.decoder" type="video/rm" />              
        <MediaCodec name="OMX.google.wmv2.decoder" type="video/wmv2" />          
        <!-- DOLBY_UDC -->                                                       
        <MediaCodec name="AML.google.ac3.decoder" >                              
            <Type name="audio/ac3" />                                            
            <Quirk name="needs-flush-before-disable" />                          
            <Quirk name="requires-flush-complete-emulation" />                   
        </MediaCodec>                                                            
        <MediaCodec name="AML.google.ec3.decoder" >                              
            <Type  name="audio/eac3" />                                          
            <Quirk name="needs-flush-before-disable" />                          
            <Quirk name="requires-flush-complete-emulation" />                   
        </MediaCodec>                                                            
        <!-- DOLBY_UDC END -->
        <MediaCodec name="OMX.google.mp2.decoder" >                              
            <Type  name="audio/mpeg-L2" />                                       
            <Quirk name="needs-flush-before-disable" />                          
            <Quirk name="requires-flush-complete-emulation" />                   
        </MediaCodec>                                                            
                                                                                 
                                                                                 
        <MediaCodec name="OMX.google.mp3.decoder" >                              
            <Type  name="audio/mpeg" />                                          
            <Quirk name="needs-flush-before-disable" />                          
            <Quirk name="requires-flush-complete-emulation" />                   
        </MediaCodec>                                                            
                                                                                 
        <MediaCodec name="AML.google.dtshd.decoder" >                            
            <Type  name="audio/dtshd" />                                         
            <Quirk name="needs-flush-before-disable" />                          
            <Quirk name="requires-flush-complete-emulation" />                   
        </MediaCodec>                                                            
    </Decoders>                                                                  
                                                                                 
    <Encoders>                                                                   
        <MediaCodec name="OMX.google.amrnb.encoder" type="audio/3gpp" />         
        <MediaCodec name="OMX.google.amrwb.encoder" type="audio/amr-wb" />       
        <MediaCodec name="OMX.google.aac.encoder" type="audio/mp4a-latm" />      
        <MediaCodec name="OMX.google.flac.encoder" type="audio/flac" />          
                                                                                 
        <MediaCodec name="OMX.google.mpeg4.encoder" type="video/mp4v-es" />      
        <MediaCodec name="OMX.google.h263.encoder" type="video/3gpp" />          
        <MediaCodec name="OMX.amlogic.video.encoder.avc" type="video/avc" />     
        <MediaCodec name="OMX.google.h264.encoder" type="video/avc" />           
        <MediaCodec name="OMX.google.vp8.encoder" type="video/x-vnd.on2.vp8" />  
    </Encoders>                                                                
</MediaCodecs>  
```

The other thing that i'm noticing is the non-standard "type" that manufacturers define for DTS and DTS-HD variants. This device uses `audio/dtshd` which doesn't match that expected in ExoPlayer. It also doesn't match the OnePlus One (which uses `audio/vnd.dts.hd`). This also is similar with just the standard DTS decoder where i've got three different devices all using a different mime type. Maybe the topic for a separate GHI, but it might be worth considering allowing multiple mimeTypes (or aliases) to improve cross-device compatibility.