### PR TITLE
Prevent ArrayIndexOutOfBoundsException when proguard is enabled

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/util/ParsableBitArray.java
+++ b/library/src/main/java/com/google/android/exoplayer/util/ParsableBitArray.java
@@ -138,7 +138,8 @@ public final class ParsableBitArray {
     int returnValue = 0;
 
     // While n >= 8, read whole bytes.
-    while (n >= 8) {
+    int numBytes = (n / 8);
+    for (int i = 0; i < numBytes; i ++) {
       int byteValue;
       if (bitOffset != 0) {
         byteValue = ((data[byteOffset] & 0xFF) << bitOffset)


### PR DESCRIPTION
When I proguraded my app which play HLS movies, surely I encountered ArrayIndexOutOfBoundsException #748 by using 303SH(4.2.2), SH-01F(4.2.2), F-01F(4.2.2) and other 4.2.2 devices.

I logged ParsableBitArray.readBits as below:
```
  public int readBits(int n) {

    Log.d("point1", String.valueOf(n) + " : " + String.valueOf(byteOffset));
    
    if (n == 0) {
      return 0;
    }

    int returnValue = 0;

    // While n >= 8, read whole bytes.
    while (n >= 8) {
      int byteValue;
      if (bitOffset != 0) {
        byteValue = ((data[byteOffset] & 0xFF) << bitOffset)
            | ((data[byteOffset + 1] & 0xFF) >>> (8 - bitOffset));
      } else {
        byteValue = data[byteOffset];
      }
      n -= 8;
      returnValue |= (byteValue & 0xFF) << n;
      byteOffset++;
    }

    Log.d("point2", String.valueOf(n) + " : " + String.valueOf(byteOffset));
```
At the crash case, unexpected values were logged.

| point | n | byteOffset |
|---|---|---|
| 1 | 16 | 4 |
| 2 | -8 | 7 |

As the result, TSExtractor read the 10th byte of PES header only holding 9 bytes.

Though I don't accurately know what happens, as perhaps the variable "n" used as loop condition is updated within the loop, some runtime environments execute this loop in parallel at the code optimized by proguard.

So I define the number of loops before that loop, and the exception isn't thrown when proguard is enabled.