### PR TITLE
Stability when playing HLS

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer/demo/EventLogger.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/EventLogger.java
@@ -150,6 +150,11 @@ public class EventLogger implements DemoPlayer.Listener, DemoPlayer.InfoListener
   }
 
   @Override
+  public void onDecoderError(IllegalStateException e) {
+    printInternalError("decoderError", e);
+  }
+
+  @Override
   public void onAudioTrackInitializationError(AudioTrack.InitializationException e) {
     printInternalError("audioTrackInitializationError", e);
   }

--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
@@ -109,6 +109,8 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
     void onCryptoError(CryptoException e);
     void onLoadError(int sourceId, IOException e);
     void onDrmSessionManagerError(Exception e);
+
+    void onDecoderError(IllegalStateException e);
   }
 
   /**
@@ -458,6 +460,13 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
   public void onDecoderInitializationError(DecoderInitializationException e) {
     if (internalErrorListener != null) {
       internalErrorListener.onDecoderInitializationError(e);
+    }
+  }
+
+  @Override
+  public void onDecoderError(IllegalStateException e) {
+    if (internalErrorListener != null) {
+      internalErrorListener.onDecoderError(e);
     }
   }
 

--- a/extensions/opus/src/main/java/com/google/android/exoplayer/ext/opus/OpusDecoderWrapper.java
+++ b/extensions/opus/src/main/java/com/google/android/exoplayer/ext/opus/OpusDecoderWrapper.java
@@ -214,9 +214,9 @@ import java.util.LinkedList;
         skipSamples = (inputBuffer.sampleHolder.timeUs == 0) ? opusHeader.skipSamples : seekPreRoll;
       }
       SampleHolder sampleHolder = inputBuffer.sampleHolder;
-      sampleHolder.data.position(sampleHolder.data.position() - sampleHolder.size);
+      sampleHolder.data.position(sampleHolder.data.position() - sampleHolder.getSize());
       outputBuffer.timestampUs = sampleHolder.timeUs;
-      outputBuffer.size = decoder.decode(sampleHolder.data, sampleHolder.size,
+      outputBuffer.size = decoder.decode(sampleHolder.data, sampleHolder.getSize(),
           outputBuffer.data, outputBuffer.data.capacity());
       outputBuffer.data.position(0);
       if (skipSamples > 0) {

--- a/extensions/vp9/src/main/java/com/google/android/exoplayer/ext/vp9/VpxDecoderWrapper.java
+++ b/extensions/vp9/src/main/java/com/google/android/exoplayer/ext/vp9/VpxDecoderWrapper.java
@@ -192,8 +192,8 @@ import java.util.LinkedList;
       SampleHolder sampleHolder = inputBuffer.sampleHolder;
       outputBuffer.timestampUs = sampleHolder.timeUs;
       outputBuffer.flags = 0;
-      sampleHolder.data.position(sampleHolder.data.position() - sampleHolder.size);
-      decodeResult = decoder.decode(sampleHolder.data, sampleHolder.size, outputBuffer, outputRgb);
+      sampleHolder.data.position(sampleHolder.data.position() - sampleHolder.getSize());
+      decodeResult = decoder.decode(sampleHolder.data, sampleHolder.getSize(), outputBuffer, outputRgb);
     }
 
     synchronized (lock) {

--- a/library/src/main/java/com/google/android/exoplayer/FrameworkSampleSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/FrameworkSampleSource.java
@@ -205,10 +205,10 @@ public final class FrameworkSampleSource implements SampleSource, SampleSourceRe
     if (extractorTrackIndex == track) {
       if (sampleHolder.data != null) {
         int offset = sampleHolder.data.position();
-        sampleHolder.size = extractor.readSampleData(sampleHolder.data, offset);
-        sampleHolder.data.position(offset + sampleHolder.size);
+        sampleHolder.setSize(extractor.readSampleData(sampleHolder.data, offset));
+        sampleHolder.data.position(offset + sampleHolder.getSize());
       } else {
-        sampleHolder.size = 0;
+        sampleHolder.setSize(0);
       }
       sampleHolder.timeUs = extractor.getSampleTime();
       sampleHolder.flags = extractor.getSampleFlags() & ALLOWED_FLAGS_MASK;

--- a/library/src/main/java/com/google/android/exoplayer/MediaCodecAudioTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaCodecAudioTrackRenderer.java
@@ -313,10 +313,13 @@ public class MediaCodecAudioTrackRenderer extends MediaCodecTrackRenderer implem
       ByteBuffer buffer, MediaCodec.BufferInfo bufferInfo, int bufferIndex, boolean shouldSkip)
       throws ExoPlaybackException {
     if (shouldSkip) {
-      codec.releaseOutputBuffer(bufferIndex, false);
-      codecCounters.skippedOutputBufferCount++;
-      audioTrack.handleDiscontinuity();
-      return true;
+      if (releaseOutputBuffer(codec, bufferIndex, false)) {
+        return false;
+      } else {
+        codecCounters.skippedOutputBufferCount++;
+        audioTrack.handleDiscontinuity();
+        return true;
+      }
     }
 
     // Initialize and start the audio track now.
@@ -355,9 +358,12 @@ public class MediaCodecAudioTrackRenderer extends MediaCodecTrackRenderer implem
 
     // Release the buffer if it was consumed.
     if ((handleBufferResult & AudioTrack.RESULT_BUFFER_CONSUMED) != 0) {
-      codec.releaseOutputBuffer(bufferIndex, false);
-      codecCounters.renderedOutputBufferCount++;
-      return true;
+      if (releaseOutputBuffer(codec, bufferIndex, false)) {
+        return false;
+      } else {
+        codecCounters.renderedOutputBufferCount++;
+        return true;
+      }
     }
 
     return false;

--- a/library/src/main/java/com/google/android/exoplayer/MediaCodecTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaCodecTrackRenderer.java
@@ -522,7 +522,7 @@ public abstract class MediaCodecTrackRenderer extends SampleSourceTrackRenderer 
    * @throws ExoPlaybackException If an error occurs feeding the input buffer.
    */
   private boolean feedInputBuffer(long positionUs, boolean firstFeed) throws ExoPlaybackException {
-    if (inputStreamEnded
+    if (codec == null || inputStreamEnded
         || codecReinitializationState == REINITIALIZATION_STATE_WAIT_END_OF_STREAM) {
       // The input stream has ended, or we need to re-initialize the codec but are still waiting
       // for the existing codec to output any final output buffers.

--- a/library/src/main/java/com/google/android/exoplayer/MediaCodecTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaCodecTrackRenderer.java
@@ -304,7 +304,7 @@ public abstract class MediaCodecTrackRenderer extends SampleSourceTrackRenderer 
       if (drmSessionState == DrmSessionManager.STATE_ERROR) {
         throw new ExoPlaybackException(drmSessionManager.getError());
       } else if (drmSessionState == DrmSessionManager.STATE_OPENED
-          || drmSessionState == DrmSessionManager.STATE_OPENED_WITH_KEYS) {
+              || drmSessionState == DrmSessionManager.STATE_OPENED_WITH_KEYS) {
         mediaCrypto = drmSessionManager.getMediaCrypto();
         requiresSecureDecoder = drmSessionManager.requiresSecureDecoderComponent(mimeType);
       } else {
@@ -318,44 +318,44 @@ public abstract class MediaCodecTrackRenderer extends SampleSourceTrackRenderer 
       decoderInfo = getDecoderInfo(mimeType, requiresSecureDecoder);
     } catch (DecoderQueryException e) {
       notifyAndThrowDecoderInitError(new DecoderInitializationException(format, e,
-          DecoderInitializationException.DECODER_QUERY_ERROR));
+              DecoderInitializationException.DECODER_QUERY_ERROR));
     }
 
     if (decoderInfo == null) {
       notifyAndThrowDecoderInitError(new DecoderInitializationException(format, null,
-          DecoderInitializationException.NO_SUITABLE_DECODER_ERROR));
+              DecoderInitializationException.NO_SUITABLE_DECODER_ERROR));
     }
 
