### PR TITLE
Added missing MimeTypes to Smooth Streaming manifest parser

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/smoothstreaming/SmoothStreamingManifestParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/smoothstreaming/SmoothStreamingManifestParser.java
@@ -676,6 +676,16 @@ public class SmoothStreamingManifestParser implements UriLoadable.Parser<SmoothS
         return MimeTypes.AUDIO_AAC;
       } else if (fourCC.equalsIgnoreCase("TTML")) {
         return MimeTypes.APPLICATION_TTML;
+      } else if (fourCC.equalsIgnoreCase("ac-3") || fourCC.equalsIgnoreCase("dac3")) {
+        return MimeTypes.AUDIO_AC3;
+      } else if (fourCC.equalsIgnoreCase("ec-3") || fourCC.equalsIgnoreCase("dec3")) {
+        return MimeTypes.AUDIO_EC3;
+      } else if (fourCC.equalsIgnoreCase("dtsc") || fourCC.equalsIgnoreCase("dtse")) {
+        return MimeTypes.AUDIO_DTS;
+      } else if (fourCC.equalsIgnoreCase("dtsh") || fourCC.equalsIgnoreCase("dtsl")) {
+        return MimeTypes.AUDIO_DTS_HD;
+      } else if (fourCC.equalsIgnoreCase("opus")) {
+        return MimeTypes.AUDIO_OPUS;
       }
       return null;
     }


### PR DESCRIPTION
This is necessary to avoid parsing errors when playing Smooth Streaming content with DTS or Dolby audio tracks.