### PR TITLE
HLS Support for Live Events

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
@@ -523,6 +523,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
     if (infoListener != null) {
       infoListener.onAvailableRangeChanged(availableRange);
     }
+    playerControl.setAvailableSeekRange(availableRange);
   }
 
   @Override

--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
@@ -31,6 +31,7 @@ import com.google.android.exoplayer.chunk.ChunkSampleSource;
 import com.google.android.exoplayer.chunk.Format;
 import com.google.android.exoplayer.dash.DashChunkSource;
 import com.google.android.exoplayer.drm.StreamingDrmSessionManager;
+import com.google.android.exoplayer.hls.HlsChunkSource;
 import com.google.android.exoplayer.hls.HlsSampleSource;
 import com.google.android.exoplayer.metadata.MetadataTrackRenderer.MetadataRenderer;
 import com.google.android.exoplayer.text.Cue;
@@ -57,7 +58,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * SmoothStreaming and so on).
  */
 public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventListener,
-    HlsSampleSource.EventListener, DefaultBandwidthMeter.EventListener,
+    HlsChunkSource.EventListener, HlsSampleSource.EventListener, DefaultBandwidthMeter.EventListener,
     MediaCodecVideoTrackRenderer.EventListener, MediaCodecAudioTrackRenderer.EventListener,
     StreamingDrmSessionManager.EventListener, DashChunkSource.EventListener, TextRenderer,
     MetadataRenderer<Map<String, Object>>, DebugTextViewHelper.Provider {

--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/HlsRendererBuilder.java
@@ -145,7 +145,9 @@ public class HlsRendererBuilder implements RendererBuilder {
 
       DataSource dataSource = new DefaultUriDataSource(context, bandwidthMeter, userAgent);
       HlsChunkSource chunkSource = new HlsChunkSource(dataSource, url, manifest, bandwidthMeter,
-          variantIndices, HlsChunkSource.ADAPTIVE_MODE_SPLICE);
+          variantIndices, HlsChunkSource.ADAPTIVE_MODE_SPLICE,
+          HlsChunkSource.DEFAULT_MIN_BUFFER_TO_SWITCH_UP_MS,
+          HlsChunkSource.DEFAULT_MAX_BUFFER_TO_SWITCH_DOWN_MS, mainHandler, player);
       HlsSampleSource sampleSource = new HlsSampleSource(chunkSource, loadControl,
           BUFFER_SEGMENTS * BUFFER_SEGMENT_SIZE, mainHandler, player, DemoPlayer.TYPE_VIDEO);
       MediaCodecVideoTrackRenderer videoRenderer = new MediaCodecVideoTrackRenderer(sampleSource,

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsMediaPlaylist.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsMediaPlaylist.java
@@ -68,14 +68,16 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
   public final List<Segment> segments;
   public final boolean live;
   public final long durationUs;
+  public final boolean liveEvent;
 
   public HlsMediaPlaylist(String baseUri, int mediaSequence, int targetDurationSecs, int version,
-      boolean live, List<Segment> segments) {
+      boolean live, boolean liveEvent, List<Segment> segments) {
     super(baseUri, HlsPlaylist.TYPE_MEDIA);
     this.mediaSequence = mediaSequence;
     this.targetDurationSecs = targetDurationSecs;
     this.version = version;
     this.live = live;
+    this.liveEvent = liveEvent;
     this.segments = segments;
 
     if (!segments.isEmpty()) {

--- a/library/src/main/java/com/google/android/exoplayer/util/PlayerControl.java
+++ b/library/src/main/java/com/google/android/exoplayer/util/PlayerControl.java
@@ -16,6 +16,7 @@
 package com.google.android.exoplayer.util;
 
 import com.google.android.exoplayer.ExoPlayer;
+import com.google.android.exoplayer.TimeRange;
 
 import android.widget.MediaController.MediaPlayerControl;
 
@@ -28,9 +29,11 @@ import android.widget.MediaController.MediaPlayerControl;
 public class PlayerControl implements MediaPlayerControl {
 
   private final ExoPlayer exoPlayer;
+  private final long[] seekRange;
 
   public PlayerControl(ExoPlayer exoPlayer) {
     this.exoPlayer = exoPlayer;
+    this.seekRange = new long[2];
   }
 
   @Override
@@ -70,14 +73,16 @@ public class PlayerControl implements MediaPlayerControl {
 
   @Override
   public int getCurrentPosition() {
-    return exoPlayer.getDuration() == ExoPlayer.UNKNOWN_TIME ? 0
+    return exoPlayer.getDuration() == ExoPlayer.UNKNOWN_TIME && seekRange[1] == 0 ? 0
         : (int) exoPlayer.getCurrentPosition();
   }
 
   @Override
   public int getDuration() {
-    return exoPlayer.getDuration() == ExoPlayer.UNKNOWN_TIME ? 0
-        : (int) exoPlayer.getDuration();
+    if(exoPlayer.getDuration() != ExoPlayer.UNKNOWN_TIME){
+      return (int) exoPlayer.getDuration();
+    }
+    return (int) seekRange[1];
   }
 
   @Override
@@ -97,9 +102,17 @@ public class PlayerControl implements MediaPlayerControl {
 
   @Override
   public void seekTo(int timeMillis) {
-    long seekPosition = exoPlayer.getDuration() == ExoPlayer.UNKNOWN_TIME ? 0
+    long seekPosition = exoPlayer.getDuration() == ExoPlayer.UNKNOWN_TIME && seekRange[1] == 0 ? 0
         : Math.min(Math.max(0, timeMillis), getDuration());
     exoPlayer.seekTo(seekPosition);
   }
 
+  public void setAvailableSeekRange(TimeRange seekRange) {
+    if(seekRange == null){
+      this.seekRange[0] = 0;
+      this.seekRange[1] = 0;
+    }else{
+      seekRange.getCurrentBoundsMs(this.seekRange);
+    }
+  }
 }


### PR DESCRIPTION
This pull requests adds support for HLS Live Event Streams where `EXT-X-PLAYLIST-TYPE` is set to `EVENT` and the player should allow seeking within the currently available range.

The seek range change is exposed through the EventListener and a delegation constructor was added so the only API change is the change of the EventListener interface.

(FYI Company Contributor Agreement should be on the way)