### PR TITLE
Add support for TrueHD audio codec in WebMExtractor

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/extractor/webm/WebmExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/webm/WebmExtractor.java
@@ -77,6 +77,7 @@ public final class WebmExtractor implements Extractor {
   private static final String CODEC_ID_DTS = "A_DTS";
   private static final String CODEC_ID_DTS_EXPRESS = "A_DTS/EXPRESS";
   private static final String CODEC_ID_DTS_LOSSLESS = "A_DTS/LOSSLESS";
+  private static final String CODEC_ID_TRUEHD = "A_TRUEHD";
   private static final String CODEC_ID_SUBRIP = "S_TEXT/UTF8";
 
   private static final int VORBIS_MAX_INPUT_SIZE = 8192;
@@ -1041,6 +1042,7 @@ public final class WebmExtractor implements Extractor {
         || CODEC_ID_DTS.equals(codecId)
         || CODEC_ID_DTS_EXPRESS.equals(codecId)
         || CODEC_ID_DTS_LOSSLESS.equals(codecId)
+        || CODEC_ID_TRUEHD.equals(codecId)
         || CODEC_ID_SUBRIP.equals(codecId);
   }
 
@@ -1200,6 +1202,9 @@ public final class WebmExtractor implements Extractor {
           break;
         case CODEC_ID_DTS_LOSSLESS:
           mimeType = MimeTypes.AUDIO_DTS_HD;
+          break;
+        case CODEC_ID_TRUEHD:
+          mimeType = MimeTypes.AUDIO_TRUEHD;
           break;
         case CODEC_ID_SUBRIP:
           mimeType = MimeTypes.APPLICATION_SUBRIP;

--- a/library/src/main/java/com/google/android/exoplayer/util/MimeTypes.java
+++ b/library/src/main/java/com/google/android/exoplayer/util/MimeTypes.java
@@ -49,6 +49,7 @@ public final class MimeTypes {
   public static final String AUDIO_DTS_HD = BASE_TYPE_AUDIO + "/vnd.dts.hd";
   public static final String AUDIO_VORBIS = BASE_TYPE_AUDIO + "/vorbis";
   public static final String AUDIO_OPUS = BASE_TYPE_AUDIO + "/opus";
+  public static final String AUDIO_TRUEHD = BASE_TYPE_AUDIO + "/true-hd";
 
   public static final String TEXT_VTT = BASE_TYPE_TEXT + "/vtt";
 


### PR DESCRIPTION
The Nvidia Shield recently added support for TrueHD passthrough. In order to fully implement that support, it requires using non-official AudioFormat encodings which is why I wouldn't suggest using it here. However, the implementation for extracting TrueHD audio from an MKV is still valid and may be useful for any device which can natively decode it. Hence why I thought i'd submit this PR.