### PR TITLE
Add onDrmSessionReady callback

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/drm/StreamingDrmSessionManager.java
+++ b/library/src/main/java/com/google/android/exoplayer/drm/StreamingDrmSessionManager.java
@@ -51,6 +51,12 @@ public class StreamingDrmSessionManager implements DrmSessionManager {
   public interface EventListener {
 
     /**
+     * Invoked when DRM keys have been loaded. Depending on license setup, this might occur multiple
+     * times during playback.
+     */
+    void onKeysLoaded();
+
+    /**
      * Invoked when a drm error occurs.
      *
      * @param e The corresponding exception.
@@ -386,6 +392,14 @@ public class StreamingDrmSessionManager implements DrmSessionManager {
     try {
       mediaDrm.provideKeyResponse(sessionId, (byte[]) response);
       state = STATE_OPENED_WITH_KEYS;
+      if (eventHandler != null && eventListener != null) {
+        eventHandler.post(new Runnable() {
+          @Override
+          public void run() {
+            eventListener.onKeysLoaded();
+          }
+        });
+      }
     } catch (Exception e) {
       onKeysError(e);
     }


### PR DESCRIPTION
This adds a callback for when the DRM session is ready.
I.e. when keys required for decryption has been acquired.

-----

We have the need of getting notified when DRM session has been successfully loaded and ready to be used. Therefore, I suggest an addition to StreamingDrmSessionManager's EventListener. Do you think it makes sense?