-    String decoderName = decoderInfo.name;
-    codecIsAdaptive = decoderInfo.adaptive;
-    codecNeedsEosPropagationWorkaround = codecNeedsEosPropagationWorkaround(decoderName);
-    codecNeedsEosFlushWorkaround = codecNeedsEosFlushWorkaround(decoderName);
-    try {
-      long codecInitializingTimestamp = SystemClock.elapsedRealtime();
-      TraceUtil.beginSection("createByCodecName(" + decoderName + ")");
-      codec = MediaCodec.createByCodecName(decoderName);
-      TraceUtil.endSection();
-      TraceUtil.beginSection("configureCodec");
-      configureCodec(codec, decoderName, format.getFrameworkMediaFormatV16(), mediaCrypto);
-      TraceUtil.endSection();
-      TraceUtil.beginSection("codec.start()");
-      codec.start();
-      TraceUtil.endSection();
-      long codecInitializedTimestamp = SystemClock.elapsedRealtime();
-      notifyDecoderInitialized(decoderName, codecInitializedTimestamp,
-          codecInitializedTimestamp - codecInitializingTimestamp);
-      inputBuffers = codec.getInputBuffers();
-      outputBuffers = codec.getOutputBuffers();
-    } catch (Exception e) {
-      notifyAndThrowDecoderInitError(new DecoderInitializationException(format, e, decoderName));
+      String decoderName = decoderInfo.name;
+      codecIsAdaptive = decoderInfo.adaptive;
+      codecNeedsEosPropagationWorkaround = codecNeedsEosPropagationWorkaround(decoderName);
+      codecNeedsEosFlushWorkaround = codecNeedsEosFlushWorkaround(decoderName);
+      try {
+        long codecInitializingTimestamp = SystemClock.elapsedRealtime();
+        TraceUtil.beginSection("createByCodecName(" + decoderName + ")");
+        codec = MediaCodec.createByCodecName(decoderName);
+        TraceUtil.endSection();
+        TraceUtil.beginSection("configureCodec");
+        configureCodec(codec, decoderName, format.getFrameworkMediaFormatV16(), mediaCrypto);
+        TraceUtil.endSection();
+        TraceUtil.beginSection("codec.start()");
+        codec.start();
+        TraceUtil.endSection();
+        long codecInitializedTimestamp = SystemClock.elapsedRealtime();
+        notifyDecoderInitialized(decoderName, codecInitializedTimestamp,
+                codecInitializedTimestamp - codecInitializingTimestamp);
+        inputBuffers = codec.getInputBuffers();
+        outputBuffers = codec.getOutputBuffers();
+      } catch (Exception e) {
+        notifyAndThrowDecoderInitError(new DecoderInitializationException(format, e, decoderName));
+      }
+      codecHotswapTimeMs = getState() == TrackRenderer.STATE_STARTED ?
+              SystemClock.elapsedRealtime() : -1;
+      inputIndex = -1;
+      outputIndex = -1;
+      waitingForFirstSyncFrame = true;
+      codecCounters.codecInitCount++;
     }
