### PR TITLE
Filtered out repeated control messages.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608Parser.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608Parser.java
@@ -156,11 +156,16 @@ public final class Eia608Parser {
         continue;
       }
 
-      // Ignore repeated control characters.
+      // Ignore repeated control characters between 0x10 and 0x1f.
       if (ccData1 == previousCtrl1 && ccData2 == previousCtrl2) {
         continue;
       }
       previousCtrl1 = previousCtrl2 = 0;
+      
+      if (0x10 <= ccData1 && ccData1 < 0x20) {
+        previousCtrl1 = ccData1;
+        previousCtrl2 = ccData2;
+      }
 
       // Special North American character set.
       // ccData2 - P|0|1|1|X|X|X|X
@@ -191,8 +196,6 @@ public final class Eia608Parser {
       // Control character.
       if (ccData1 < 0x20) {
         addCtrl(ccData1, ccData2);
-        previousCtrl1 = ccData1;
-        previousCtrl2 = ccData2;
         continue;
       }
 

--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608Parser.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608Parser.java
@@ -106,6 +106,9 @@ public final class Eia608Parser {
   private final StringBuilder stringBuilder;
   private final ArrayList<ClosedCaption> captions;
 
+  // Previous control message, used for identifying repeated ones.
+  private byte previousCtrl1 = 0, previousCtrl2 = 0;
+
   /* package */ Eia608Parser() {
     seiBuffer = new ParsableBitArray();
     stringBuilder = new StringBuilder();
@@ -153,6 +156,12 @@ public final class Eia608Parser {
         continue;
       }
 
+      // Ignore repeated control characters.
+      if (ccData1 == previousCtrl1 && ccData2 == previousCtrl2) {
+        continue;
+      }
+      previousCtrl1 = previousCtrl2 = 0;
+
       // Special North American character set.
       // ccData2 - P|0|1|1|X|X|X|X
       if ((ccData1 == 0x11 || ccData1 == 0x19)
@@ -182,6 +191,8 @@ public final class Eia608Parser {
       // Control character.
       if (ccData1 < 0x20) {
         addCtrl(ccData1, ccData2);
+        previousCtrl1 = ccData1;
+        previousCtrl2 = ccData2;
         continue;
       }
 


### PR DESCRIPTION
ANSI CEA-608-E (Annex D.2) specifies that control messages for captions / text with codes of which the first character is in the range 0x10 - 0x1f should be transmitted twice in successive frames.
In streams that follow this recommendation, there are issues where captions disappear one frame after appearing.
This pull request adds functionality for ignoring these duplicate control messages.