### PR TITLE
Improve WebVTT parser according to WebVTT spec

### DIFF
--- a/library/src/androidTest/assets/webvtt/typical_with_comments
+++ b/library/src/androidTest/assets/webvtt/typical_with_comments
@@ -1,0 +1,18 @@
+WEBVTT
+
+NOTE
+This is a comment block
+with multiple lines
+
+1
+00:00.000 --> 00:01.234
+This is the first subtitle.
+
+NOTE Single line comment
+
+2
+00:02.345 --> 00:03.456
+This is the second subtitle.
+
+NOTE
+File ending with a comment

--- a/library/src/androidTest/assets/webvtt/typical_with_metadata
+++ b/library/src/androidTest/assets/webvtt/typical_with_metadata
@@ -1,0 +1,22 @@
+WEBVTT
+
+NOTE Position with percentage and position alignment
+
+00:00:00.000 --> 00:00:01.234 position:10%,start align:start size:35%
+This is the first subtitle.
+
+NOTE Wrong position provided. It should be provided as
+a percentage value
+
+00:02.345 --> 00:03.456 position:10 align:end size:35%
+This is the second subtitle.
+
+NOTE Line as percentage and line alignment
+
+00:04.000 --> 00:05.000 line:45%,end align:middle size:35%
+This is the third subtitle.
+
+NOTE Line as absolute negative number and without line alignment
+
+00:06.000 --> 00:07.000 line:-10 align:middle size:35%
+This is the forth subtitle.

--- a/library/src/androidTest/java/com/google/android/exoplayer/text/webvtt/WebvttParserTest.java
+++ b/library/src/androidTest/java/com/google/android/exoplayer/text/webvtt/WebvttParserTest.java
@@ -16,6 +16,9 @@
 package com.google.android.exoplayer.text.webvtt;
 
 import android.test.InstrumentationTestCase;
