### PR TITLE
Bump bintray release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.2.3'
-        classpath 'com.novoda:bintray-release:0.3.2'
+        classpath 'com.novoda:bintray-release:0.3.4'
     }
 }
 


### PR DESCRIPTION
We are using ExoPlayer as a git submodule in our Android Studio project and we were experiencing failing gradle builds with the following message:

```
Creating configuration testReleaseWearApp.

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> A problem occurred configuring project ':sdk'.
   > A problem occurred configuring project ':ExoPlayer:library'.
      > Cannot access first() element from an empty List
```

After upgrading bintray-release these issues were gone.

See: https://github.com/novoda/bintray-release/commits/0.3.4
For the changes in bintray-release.