### PR TITLE
[WIP] Add SequenceSampleSource for playing multiple sources back-to-back

### DIFF
--- a/library/src/androidTest/java/com/google/android/exoplayer/playlist/SequenceSampleSourceTest.java
+++ b/library/src/androidTest/java/com/google/android/exoplayer/playlist/SequenceSampleSourceTest.java
@@ -1,0 +1,114 @@
+package com.google.android.exoplayer.playlist;
+
+import com.google.android.exoplayer.MediaFormat;
+import com.google.android.exoplayer.MediaFormatHolder;
+import com.google.android.exoplayer.SampleHolder;
+import com.google.android.exoplayer.SampleSource;
+import com.google.android.exoplayer.util.MimeTypes;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Test for {@link SequenceSampleSource}
+ */
+public class SequenceSampleSourceTest extends TestCase {
+
+    public void testSequencePlaylist() {
+        final long[] duration = {0};
+
+        SequenceSampleSource.SequenceInfoListener listener = new SequenceSampleSource.SequenceInfoListener() {
+            @Override
+            public void onTimesKnown(long[] durationsUs, long[] startTimesUs) {
+                duration[0] = durationsUs[0];
+            }
+        };
+
+        SequenceSampleSource sequenceSampleSource = new SequenceSampleSource(buildPlaylist(), listener);
+        SampleSource.SampleSourceReader sourceReader = sequenceSampleSource.register();
+        sourceReader.prepare(0);
+
+        assertEquals("Check that duration is extracted from sub sources", (long) 10e6, duration[0]);
+    }
+
+
+    private Collection<SampleSource> buildPlaylist() {
+        ArrayList<SampleSource> list = new ArrayList<>();
+
+        list.add(new DummySource());
+        list.add(new DummySource());
+
+        return list;
+    }
+
+    class DummySource implements SampleSource {
+
+        @Override
+        public SampleSourceReader register() {
+            return new DummyReader();
+        }
+    }
+
+    class DummyReader implements SampleSource.SampleSourceReader {
+        @Override
+        public void maybeThrowError() throws IOException {
+
+        }
+
+        @Override
+        public boolean prepare(long positionUs) {
+            return true;
+        }
+
+        @Override
+        public int getTrackCount() {
+            return 2;
+        }
+
+        @Override
+        public MediaFormat getFormat(int track) {
+            if(track == 0)
+                return MediaFormat.createFormatForMimeType(track, MimeTypes.VIDEO_MP4, MediaFormat.NO_VALUE, (long) 10e6);
+            return MediaFormat.createFormatForMimeType(track, MimeTypes.AUDIO_AAC, MediaFormat.NO_VALUE, (long) 10e6);
+        }
+
+        @Override
+        public void enable(int track, long positionUs) {
+
+        }
+
+        @Override
+        public boolean continueBuffering(int track, long positionUs) {
+            return true;
+        }
+
+        @Override
+        public int readData(int track, long positionUs, MediaFormatHolder formatHolder, SampleHolder sampleHolder, boolean onlyReadDiscontinuity) {
+            return 0;
+        }
+
+        @Override
+        public void seekToUs(long positionUs) {
+
+        }
+
+        @Override
+        public long getBufferedPositionUs() {
+            return 0;
+        }
+
+        @Override
+        public void disable(int track) {
+
+        }
+
+        @Override
+        public void release() {
+
+        }
+    }
+
+}

