### PR TITLE
Add support for MPEG2 video codec in WebMExtractor

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/extractor/webm/WebmExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/webm/WebmExtractor.java
@@ -64,6 +64,7 @@ public final class WebmExtractor implements Extractor {
   private static final String DOC_TYPE_MATROSKA = "matroska";
   private static final String CODEC_ID_VP8 = "V_VP8";
   private static final String CODEC_ID_VP9 = "V_VP9";
+  private static final String CODEC_ID_MPEG2 = "V_MPEG2";
   private static final String CODEC_ID_MPEG4_SP = "V_MPEG4/ISO/SP";
   private static final String CODEC_ID_MPEG4_ASP = "V_MPEG4/ISO/ASP";
   private static final String CODEC_ID_MPEG4_AP = "V_MPEG4/ISO/AP";
@@ -1028,6 +1029,7 @@ public final class WebmExtractor implements Extractor {
   private static boolean isCodecSupported(String codecId) {
     return CODEC_ID_VP8.equals(codecId)
         || CODEC_ID_VP9.equals(codecId)
+        || CODEC_ID_MPEG2.equals(codecId)
         || CODEC_ID_MPEG4_SP.equals(codecId)
         || CODEC_ID_MPEG4_ASP.equals(codecId)
         || CODEC_ID_MPEG4_AP.equals(codecId)
@@ -1146,6 +1148,9 @@ public final class WebmExtractor implements Extractor {
           break;
         case CODEC_ID_VP9:
           mimeType = MimeTypes.VIDEO_VP9;
+          break;
+        case CODEC_ID_MPEG2:
+          mimeType = MimeTypes.VIDEO_MPEG2;
           break;
         case CODEC_ID_MPEG4_SP:
         case CODEC_ID_MPEG4_ASP:

--- a/library/src/main/java/com/google/android/exoplayer/util/MimeTypes.java
+++ b/library/src/main/java/com/google/android/exoplayer/util/MimeTypes.java
@@ -34,6 +34,7 @@ public final class MimeTypes {
   public static final String VIDEO_VP8 = BASE_TYPE_VIDEO + "/x-vnd.on2.vp8";
   public static final String VIDEO_VP9 = BASE_TYPE_VIDEO + "/x-vnd.on2.vp9";
   public static final String VIDEO_MP4V = BASE_TYPE_VIDEO + "/mp4v-es";
+  public static final String VIDEO_MPEG2 = BASE_TYPE_VIDEO + "/mpeg2";
 
   public static final String AUDIO_UNKNOWN = BASE_TYPE_AUDIO + "/x-unknown";
   public static final String AUDIO_MP4 = BASE_TYPE_AUDIO + "/mp4";


### PR DESCRIPTION
This change adds support for mpeg2 decoding on devices like the Nvidia Shield.