### PR TITLE
Fixed issue with WebVTT percentage values

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/text/webvtt/WebvttParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/webvtt/WebvttParser.java
@@ -60,6 +60,8 @@ public final class WebvttParser implements SubtitleParser {
   private static final String WEBVTT_CUE_SETTING_STRING = "\\S*:\\S*";
   private static final Pattern WEBVTT_CUE_SETTING = Pattern.compile(WEBVTT_CUE_SETTING_STRING);
 
+  private static final String WEBVTT_PERCENTAGE_NUMBER = "^([0-9]+|[0-9]+\\.[0-9]+)$";
+
   private static final String NON_NUMERIC_STRING = ".*[^0-9].*";
 
   private final StringBuilder textBuilder;
@@ -226,11 +228,11 @@ public final class WebvttParser implements SubtitleParser {
     }
 
     s = s.substring(0, s.length() - 1);
-    if (s.matches(NON_NUMERIC_STRING)) {
+    if (!s.matches(WEBVTT_PERCENTAGE_NUMBER)) {
       throw new NumberFormatException(s + " contains an invalid character");
     }
 
-    int value = Integer.parseInt(s);
+    int value = Math.round(Float.parseFloat(s));
     if (value < 0 || value > 100) {
       throw new NumberFormatException(value + " is out of range [0-100]");
     }


### PR DESCRIPTION
Current WebVTT parser is assuming percentages are always integer values.
However, following WebVTT specification percentage values format is as
follows (http://dev.w3.org/html5/webvtt/#webvtt-file-structure):

“
A WebVTT percentage consists of the following components:

1.- One or more ASCII digits.
2.- Optionally:
1.- A U+002E DOT character (.).
2.- One or more ASCII digits.
3.- A U+0025 PERCENT SIGN character (%).
”

This change modifies the way the percentage values are checked to ensure
parser takes into account the format defined in the specification.

Note: While checking format I am keeping check of existence of “%”
character and check of number format separated (instead of using the regex for checking all) just for keeping as
detailed logs as we have today (log message advising about lack of “%”
character; log message advising about wrong number format). 