### PR TITLE
Implemented fade in and fade out volume animations.

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
@@ -174,7 +174,8 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
 
   private Surface surface;
   private TrackRenderer videoRenderer;
-  private CodecCounters codecCounters;
+    private TrackRenderer audioRenderer;
+    private CodecCounters codecCounters;
   private Format videoFormat;
   private int videoTrackToRestore;
 
@@ -306,6 +307,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
     }
     // Complete preparation.
     this.videoRenderer = renderers[TYPE_VIDEO];
+      this.audioRenderer = renderers[TYPE_AUDIO];
     this.codecCounters = videoRenderer instanceof MediaCodecTrackRenderer
         ? ((MediaCodecTrackRenderer) videoRenderer).codecCounters
         : renderers[TYPE_AUDIO] instanceof MediaCodecTrackRenderer
@@ -556,7 +558,7 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
       long mediaStartTimeMs, long mediaEndTimeMs, long elapsedRealtimeMs, long loadDurationMs) {
     if (infoListener != null) {
       infoListener.onLoadCompleted(sourceId, bytesLoaded, type, trigger, format, mediaStartTimeMs,
-          mediaEndTimeMs, elapsedRealtimeMs, loadDurationMs);
+              mediaEndTimeMs, elapsedRealtimeMs, loadDurationMs);
     }
   }
 
@@ -596,4 +598,10 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
     }
   }
 
+  public void fadeOut(float fromVolume, float maxDeviceVolume, double duration, double velocity, ExoPlayer.FadeCallback fadeCallback){
+      player.fadeOut(this.audioRenderer, fromVolume, maxDeviceVolume, duration, velocity, fadeCallback);
+  }
+    public void fadeIn(float fromVolume, float maxDeviceVolume, double duration, double velocity, ExoPlayer.FadeCallback fadeCallback){
+        player.fadeIn(this.audioRenderer, fromVolume, maxDeviceVolume, duration, velocity, fadeCallback);
+    }
 }

--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayer.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayer.java
@@ -195,6 +195,15 @@ public interface ExoPlayer {
     void handleMessage(int messageType, Object message) throws ExoPlaybackException;
 
   }
+    /**
+     * Interface definition for a callback to be notified after fade is finished.
+     */
+    public interface FadeCallback {
+        /**
+         * Handles the callback after fade audio animation is completed.
+         */
+        void onFadeFinished();
+    }
 
   /**
    * The player is neither prepared or being prepared.
@@ -338,7 +347,6 @@ public interface ExoPlayer {
    * @param positionMs The seek position.
    */
   public void seekTo(long positionMs);
-
   /**
    * Stops playback. Use {@code setPlayWhenReady(false)} rather than this method if the intention
    * is to pause playback.
@@ -359,6 +367,30 @@ public interface ExoPlayer {
    * The player must not be used after calling this method.
    */
   public void release();
+
+  /**
+   * Allow fade in player audio.
+   *
+   * @param audioRenderer Exoplayer component for audio render.
+   * @param fromVolume Fade start volume.
+   * @param maxDeviceVolume The maximum volume value of the device.
+   * @param duration Duration of the fade in seconds.
+   * @param velocity Velocity of the fade. Velocity can vary from linear (0) to logarithmic (greater than 0).
+   * @param onFinishFadeCallback Completion callback.
+   */
+  public void fadeIn(final TrackRenderer audioRenderer, float fromVolume, float maxDeviceVolume, double duration, double velocity, FadeCallback onFinishFadeCallback);
+
+  /**
+   * Allow fade out player audio.
+   *
+   * @param audioRenderer Exoplayer component for audio render.
+   * @param fromVolume Fade start volume.
+   * @param maxDeviceVolume The maximum volume value of the device.
+   * @param duration Duration of the fade in seconds.
+   * @param velocity Velocity of the fade. Velocity can vary from linear (0) to logarithmic (greater than 0).
+   * @param onFinishFadeCallback Completion callback.
+   */
+  public void fadeOut(final TrackRenderer audioRenderer, float fromVolume, float maxDeviceVolume, double duration, double velocity, FadeCallback onFinishFadeCallback);
 
   /**
    * Sends a message to a specified component. The message is delivered to the component on the


### PR DESCRIPTION
Implemented fade in and fade out volume animations using logarithmic formulas.

## Fade In Formula
![image](https://cloud.githubusercontent.com/assets/1569193/12613941/104f5a88-c4fd-11e5-8f27-818b6132cea8.png)

## Fade Out Formula
![image](https://cloud.githubusercontent.com/assets/1569193/12613954/21c6a37a-c4fd-11e5-9bfb-cc1038501052.png)

Where x is time and v velocity.

# Example
`player.fadeIn(0, 15, 10, 2, fadeCallback)`

Where:
* 0 is the start volume
* 15 is the maximum device value
* 10 is the duration of the fade
* 2 the velocity of the fade
* fadeCallback is the completion callback (can be null)