### PR TITLE
Parse HLS NAME label from the MasterPlaylist

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -184,7 +184,7 @@ public class HlsChunkSource {
     playlistParser = new HlsPlaylistParser();
 
     if (playlist.type == HlsPlaylist.TYPE_MEDIA) {
-      variants = new Variant[] {new Variant(0, playlistUrl, 0, null, -1, -1)};
+      variants = new Variant[] {new Variant(0, null, playlistUrl, 0, null, -1, -1)};
       variantPlaylists = new HlsMediaPlaylist[1];
       variantLastPlaylistLoadTimesMs = new long[1];
       variantBlacklistTimes = new long[1];

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -153,13 +153,12 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
         String type = HlsParserUtil.parseStringAttr(line, TYPE_ATTR_REGEX, TYPE_ATTR);
         if (SUBTITLES_TYPE.equals(type)) {
           // We assume all subtitles belong to the same group.
-          name = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
+          String subtitleName = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
           String uri = HlsParserUtil.parseStringAttr(line, URI_ATTR_REGEX, URI_ATTR);
           String language = HlsParserUtil.parseOptionalStringAttr(line, LANGUAGE_ATTR_REGEX);
           boolean isDefault = HlsParserUtil.parseOptionalBooleanAttr(line, DEFAULT_ATTR_REGEX);
           boolean autoSelect = HlsParserUtil.parseOptionalBooleanAttr(line, AUTOSELECT_ATTR_REGEX);
-          subtitles.add(new Subtitle(name, uri, language, isDefault, autoSelect));
-          name = null;
+          subtitles.add(new Subtitle(subtitleName, uri, language, isDefault, autoSelect));
         } else {
           // TODO: Support other types of media tag.
         }

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -143,6 +143,7 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
     String codecs = null;
     int width = -1;
     int height = -1;
+    String name = null;
 
     boolean expectingStreamInfUrl = false;
     String line;
@@ -152,18 +153,20 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
         String type = HlsParserUtil.parseStringAttr(line, TYPE_ATTR_REGEX, TYPE_ATTR);
         if (SUBTITLES_TYPE.equals(type)) {
           // We assume all subtitles belong to the same group.
-          String name = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
+          name = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
           String uri = HlsParserUtil.parseStringAttr(line, URI_ATTR_REGEX, URI_ATTR);
           String language = HlsParserUtil.parseOptionalStringAttr(line, LANGUAGE_ATTR_REGEX);
           boolean isDefault = HlsParserUtil.parseOptionalBooleanAttr(line, DEFAULT_ATTR_REGEX);
           boolean autoSelect = HlsParserUtil.parseOptionalBooleanAttr(line, AUTOSELECT_ATTR_REGEX);
           subtitles.add(new Subtitle(name, uri, language, isDefault, autoSelect));
+          name = null;
         } else {
           // TODO: Support other types of media tag.
         }
       } else if (line.startsWith(STREAM_INF_TAG)) {
         bitrate = HlsParserUtil.parseIntAttr(line, BANDWIDTH_ATTR_REGEX, BANDWIDTH_ATTR);
         codecs = HlsParserUtil.parseOptionalStringAttr(line, CODECS_ATTR_REGEX);
+        name = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
         String resolutionString = HlsParserUtil.parseOptionalStringAttr(line,
             RESOLUTION_ATTR_REGEX);
         if (resolutionString != null) {
@@ -184,9 +187,10 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
         }
         expectingStreamInfUrl = true;
       } else if (!line.startsWith("#") && expectingStreamInfUrl) {
-        variants.add(new Variant(variants.size(), line, bitrate, codecs, width, height));
+        variants.add(new Variant(variants.size(), name, line, bitrate, codecs, width, height));
         bitrate = 0;
         codecs = null;
+        name = null;
         width = -1;
         height = -1;
         expectingStreamInfUrl = false;

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -166,7 +166,7 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
       } else if (line.startsWith(STREAM_INF_TAG)) {
         bitrate = HlsParserUtil.parseIntAttr(line, BANDWIDTH_ATTR_REGEX, BANDWIDTH_ATTR);
         codecs = HlsParserUtil.parseOptionalStringAttr(line, CODECS_ATTR_REGEX);
-        name = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
+        name = HlsParserUtil.parseOptionalStringAttr(line, NAME_ATTR_REGEX);
         String resolutionString = HlsParserUtil.parseOptionalStringAttr(line,
             RESOLUTION_ATTR_REGEX);
         if (resolutionString != null) {

--- a/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
@@ -26,9 +26,11 @@ public final class Variant implements FormatWrapper {
 
   public final String url;
   public final Format format;
+  public final String name;
 
-  public Variant(int index, String url, int bitrate, String codecs, int width, int height) {
+  public Variant(int index, String name, String url, int bitrate, String codecs, int width, int height) {
     this.url = url;
+    this.name = name;
     format = new Format(Integer.toString(index), MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
         -1, bitrate, null, codecs);
   }

--- a/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
@@ -26,21 +26,22 @@ public final class Variant implements FormatWrapper {
 
   public final String url;
   public final Format format;
+  public final String name;
 
   public Variant(int index, String name, String url, int bitrate, String codecs, int width, int height) {
     this.url = url;
-    if (name != null) {
-      format = new Format(name, MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
-              -1, bitrate, null, codecs);
-    } else {
-      format = new Format(Integer.toString(index), MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
-              -1, bitrate, null, codecs);
-    }
+    this.name = name;
+    format = new Format(Integer.toString(index), MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
+            -1, bitrate, null, codecs);
   }
 
   @Override
   public Format getFormat() {
     return format;
+  }
+
+  public String getName() {
+    return name;
   }
 
 }

--- a/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
@@ -40,8 +40,4 @@ public final class Variant implements FormatWrapper {
     return format;
   }
 
-  public String getName() {
-    return name;
-  }
-
 }

--- a/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
@@ -31,8 +31,9 @@ public final class Variant implements FormatWrapper {
   public Variant(int index, String name, String url, int bitrate, String codecs, int width, int height) {
     this.url = url;
     this.name = name;
-    format = new Format(Integer.toString(index), MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
-            -1, bitrate, null, codecs);
+    String formatName = name != null ? name : Integer.toString(index);
+    format = new Format(formatName, MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
+        -1, bitrate, null, codecs);
   }
 
   @Override

--- a/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/Variant.java
@@ -26,13 +26,16 @@ public final class Variant implements FormatWrapper {
 
   public final String url;
   public final Format format;
-  public final String name;
 
   public Variant(int index, String name, String url, int bitrate, String codecs, int width, int height) {
     this.url = url;
-    this.name = name;
-    format = new Format(Integer.toString(index), MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
-        -1, bitrate, null, codecs);
+    if (name != null) {
+      format = new Format(name, MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
+              -1, bitrate, null, codecs);
+    } else {
+      format = new Format(Integer.toString(index), MimeTypes.APPLICATION_M3U8, width, height, -1, -1,
+              -1, bitrate, null, codecs);
+    }
   }
 
   @Override


### PR DESCRIPTION
For the same usecase as mentioned in: https://github.com/google/ExoPlayer/pull/884 we needed to parse the `NAME` label from the HlsMasterPlaylist and have it available in the `variants` array.

CLA should be signed: https://groups.google.com/forum/#!forum/jwplayer-google-contributors

Feel free to ask questions, feedback is appreciated.
Thanks.