### PR TITLE
Parse audioChannels only when on mpeg-dash

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/dash/mpd/MediaPresentationDescriptionParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/dash/mpd/MediaPresentationDescriptionParser.java
@@ -590,7 +590,10 @@ public class MediaPresentationDescriptionParser extends DefaultHandler
 
   protected int parseAudioChannelConfiguration(XmlPullParser xpp)
       throws XmlPullParserException, IOException {
-    int audioChannels = parseInt(xpp, "value");
+    int audioChannels = -1;
+    String schemeIdUri = parseString(xpp, "schemeIdUri", "");
+    if (schemeIdUri.equals("urn:mpeg:dash:23003:3:audio_channel_configuration:2011"))
+      audioChannels = parseInt(xpp, "value");
     do {
       xpp.next();
     } while (!ParserUtil.isEndTag(xpp, "AudioChannelConfiguration"));


### PR DESCRIPTION
Only parse the `value` as Int when the `schemeIdUri` is `urn:mpeg:dash:23003:3:audio_channel_configuration:2011`

For example this stream contains Dolby audio tracks which follow a different scheme: http://demo.cf.castlabs.com/media/TOS/abr/Manifest.mpd

Example:

`<AudioChannelConfiguration schemeIdUri="urn:dolby:dash:audio_channel_configuration:2011" value="A000"/>`

For that case the `audioChannel` is set to -1, as the Format class expects when it is not applicable.