### PR TITLE
[RollingSampleBuffer] prevent internal runtime error (NoSuchElementException)

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/extractor/RollingSampleBuffer.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/RollingSampleBuffer.java
@@ -317,7 +317,7 @@ import java.util.concurrent.LinkedBlockingDeque;
   private void dropDownstreamTo(long absolutePosition) {
     int relativePosition = (int) (absolutePosition - totalBytesDropped);
     int allocationIndex = relativePosition / allocationLength;
-    for (int i = 0; i < allocationIndex; i++) {
+    for (int i = 0; i < allocationIndex && !dataQueue.isEmpty(); i++) {
       allocator.release(dataQueue.remove());
       totalBytesDropped += allocationLength;
     }


### PR DESCRIPTION
Hi,

I'm developing a TVInputService for Android TV using a custom Extractor class.
Unfortunately I'm sometimes facing a "NoSuchElementException" in 
"RollingSampleBuffer.dropDownstreamTo(RollingSampleBuffer.java:321".

This patch helped to fix the problem for me.

Regards,
Alex