+import android.text.Layout;
+
+import com.google.android.exoplayer.text.Cue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,6 +31,8 @@ public class WebvttParserTest extends InstrumentationTestCase {
   private static final String TYPICAL_WEBVTT_FILE = "webvtt/typical";
   private static final String TYPICAL_WITH_IDS_WEBVTT_FILE = "webvtt/typical_with_identifiers";
   private static final String TYPICAL_WITH_TAGS_WEBVTT_FILE = "webvtt/typical_with_tags";
+  private static final String TYPICAL_WITH_COMMENTS_WEBVTT_FILE = "webvtt/typical_with_comments";
+  private static final String TYPICAL_WITH_METADATA_WEBVTT_FILE = "webvtt/typical_with_metadata";
   private static final String LIVE_TYPICAL_WEBVTT_FILE = "webvtt/live_typical";
   private static final String EMPTY_WEBVTT_FILE = "webvtt/empty";
 
@@ -121,6 +126,88 @@ public class WebvttParserTest extends InstrumentationTestCase {
     assertEquals(6000000, subtitle.getEventTime(6));
     assertEquals("This is the <fourth> &subtitle.",
         subtitle.getCues(subtitle.getEventTime(6)).get(0).text.toString());
+    assertEquals(7000000, subtitle.getEventTime(7));
+  }
+
+  public void testParseTypicalWithCommentsWebvttFile() throws IOException {
+    WebvttParser parser = new WebvttParser();
+    InputStream inputStream =
+            getInstrumentation().getContext().getResources().getAssets()
+                    .open(TYPICAL_WITH_COMMENTS_WEBVTT_FILE);
+    WebvttSubtitle subtitle = parser.parse(inputStream);
+
+    // test event count
+    assertEquals(4, subtitle.getEventTimeCount());
+
+    // test first cue
+    assertEquals(0, subtitle.getEventTime(0));
+    assertEquals("This is the first subtitle.",
+            subtitle.getCues(subtitle.getEventTime(0)).get(0).text.toString());
+    assertEquals(1234000, subtitle.getEventTime(1));
+
+    // test second cue
+    assertEquals(2345000, subtitle.getEventTime(2));
+    assertEquals("This is the second subtitle.",
+            subtitle.getCues(subtitle.getEventTime(2)).get(0).text.toString());
+    assertEquals(3456000, subtitle.getEventTime(3));
+  }
+
+  public void testParseTypicalWithMetadataWebvttFile() throws IOException {
+    WebvttParser parser = new WebvttParser();
+    InputStream inputStream =
+            getInstrumentation().getContext().getResources().getAssets()
+                    .open(TYPICAL_WITH_METADATA_WEBVTT_FILE);
+    WebvttSubtitle subtitle = parser.parse(inputStream);
+
+    // test event count
+    assertEquals(8, subtitle.getEventTimeCount());
+
+    // test first cue
+    assertEquals(0, subtitle.getEventTime(0));
+    assertEquals("This is the first subtitle.",
+        subtitle.getCues(subtitle.getEventTime(0)).get(0).text.toString());
+    assertEquals(10,
+        subtitle.getCues(subtitle.getEventTime(0)).get(0).position);
+    assertEquals(Layout.Alignment.ALIGN_NORMAL,
+        subtitle.getCues(subtitle.getEventTime(0)).get(0).alignment);
+    assertEquals(35,
+        subtitle.getCues(subtitle.getEventTime(0)).get(0).size);
+    assertEquals(1234000, subtitle.getEventTime(1));
+
+    // test second cue
+    assertEquals(2345000, subtitle.getEventTime(2));
+    assertEquals("This is the second subtitle.",
+        subtitle.getCues(subtitle.getEventTime(2)).get(0).text.toString());
+    assertEquals(Cue.UNSET_VALUE,
+        subtitle.getCues(subtitle.getEventTime(2)).get(0).position);
+    assertEquals(Layout.Alignment.ALIGN_OPPOSITE,
+        subtitle.getCues(subtitle.getEventTime(2)).get(0).alignment);
+    assertEquals(35,
+        subtitle.getCues(subtitle.getEventTime(2)).get(0).size);
+    assertEquals(3456000, subtitle.getEventTime(3));
+
+    // test third cue
+    assertEquals(4000000, subtitle.getEventTime(4));
+    assertEquals("This is the third subtitle.",
+        subtitle.getCues(subtitle.getEventTime(4)).get(0).text.toString());
+    assertEquals(45,
+        subtitle.getCues(subtitle.getEventTime(4)).get(0).line);
+    assertEquals(Layout.Alignment.ALIGN_CENTER,
+        subtitle.getCues(subtitle.getEventTime(4)).get(0).alignment);
+    assertEquals(35,
+        subtitle.getCues(subtitle.getEventTime(4)).get(0).size);
+    assertEquals(5000000, subtitle.getEventTime(5));
+
+    // test forth cue
+    assertEquals(6000000, subtitle.getEventTime(6));
+    assertEquals("This is the forth subtitle.",
+        subtitle.getCues(subtitle.getEventTime(6)).get(0).text.toString());
+    assertEquals(-10,
+        subtitle.getCues(subtitle.getEventTime(6)).get(0).line);
+    assertEquals(Layout.Alignment.ALIGN_CENTER,
+        subtitle.getCues(subtitle.getEventTime(6)).get(0).alignment);
+    assertEquals(35,
+        subtitle.getCues(subtitle.getEventTime(6)).get(0).size);
     assertEquals(7000000, subtitle.getEventTime(7));
   }
 


### PR DESCRIPTION
- Line parameter
  - Added support for value and line alignment attributes.
  - Support negative numbers when line is an absolute number (not a
percentage).
- Position parameter
  - Added support for value and position alignment attributes
- Added support for WebVTT comment blocks
- Percentage values now accept decimal numbers (as webvtt spec states)
- Added new WebVTT tests for testing all new implemented features

This PR is focused on improving the parser. Later work is needed on improving WebVTT cue rendering process to use new parsed parameters (line alignment, position alignment, line as percentage, etc)