--- a/library/src/main/java/com/google/android/exoplayer/playlist/SequenceSampleSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/playlist/SequenceSampleSource.java
@@ -1,0 +1,296 @@
+package com.google.android.exoplayer.playlist;
+
+import android.util.SparseArray;
+
+import com.google.android.exoplayer.MediaFormat;
+import com.google.android.exoplayer.MediaFormatHolder;
+import com.google.android.exoplayer.SampleHolder;
+import com.google.android.exoplayer.SampleSource;
+import com.google.android.exoplayer.TrackRenderer;
+import com.google.android.exoplayer.extractor.DefaultTrackOutput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+
+/**
+ * A source of media samples.
+ * <p>
+ * Wraps other {@link SampleSource}s to achieve smooth edge-to-edge multi-source playback.
+ * Very useful to create a playlist, which not natively supported by Android.
+ */
+public class SequenceSampleSource implements SampleSource {
+
+    private ArrayList<SampleSource> sources;
+    private SequenceInfoListener listener;
+
+    public SequenceSampleSource(Collection<SampleSource> playlist, SequenceInfoListener listener) {
+        this.listener = listener;
+        sources = new ArrayList<>(playlist);
+    }
+
+    @Override
+    public SampleSourceReader register() {
+        Collection<SampleSourceReader> readers = new ArrayList<>();
+        for (SampleSource source : sources) {
+            readers.add(source.register());
+        }
+        return new SequenceSampleSourceReader(readers, listener);
+    }
+
+    /**
+     * Searches a sorted list for a given value.
+     *
+     * @param list  sorted list
+     * @param value minimum value
+     * @return the smallest index that corresponds to a item at least the value.
+     */
+    public static int indexOfItemAtLeast(long[] list, long value) {
+        int index = Arrays.binarySearch(list, value);
+        if (index >= 0) {
+            return index;
+        }
+
+        // Negative index denotes where the value would be inserted negated and - 1
+        // See documentation of {@link Arrays.binarySearch}
+        int wouldInsertAt = -index - 1;
+        if (wouldInsertAt == 0)
+            return 0;
+        // We need to now the item before the insertion index
+        return wouldInsertAt - 1;
+    }
+
+    public interface SequenceInfoListener {
+        void onTimesKnown(long[] durationsUs, long[] startTimesUs);
+    }
+
+    public class SequenceSampleSourceReader implements SampleSourceReader {
+
+        boolean isPrepared;
+        boolean hasRegisteredSources;
+        private LinkedList<SampleSourceReader> readers;
+        private final SparseArray<DefaultTrackOutput> sampleQueues;
+
+        boolean hasLookup;
+        private long[] durationsUs = null;
+        private long[] startTimesUs = null;
+        private SequenceInfoListener listener;
+
+        private long lastSeekPositionUs;
+        private boolean[] pendingDiscontinuities;
+
+        public SequenceSampleSourceReader(Collection<SampleSourceReader> readers, SequenceInfoListener listener) {
+            this.listener = listener;
+            this.readers = new LinkedList<>(readers);
+            sampleQueues = new SparseArray<>();
+        }
+
+        /**
+         * Prepares time indexes to quickly access the SampleSourceReader for a given time.
+         */
+        private void createLookup() {
+            durationsUs = new long[readers.size()];
+            startTimesUs = new long[readers.size()];
+
+            int i = 0;
+            for (SampleSourceReader reader : readers) {
+                durationsUs[i] = reader.getFormat(0).durationUs;
+                startTimesUs[i] = i == 0 ? 0 : startTimesUs[i - 1] + durationsUs[i - 1];
+                i++;
+            }
+            if (listener != null) {
+                listener.onTimesKnown(durationsUs, startTimesUs);
+            }
+            hasLookup = true;
+        }
+
+        private int nestedIndex(long globalPositionUs) {
+            if (!isPrepared)
+                throw new AssertionError("All sub readers need to be prepared to this");
+
+            return indexOfItemAtLeast(startTimesUs, globalPositionUs);
+        }
+
+        private SampleSourceReader nestedReader(long globalPositionUs) {
+            return readers.get(nestedIndex(globalPositionUs));
+        }
+
+        private long nestedPositionUs(long globalPositionUs) {
+            return globalPositionUs - startTimesUs[nestedIndex(globalPositionUs)];
+        }
+
+        private long getTotalDuration() {
+            if (!isPrepared)
+                throw new AssertionError("All sub readers need to be prepared to this");
+
+            long total = 0;
+            for (long d : durationsUs) {
+                total += d;
+            }
+            return total;
+        }
+
+        @Override
+        public boolean prepare(long positionUs) {
+            if (isPrepared) {
+                return true;
+            }
+
+            if (!hasRegisteredSources) {
+                for (SampleSource s : sources) {
+                    s.register();
+                }
+                hasRegisteredSources = true;
+            }
+
+            // Check if all sub sources are prepared too
+            boolean prepped = true;
+            for (int i = 0; prepped && i < sources.size(); i++) {
+                prepped = readers.get(i).prepare(0);
+            }
+
+            if (prepped) {
+                // Setup things depending on track count
+                int trackCount = readers.get(0).getTrackCount();
+                pendingDiscontinuities = new boolean[readers.get(0).getTrackCount()];
+                createLookup();
+            }
+
+            isPrepared = prepped;
+
+            return isPrepared;
+        }
+
+        @Override
+        public int getTrackCount() {
+            return nestedReader(0).getTrackCount();
+        }
+
+        @Override
+        public MediaFormat getFormat(int track) {
+            MediaFormat format = nestedReader(0).getFormat(track);
+            format.copyWithDurationUs(getTotalDuration());
+            return format;
+        }
+
+        @Override
+        public void enable(int track, long positionUs) {
+            for (SampleSourceReader s : readers) {
+                s.enable(track, 0);
+            }
+            lastSeekPositionUs = positionUs;
+        }
+
+        @Override
+        public boolean continueBuffering(int track, long positionUs) {
+            return nestedReader(positionUs).continueBuffering(track, nestedPositionUs(positionUs));
+        }
+
+
+        @Override
+        public int readData(int track, long positionUs, MediaFormatHolder formatHolder, SampleHolder sampleHolder, boolean onlyReadDiscontinuity) {
+
+            // After seeking we need to emit a discontinuity
+            if (pendingDiscontinuities[track]) {
+                pendingDiscontinuities[track] = false;
+                sampleHolder.timeUs = lastSeekPositionUs;
+                return DISCONTINUITY_READ;
+            }
+
+            // When this flag is true we may only emit {@link SampleSource#NOTHING_READ}
+            if (onlyReadDiscontinuity) {
+                return NOTHING_READ;
+            }
+
+            // Perform normal read operation
+            int readerIndex = nestedIndex(positionUs);
+            int result = nestedReader(positionUs).readData(track, nestedPositionUs(positionUs), formatHolder, sampleHolder, false);
+
+            // Prevent end of stream notices by reading ahead
+            if (result == END_OF_STREAM && readers.get(readerIndex) != readers.getLast()) {
+                readerIndex++;
+                result = readers.get(readerIndex).readData(track, 0, formatHolder, sampleHolder, false);
+            }
+
+            // Fix timeUs to be global instead of local to the nested source
+            if (result == SAMPLE_READ)
+                sampleHolder.timeUs += startTimesUs[readerIndex];
+
+            return result;
+        }
+
+        /**
+         * Ensure that the transition is smooth and uses keyframes
+         * Checks for keyframe property via {@link SampleHolder#isSyncFrame()}
+         *
+         * @param sampleSourceReader splice to this reader
+         */
+        private void configureSpliceTo(SampleSourceReader sampleSourceReader) {
+            // TODO discard all samples from sampleSource which are not keyframes
+        }
+
+        @Override
+        public void seekToUs(long positionUs) {
+            nestedReader(positionUs).seekToUs(nestedPositionUs(positionUs));
+            lastSeekPositionUs = positionUs;
+            Arrays.fill(pendingDiscontinuities, true);
+        }
+
+        /**
+         * Find maximum buffered positionUs. Traverse all sub sources to do so.
+         *
+         * @return An estimate of the absolute position in microseconds up to which the data is buffered,
+         * or {@link TrackRenderer#END_OF_TRACK_US} if all sub sources are fully buffered,
+         * or {@link TrackRenderer#UNKNOWN_TIME_US} if no estimate is available.
+         */
+        @Override
+        public long getBufferedPositionUs() {
+            long last = TrackRenderer.UNKNOWN_TIME_US;
+            int i = 0;
+            for (SampleSourceReader s : readers) {
+                long buffered = s.getBufferedPositionUs();
+
+                // Fully buffered, look further
+                if (buffered == TrackRenderer.END_OF_TRACK_US)
+                    last = TrackRenderer.END_OF_TRACK_US;
+
+                    // Unknown, escalate
+                else if (buffered == TrackRenderer.UNKNOWN_TIME_US)
+                    return TrackRenderer.UNKNOWN_TIME_US;
+
+                    // Found first sub source that is not yet fully buffered
+                else {
+                    return startTimesUs[i] + buffered;
+                }
+                i++;
+            }
+            return last;
+        }
+
+        @Override
+        public void disable(int track) {
+            for (SampleSourceReader s : readers) {
+                s.disable(track);
+            }
+        }
+
+        @Override
+        public void release() {
+            if (hasRegisteredSources) {
+                for (SampleSourceReader s : readers) {
+                    s.release();
+                }
+                hasRegisteredSources = false;
+            }
+        }
+
+        @Override
+        public void maybeThrowError() throws IOException {
+            for (SampleSourceReader s : readers) {
+                s.maybeThrowError();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Seamless playback is the goal of this pull request, without even the slightest gap.

Multiple people are trying to achieve a playlist like functionality, with either ExoPlayer or MediaPlayer, see for example:
- http://stackoverflow.com/questions/28277091/exoplayer-play-10-files-one-after-another
- http://stackoverflow.com/questions/33362339/does-exoplayer-support-mp4-playlist
- http://stackoverflow.com/questions/3877119/android-mediaplayer-gapless-or-seamless-video-playing
- http://stackoverflow.com/questions/2030487/play-playlist-with-mediaplayer (MediaPlayer)
- http://stackoverflow.com/questions/22743693/android-media-player-playlist-and-reset (MediaPlayer)
- http://stackoverflow.com/questions/30681002/play-list-of-mp3-file-with-mediaplayer-in-android (MediaPlayer)

Some of these questions are about simple audio playlists, some for video playlists. What I'm trying to do is create an application like (a very lightweight variant of) Apple's iMovie. So basically play 2 or more video files (stored locally) with 0-frames gap. On iOS the AVFoundation framework provides these features and it works easily and performs well.

On Android, implementations that rely on substituting the ExoPlayer or it's data sources do not perform well in our tests (either release/prepare-cycles, or having a spare player stand ready). Even on modern devices (tested old & new devices) there exists a noticeable freeze.

The SequenceSampleSource is an effort to solve this issue. It wraps multiple SampleSources so that buffering is continued cross video and the video timeline is seekable as a whole. The inner clip durations would be available for keeping track of which video is played currently, or another listener could be implemented, both options are fine by me.

I am completely open for feedback and would love to solve this 'problem' for the Android platform. The ultimate goal would be to have something like this in the MediaPlayer interface, something as simple as this:

```
mediaPlayer.setDataSources(new String[] { "http://video.url" });
mediaPlayer.prepare();
mediaPlayer.start();
```

For now I'm using the following setup myself:

```
String[] path = new String[] { "A.mp4", "B.mp4" };
ArrayList<SampleSource> playlist = new ArrayList<>();
for(String path : paths) {
  playlist.add(new ExtractorSampleSource(Uri.parse(path), new FileDataSource(), new DefaultAllocator(256 * 1024), 1024 * 1024));
}

SampleSource sampleSource = new SequenceSampleSource(playlist, null);

Handler mainHandler = player.getMainHandler();
MediaCodecVideoTrackRenderer videoRenderer = new MediaCodecVideoTrackRenderer(context, sampleSource, MediaCodec.VIDEO_SCALING_MODE_SCALE_TO_FIT, 5000, mainHandler, player, 50);
MediaCodecAudioTrackRenderer audioRenderer = new MediaCodecAudioTrackRenderer(sampleSource, null, true, mainHandler, player, AudioCapabilities.getCapabilities(context));

TrackRenderer[] renderers = new TrackRenderer[Player.RENDERER_COUNT];
renderers[Player.TYPE_VIDEO] = videoRenderer;
renderers[Player.TYPE_AUDIO] = audioRenderer;

player.onRenderers(renderers, new DefaultBandwidthMeter());
```

The code in this pull request is not finished. It is inspired by the HLS playback, but my knowlegde of video data formats and the internal defacto ExoPlayer lifecycle/ways is lacking. Known bugs:

- [ ] Although first playback works fine, after seeking the video tends to jump upon clip transition
- [ ] After first seek, some clip transitions seem to lack a keyframe, we see typical behaviour like when normal frame differences are applied to the wrong keyframe. Smudgy motions in regions that are not reset by the keyframe.

Any help would be wonderful!