### PR TITLE
Improve identification of (E)AC3 content in MPEGTS and tweak EAC3 parsing

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/extractor/ts/TsExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/ts/TsExtractor.java
@@ -392,7 +392,14 @@ public final class TsExtractor implements Extractor {
             streamType = TS_STREAM_TYPE_H265;
           }
           break;
+        } else if (descriptorTag == 0x6a) {
+          streamType = TS_STREAM_TYPE_AC3;
+        } else if (descriptorTag == 0x7a) {
+          streamType = TS_STREAM_TYPE_E_AC3;
+        } else if (descriptorTag == 0x7b) {
+          // TODO: TS_STREAM_TYPE_DTS;
         }
+
         data.skipBytes(descriptorLength);
       }
       data.setPosition(descriptorsEndPosition);

--- a/library/src/main/java/com/google/android/exoplayer/util/Ac3Util.java
+++ b/library/src/main/java/com/google/android/exoplayer/util/Ac3Util.java
@@ -152,7 +152,7 @@ public final class Ac3Util {
    */
   public static MediaFormat parseEac3SyncframeFormat(ParsableBitArray data, String trackId,
       long durationUs, String language) {
-    data.skipBits(16 + 2 + 11); // syncword, strmtype, frmsiz
+    data.skipBits(16 + 2 + 3 + 11); // syncword, strmtype, strmid, frmsiz
     int sampleRate;
     int fscod = data.readBits(2);
     if (fscod == 3) {


### PR DESCRIPTION
These changes:
 - Add support to identify a number of audio stream types via the descriptor tag in MPEGTS
 - Modify (fix?) the way EAC3 sync frame format was parsed

The following is the set of descriptor tags used by ffmpeg:
```c++
static const StreamType DESC_types[] = {
    { 0x6a, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_AC3          }, /* AC-3 descriptor */
    { 0x7a, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_EAC3         }, /* E-AC-3 descriptor */
    { 0x7b, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_DTS          },
    { 0x56, AVMEDIA_TYPE_SUBTITLE, AV_CODEC_ID_DVB_TELETEXT },
    { 0x59, AVMEDIA_TYPE_SUBTITLE, AV_CODEC_ID_DVB_SUBTITLE }, /* subtitling descriptor */
    { 0 },
};
```

After I made the change to handle the descriptor tags, I found that ExoPlayer still didn't like the EAC3 MPEGTS files output by FFMPEG. Upon investigation, we found that ExoPlayer wasn't skipping the substream ID field and therefore the parsing was misaligned. We are under the impression that the field is mandatory so not sure how this worked originally?