-    codecHotswapTimeMs = getState() == TrackRenderer.STATE_STARTED ?
-        SystemClock.elapsedRealtime() : -1;
-    inputIndex = -1;
-    outputIndex = -1;
-    waitingForFirstSyncFrame = true;
-    codecCounters.codecInitCount++;
-  }
 
   private void notifyAndThrowDecoderInitError(DecoderInitializationException e)
       throws ExoPlaybackException {
@@ -637,7 +637,7 @@ public abstract class MediaCodecTrackRenderer extends SampleSourceTrackRenderer 
     }
     try {
       int bufferSize = sampleHolder.data.position();
-      int adaptiveReconfigurationBytes = bufferSize - sampleHolder.size;
+      int adaptiveReconfigurationBytes = bufferSize - sampleHolder.getSize();
       long presentationTimeUs = sampleHolder.timeUs;
       if (sampleHolder.isDecodeOnly()) {
         decodeOnlyPresentationTimestamps.add(presentationTimeUs);
@@ -804,7 +804,7 @@ public abstract class MediaCodecTrackRenderer extends SampleSourceTrackRenderer 
 
     if (outputIndex < 0) {
       try {
-      outputIndex = codec.dequeueOutputBuffer(outputBufferInfo, getDequeueOutputBufferTimeoutUs());
+        outputIndex = codec.dequeueOutputBuffer(outputBufferInfo, getDequeueOutputBufferTimeoutUs());
       } catch (IllegalStateException e) {
         // An illegal state is thrown after a playing exception has occurred. Root cause cannot be
         // known (except if we were to use setCallbacks / onError, but only for API >= 21)

--- a/library/src/main/java/com/google/android/exoplayer/MediaCodecVideoTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaCodecVideoTrackRenderer.java
@@ -508,14 +508,14 @@ public class MediaCodecVideoTrackRenderer extends MediaCodecTrackRenderer {
 
   protected void skipOutputBuffer(MediaCodec codec, int bufferIndex) {
     TraceUtil.beginSection("skipVideoBuffer");
-    codec.releaseOutputBuffer(bufferIndex, false);
+    releaseOutputBuffer(codec, bufferIndex, false);
     TraceUtil.endSection();
     codecCounters.skippedOutputBufferCount++;
   }
 
   protected void dropOutputBuffer(MediaCodec codec, int bufferIndex) {
     TraceUtil.beginSection("dropVideoBuffer");
-    codec.releaseOutputBuffer(bufferIndex, false);
+    releaseOutputBuffer(codec, bufferIndex, false);
     TraceUtil.endSection();
     codecCounters.droppedOutputBufferCount++;
     droppedFrameCount++;
@@ -527,7 +527,7 @@ public class MediaCodecVideoTrackRenderer extends MediaCodecTrackRenderer {
   protected void renderOutputBuffer(MediaCodec codec, int bufferIndex) {
     maybeNotifyVideoSizeChanged();
     TraceUtil.beginSection("releaseOutputBuffer");
-    codec.releaseOutputBuffer(bufferIndex, true);
+    releaseOutputBuffer(codec, bufferIndex, true);
     TraceUtil.endSection();
     codecCounters.renderedOutputBufferCount++;
     renderedFirstFrame = true;

--- a/library/src/main/java/com/google/android/exoplayer/SampleHolder.java
+++ b/library/src/main/java/com/google/android/exoplayer/SampleHolder.java
@@ -45,11 +45,6 @@ public final class SampleHolder {
   public ByteBuffer data;
 
   /**
-   * The size of the sample in bytes.
-   */
-  public int size;
-
-  /**
    * Flags that accompany the sample. A combination of {@link C#SAMPLE_FLAG_SYNC},
    * {@link C#SAMPLE_FLAG_ENCRYPTED} and {@link C#SAMPLE_FLAG_DECODE_ONLY}.
    */
@@ -61,9 +56,10 @@ public final class SampleHolder {
   public long timeUs;
 
   private final int bufferReplacementMode;
+  private int size;
 
   /**
-   * @param bufferReplacementMode Determines the behavior of {@link #replaceBuffer(int)}. One of
+   * @param bufferReplacementMode Determines the behavior of the buffer allocation. One of
    *     {@link #BUFFER_REPLACEMENT_MODE_DISABLED}, {@link #BUFFER_REPLACEMENT_MODE_NORMAL} and
    *     {@link #BUFFER_REPLACEMENT_MODE_DIRECT}.
    */
@@ -78,7 +74,7 @@ public final class SampleHolder {
    * @param capacity The capacity of the replacement buffer, in bytes.
    * @return True if the buffer was replaced. False otherwise.
    */
-  public boolean replaceBuffer(int capacity) {
+  private boolean allocateBuffer(int capacity) {
     switch (bufferReplacementMode) {
       case BUFFER_REPLACEMENT_MODE_NORMAL:
         data = ByteBuffer.allocate(capacity);
@@ -120,4 +116,19 @@ public final class SampleHolder {
     }
   }
 
+  /**
+   * The size of the sample in bytes.
+   */
+  public int getSize() {
+    return Math.min(size, data == null ? 0 : data.capacity());
+  }
+
+  public void setSize(int size) {
+    if (data == null) {
+      allocateBuffer(size);
+    } else if (data.capacity() < size) {
+      allocateBuffer(size);
+    }
+    this.size = size;
+  }
 }

--- a/library/src/main/java/com/google/android/exoplayer/SingleSampleSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/SingleSampleSource.java
@@ -137,11 +137,8 @@ public final class SingleSampleSource implements SampleSource, SampleSourceReade
       return NOTHING_READ;
     } else {
       sampleHolder.timeUs = 0;
-      sampleHolder.size = sampleSize;
+      sampleHolder.setSize(sampleSize);
       sampleHolder.flags = C.SAMPLE_FLAG_SYNC;
-      if (sampleHolder.data == null || sampleHolder.data.capacity() < sampleSize) {
-        sampleHolder.replaceBuffer(sampleHolder.size);
-      }
       sampleHolder.data.put(sampleData, 0, sampleSize);
       state = STATE_END_OF_STREAM;
       return SAMPLE_READ;

--- a/library/src/main/java/com/google/android/exoplayer/extractor/RollingSampleBuffer.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/RollingSampleBuffer.java
@@ -185,12 +185,8 @@ import java.util.concurrent.LinkedBlockingDeque;
     if (sampleHolder.isEncrypted()) {
       readEncryptionData(sampleHolder, extrasHolder);
     }
-    // Write the sample data into the holder.
-    if (sampleHolder.data == null || sampleHolder.data.capacity() < sampleHolder.size) {
-      sampleHolder.replaceBuffer(sampleHolder.size);
-    }
     if (sampleHolder.data != null) {
-      readData(extrasHolder.offset, sampleHolder.data, sampleHolder.size);
+      readData(extrasHolder.offset, sampleHolder.data, sampleHolder.getSize() - sampleHolder.data.position());
     }
     // Advance the read head.
     long nextOffset = infoQueue.moveToNextSample();
@@ -257,7 +253,7 @@ import java.util.concurrent.LinkedBlockingDeque;
       }
     } else {
       clearDataSizes[0] = 0;
-      encryptedDataSizes[0] = sampleHolder.size - (int) (offset - extrasHolder.offset);
+      encryptedDataSizes[0] = sampleHolder.getSize() - (int) (offset - extrasHolder.offset);
     }
 
     // Populate the cryptoInfo.
@@ -267,7 +263,7 @@ import java.util.concurrent.LinkedBlockingDeque;
     // Adjust the offset and size to take into account the bytes read.
     int bytesRead = (int) (offset - extrasHolder.offset);
     extrasHolder.offset += bytesRead;
-    sampleHolder.size -= bytesRead;
+    sampleHolder.setSize(sampleHolder.getSize() - bytesRead);
   }
 
   /**
@@ -544,7 +540,7 @@ import java.util.concurrent.LinkedBlockingDeque;
         return false;
       }
       holder.timeUs = timesUs[relativeReadIndex];
-      holder.size = sizes[relativeReadIndex];
+      holder.setSize(sizes[relativeReadIndex]);
       holder.flags = flags[relativeReadIndex];
       extrasHolder.offset = offsets[relativeReadIndex];
       extrasHolder.encryptionKeyId = encryptionKeys[relativeReadIndex];

--- a/library/src/main/java/com/google/android/exoplayer/metadata/MetadataTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/metadata/MetadataTrackRenderer.java
@@ -118,7 +118,7 @@ public final class MetadataTrackRenderer<T> extends SampleSourceTrackRenderer im
       if (result == SampleSource.SAMPLE_READ) {
         pendingMetadataTimestamp = sampleHolder.timeUs;
         try {
-          pendingMetadata = metadataParser.parse(sampleHolder.data.array(), sampleHolder.size);
+          pendingMetadata = metadataParser.parse(sampleHolder.data.array(), sampleHolder.getSize());
         } catch (IOException e) {
           throw new ExoPlaybackException(e);
         }

--- a/library/src/main/java/com/google/android/exoplayer/text/SubtitleParserHelper.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/SubtitleParserHelper.java
@@ -160,7 +160,7 @@ import java.io.InputStream;
     Subtitle parsedSubtitle = null;
     IOException error = null;
     try {
-      InputStream inputStream = new ByteArrayInputStream(holder.data.array(), 0, holder.size);
+      InputStream inputStream = new ByteArrayInputStream(holder.data.array(), 0, holder.getSize());
       parsedSubtitle = parser.parse(inputStream);
     } catch (IOException e) {
       error = e;

--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608Parser.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608Parser.java
@@ -117,7 +117,7 @@ public final class Eia608Parser {
   }
 
   /* package */ ClosedCaptionList parse(SampleHolder sampleHolder) {
-    if (sampleHolder.size < 10) {
+    if (sampleHolder.getSize() < 10) {
       return null;
     }
 

--- a/library/src/main/java/com/google/android/exoplayer/upstream/HttpDataSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/upstream/HttpDataSource.java
@@ -107,7 +107,7 @@ public interface HttpDataSource extends UriDataSource {
 
     public InvalidResponseCodeException(int responseCode, Map<String, List<String>> headerFields,
         DataSpec dataSpec) {
-      super("Response code: " + responseCode, dataSpec);
+      super("Response code: " + responseCode + " for " + dataSpec.uri, dataSpec);
       this.responseCode = responseCode;
       this.headerFields = headerFields;
     }


### PR DESCRIPTION
Hi,

This is our first pull request for the project. We use the ExoPlayer in production for our apps : ch.rts.player , ch.srf.mobile.srfplayer and others
The CLA should be signed ( Radio Télévision Suisse , rts-developers@googlegroups.com )

We encountered a few issues while using the player:
- some AAC decoding issues in our stream where causing the player to crash without reporting the exception devices < API 21. This is solved by the IllegalStateException commit ( e77a2a1 )
- A rare codec null race condition ( 3921919 )
- One big issue that happens very rarely ( about every 20 minutes of playing an HLS stream ) where the SampleHolder has a mismatch between declared size and data field actual size. The only safe option I could think of was to be "more OO" and encapsulate the size and data fields. SampleHolder is now fully responsible for reallocs ( 482b045 ) 

Let me know if you have any feedback on any of those. They seem to work fine for us in our HLS streams.

For your information, we are also working on HLS DVR, but we can discuss this later!