### PR TITLE
allow "center" for alignment and position

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/text/webvtt/WebvttCueParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/webvtt/WebvttCueParser.java
@@ -276,6 +276,7 @@ public final class WebvttCueParser {
       case "start":
         return Cue.ANCHOR_TYPE_START;
       case "middle":
+      case "center":
         return Cue.ANCHOR_TYPE_MIDDLE;
       case "end":
         return Cue.ANCHOR_TYPE_END;
@@ -291,6 +292,7 @@ public final class WebvttCueParser {
       case "left":
         return Alignment.ALIGN_NORMAL;
       case "middle":
+      case "center":
         return Alignment.ALIGN_CENTER;
       case "end":
       case "right":


### PR DESCRIPTION
For both alignment cue setting value and position cue setting alignment value,  allow "center".
This value (and not "middle") is listed in 
https://w3c.github.io/webvtt/ ( WebVTT: The Web Video Text Tracks Format, Draft Community Group Report, 21 December 2015).

Leaving the behavior for "middle" unchanged.