### PR TITLE
Fixed crash when having different startNumber values in a DASH manifest

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/dash/mpd/SegmentBase.java
+++ b/library/src/main/java/com/google/android/exoplayer/dash/mpd/SegmentBase.java
@@ -175,6 +175,7 @@ public abstract class SegmentBase {
      */
     public final long getSegmentDurationUs(int sequenceNumber, long periodDurationUs) {
       if (segmentTimeline != null) {
+        sequenceNumber = sequenceNumber < startNumber ? startNumber : sequenceNumber;
         long duration = segmentTimeline.get(sequenceNumber - startNumber).duration;
         return (duration * C.MICROS_PER_SECOND) / timescale;
       } else {
@@ -188,6 +189,7 @@ public abstract class SegmentBase {
      * @see DashSegmentIndex#getTimeUs(int)
      */
     public final long getSegmentTimeUs(int sequenceNumber) {
+      sequenceNumber = sequenceNumber < startNumber ? startNumber : sequenceNumber;
       long unscaledSegmentTime;
       if (segmentTimeline != null) {
         unscaledSegmentTime = segmentTimeline.get(sequenceNumber - startNumber).startTime
@@ -328,6 +330,7 @@ public abstract class SegmentBase {
     @Override
     public RangedUri getSegmentUrl(Representation representation, int sequenceNumber) {
       long time = 0;
+      sequenceNumber = sequenceNumber < startNumber ? startNumber : sequenceNumber;
       if (segmentTimeline != null) {
         time = segmentTimeline.get(sequenceNumber - startNumber).startTime;
       } else {


### PR DESCRIPTION
The crash happens when we have a dash stream that has different startNumbers on each Representation SegmentTemplate as this example shows.

The sequenceNumber - startNumber is a negative number that causes a crash.

Setting the sequenceNumber - startNumber to 0 (by setting the sequenceNumber = startNumber) avoids the crash and the playback continues uninterrupted.

```xml
<AdaptationSet mimeType="video/mp4" segmentAlignment="true" subsegmentAlignment="true" startWithSAP="1" subsegmentStartsWithSAP="1" bitstreamSwitching="true">
      <Representation id="1" width="960" height="540" frameRate="30/1" bandwidth="1499968" codecs="avc1.4D401F">
        <SegmentTemplate timescale="90000" media="_____" initialization="_____" startNumber="48785" presentationTimeOffset="774314720">
          <SegmentTimeline>
            <S t="774314720" d="900000" r="125"/>
            <S t="887714720" d="204000"/>
          </SegmentTimeline>
        </SegmentTemplate>
      </Representation>
      <Representation id="2" width="640" height="360" frameRate="30/1" bandwidth="899968" codecs="avc1.4D401F">
        <SegmentTemplate timescale="90000" media="_____" initialization="_____" startNumber="48780" presentationTimeOffset="774314720">
          <SegmentTimeline>
            <S t="774314720" d="900000" r="125"/>
            <S t="887714720" d="204000"/>
          </SegmentTimeline>
        </SegmentTemplate>
      </Representation>
      <Representation id="3" width="480" height="270" frameRate="30/1" bandwidth="499968" codecs="avc1.4D401F">
        <SegmentTemplate timescale="90000" media="_____" initialization="____" startNumber="48782" presentationTimeOffset="774314720">
          <SegmentTimeline>
            <S t="774314720" d="900000" r="125"/>
            <S t="887714720" d="180000"/>
          </SegmentTimeline>
        </SegmentTemplate>
      </Representation>
      <Representation id="4" width="320" height="180" frameRate="30/1" bandwidth="299968" codecs="avc1.4D400D">
        <SegmentTemplate timescale="90000" media="_____" initialization="____" startNumber="48782" presentationTimeOffset="774314720">
          <SegmentTimeline>
            <S t="774314720" d="900000" r="125"/>
            <S t="887714720" d="180000"/>
          </SegmentTimeline>
        </SegmentTemplate>
      </Representation>
    </AdaptationSet>
    <AdaptationSet mimeType="audio/mp4" segmentAlignment="0">
      <Representation id="5" bandwidth="64034" audioSamplingRate="48000" codecs="mp4a.40.2">
        <SegmentTemplate timescale="90000" media="_____" initialization="_____" startNumber="48785" presentationTimeOffset="774315680">
          <SegmentTimeline>
```

(filenames removed for confidentiality)