### PR TITLE
The status is already "Ready" status. If  we call onPlayerStateChange…

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayerImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayerImpl.java
@@ -143,9 +143,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
       this.playWhenReady = playWhenReady;
       pendingPlayWhenReadyAcks++;
       internalPlayer.setPlayWhenReady(playWhenReady);
-      for (Listener listener : listeners) {
-        listener.onPlayerStateChanged(playWhenReady, playbackState);
-      }
     }
   }
 


### PR DESCRIPTION
…d again, it will cause top layer execute the On Ready twice.