### PR TITLE
EIA608 Styling

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/ClosedCaptionCtrl.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/ClosedCaptionCtrl.java
@@ -15,6 +15,8 @@
  */
 package com.google.android.exoplayer.text.eia608;
 
+import android.graphics.Color;
+
 /* package */ final class ClosedCaptionCtrl extends ClosedCaption {
 
   /**
@@ -59,7 +61,6 @@ package com.google.android.exoplayer.text.eia608;
 
   public static final byte BACKSPACE = 0x21;
 
-
   public static final byte MID_ROW_CHAN_1 = 0x11;
   public static final byte MID_ROW_CHAN_2 = 0x19;
 
@@ -69,6 +70,43 @@ package com.google.android.exoplayer.text.eia608;
   public static final byte TAB_OFFSET_CHAN_1 = 0x17;
   public static final byte TAB_OFFSET_CHAN_2 = 0x1F;
 
+  private static final int[] COLOR_VALUES = {
+          Color.WHITE,
+          Color.GREEN,
+          Color.BLUE,
+          Color.CYAN,
+          Color.RED,
+          Color.YELLOW,
+          Color.MAGENTA,
+          Color.TRANSPARENT // Last color setting should be kept
+  };
+
+  // for debug purposes
+  private static final String[] COLOR_NAMES = {
+          "WHITE",
+          "GREEN",
+          "BLUE",
+          "CYAN",
+          "RED",
+          "YELLOW",
+          "MAGENTA",
+          "KEEP PREVIOUS COLOR" // Used to turn on Italics and UnderLine.
+  };
+
+  // The final position of the text should be one of the predefined ROWs of the display.
+  // The target row is selected by 3 bits of CC1 and 1 bit of CC2. So let's have an array of 16
+  // indices that can be addressed by the incoming 4 bits.
+  // There is one duplication, row 11 is the default, where the bit in CC2 is not used for row
+  // selection, so the first 2 value will be 11: if the CC1 has the value of 0x10 or 0x18 than the
+  // target row is '11' irrespective of CC2.
+  final static short[] ROW_INDICES = { 11, 11, 1, 2, 3, 4, 12, 13, 14, 15, 5, 6, 7, 8, 9, 10 };
+
+  // 608 parser drops the first bits of the incoming data (parity bit), so both bytes has the max
+  // value of 0x7F.
+  // For Closed Captioning, cc1 values in the range 0 - 0xF are not defined, they are used as XDS
+  // control values (independent from closed caption control codes), so probably the parser should
+  // drop such values: the following functions do not really expect cc1 values
+  // outside the 0x10 - 0x7F range.
   public final byte cc1;
   public final byte cc2;
 
@@ -91,6 +129,12 @@ package com.google.android.exoplayer.text.eia608;
   }
 
   public boolean isPreambleAddressCode() {
+    // Note: Current implementation might throw compile warnings as cc2 cannot be bigger than
+    // 0x7F when we call this function.
+    // Preamble Code could also be checked as
+    // cc1 & 0x70 == 0x10 // bits required: 0bx001xxxx
+    // and
+    // cc2 & 0x40 == 0x40 // bits required: 0bx1xxxxxx
     return (cc1 >= 0x10 && cc1 <= 0x1F) && (cc2 >= 0x40 && cc2 <= 0x7F);
   }
 
@@ -98,4 +142,162 @@ package com.google.android.exoplayer.text.eia608;
     return cc1 >= 0x10 && cc1 <= 0x1F;
   }
 
+  // for debug purposes only
+  public String getMidRowCodeMeaning() {
+    String styleStr = COLOR_NAMES[ getMidRowControlColorIdx() ];
+
+    if (isUnderline()) {
+      styleStr += " + UNDERLINE";
+    }
+
+    return styleStr;
+  }
+
+  // returns the index that can be used to address the predefined arrays for selecting the color
+  // based on the CC2 byte. Only call this function, if you are sure, that this is a mid row
+  // command.
+  private int getMidRowControlColorIdx() {
+    return (cc2 - 0x20) / 2; // first color is 0x20, than every second value is a new color
+  }
+
+  // note: TRANSPARENT should be handled carefully! That is used for Italics and underline changes
+  int getMidRowColorValue() {
+    return COLOR_VALUES[ getMidRowControlColorIdx() ];
+  }
+
+  // returns 0 based index (while the standard mentions channel 1 and 2)!
+  public int getPreambleAddressCodeChannel() {
+    // the first byte is between 0x10 - 0x17 for channel 1 and
+    // between 0x18 - 0x1F for channel 2.
+    return (cc1 > 0x17) ? 1 : 0;
+  }
+
+  // for debug purposes
+  public String getPreambleAddressCodeMeaning() {
+    int cc1Bits = (cc1 & 0x7);
+    int cc2bit = (cc2 & 0x20) > 0 ? 1 : 0;
+
+    int index = (cc1Bits << 1) + cc2bit;
+
+    int rowAddress = ROW_INDICES[ index ];
+
+    return "Row:"+rowAddress
+            + "; Col:" + getIndentation()
+            + "; Color:" + getPreambleColorName()
+            + "; italic:" + isPreambleItalic()
+            + "; underline:" + isUnderline();
+  }
+
+  // color values are defined for CC2 between 0x40 and 0x4F only. Higher values only set indentation
+  private int getPreambleColorIdx() {
+    // The bits of the two bytes of the Preamble Are:
+    // CC1: 0bP001CRRR CC2: 0b1RSSSSU
+    // P is the parity bit
+    // C is the 'Channel selector'
+    // R is a bit that is used for 'Row selection'
+    // U is the 'Underline Flag'
+    // S is a bit used for 'Style selection'
+
+    // so for color selection we are only interested in the 4 bits of cc2 marked with 'S'. If the
+    // most significant one is set, than the color is White, and the leftover bits mean indentation.
+    if((cc2 & 0x10)> 0) {
+      return 0; // the index of white
+    }
+
+    // The last bit is irrelevant, that is the "Underline Flag" -> we will divide by 2.
+    // Let's mask the 4 bits we are interested in: 0b11110 = 0x1E.
+    return (cc2 & 0x1E) / 2;
+  }
+
+  public int getPreambleColor() {
+    return COLOR_VALUES[getPreambleColorIdx()];
+  }
+
+  // for debug purposes
+  public String getPreambleColorName() {
+    return COLOR_NAMES[getPreambleColorIdx()];
+  }
+
+  public  boolean isPreambleItalic() {
+    // The last bit ("Underline Flag") is irrelevant
+    // The 6th least significant bit is the part of the Row selection, so only the bits 2-5 count.
+    // For italic we need the least significant bits to be exactly 0b0111x so the entire byte is
+    // 0bxxR0111U, where x is "don't care", R is the 'Row Selector', U is the 'Underline Flag'
+    return (cc2 & 0x1E) == 0xE;
+  }
+
+  // Indentation is the column address of the Caption on the final display. The useful area of the
+  // screen should be divided into 32 equal columns. The useful area is the center 80% of the
+  // screen (10-10% should be left empty on both left and right side). Column 0 and 33 can be
+  // used to display a "solid space to improve legibility", but cannot contain displayable
+  // characters.
+  // A single column can be further divided into 4 equal parts. Tabs can be used (0-3) for
+  // positioning inside a column.
+  // Fun fact: the standard says that for screens with aspect ration of 16x9, the screen should be
+  // divided into 42 equal columns instead of 32. So the text positioning should be depending on
+  // the aspect ratio of the video content. What if the content is letterboxed? Than aspect ration
+  // checks will return incorrect results. I do not introduce this dependency at this time.
+  // See Federal Communications Commission §79.102
+  private int getIndentation() {
+    // The bits of the two bytes of the Preamble Are:
+    // CC1: 0bP001CRRR CC2: 0b1RSSSSU
+    // P is the parity bit for
+    // C is the 'Channel selector'
+    // R is a bit that is used for 'Row selection'
+    // U is the 'Underline Flag'
+    // S is a bit used for 'Style selection'
+
+    // we are again interested in the 4 bits marked with S. If the most significant one is set to 1,
+    // than the bits mean indentation, color otherwise.
+    if ((cc2 & 0x10) == 0) {
+      return 0; // the S bits mean a color value.
+    }
+
+    // If we are here, the S bits mean indentation.
+    // Lets remove the unnecessary bits
+    int indentValue = (cc2 & 0xE) >> 1; // Note: we can only have values between 0 and 7 from now on.
+
+    // the required indentation is 4 times of this value represented by the bits.
+    // Note: Indentation is between 0 and 28 columns this way, and there can be 0-3 tabs also added
+    // by following TAB offset codes.
+    return indentValue * 4;
+  }
+
+  // last bit of the styling commands (Preamble Address Code or Mid Row CODE) is "Underline Flag".
+  public boolean isUnderline() {
+    return (cc2 & 1) == 1;
+  }
+
+  // for debug purposes
+  private String getControlCodeMeaning() {
+    switch ( cc2 ) {
+      case RESUME_CAPTION_LOADING:     return "RESUME_CAPTION_LOADING";
+      case ROLL_UP_CAPTIONS_2_ROWS:    return "ROLL_UP_CAPTIONS_2_ROWS";
+      case ROLL_UP_CAPTIONS_3_ROWS:    return "ROLL_UP_CAPTIONS_3_ROWS";
+      case ROLL_UP_CAPTIONS_4_ROWS:    return "ROLL_UP_CAPTIONS_4_ROWS";
+      case RESUME_DIRECT_CAPTIONING:   return "RESUME_DIRECT_CAPTIONING";
+      case END_OF_CAPTION:             return "END_OF_CAPTION";
+      case ERASE_DISPLAYED_MEMORY:     return "ERASE_DISPLAYED_MEMORY";
+      case CARRIAGE_RETURN:            return "CARRIAGE_RETURN";
+      case ERASE_NON_DISPLAYED_MEMORY: return "ERASE_NON_DISPLAYED_MEMORY";
+      case BACKSPACE:                  return "BACKSPACE";
+    }
+    return "UNKNOWN";
+  }
+
+  // for debug purposes
+  @Override
+  public String toString() {
+    String value = "CC1:" + Integer.toHexString(cc1) + "; CC2:" + Integer.toHexString(cc2) + " ";
+
+    if (isPreambleAddressCode()) {
+      value += getPreambleAddressCodeMeaning();
+    } else if (isMidRowCode()) {
+      value += getMidRowCodeMeaning();
+    } else {
+      value += getControlCodeMeaning();
+    }
+
+    return value;
+  }
 }

--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/ClosedCaptionText.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/ClosedCaptionText.java
@@ -24,4 +24,9 @@ package com.google.android.exoplayer.text.eia608;
     this.text = text;
   }
 
+  // for debug purposes
+  @Override
+  public String toString() {
+    return text;
+  }
 }

--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608CueBuilder.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608CueBuilder.java
@@ -30,7 +30,7 @@ public class Eia608CueBuilder {
   }
 
   public Eia608CueBuilder(Eia608CueBuilder other) {
-    text = other.text;
+    text = new SpannableStringBuilder(other.text);
     position = other.position;
     line = other.line;
     rowIndex = other.rowIndex;

--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608CueBuilder.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608CueBuilder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer.text.eia608;
+
+import android.text.Layout;
+import android.text.SpannableStringBuilder;
+import com.google.android.exoplayer.text.Cue;
+
+public class Eia608CueBuilder {
+  private SpannableStringBuilder text;
+  private float position;
+  private float line;
+  private int rowIndex;
+
+  public Eia608CueBuilder() {
+    reset();
+  }
+
+  public Eia608CueBuilder(Eia608CueBuilder other) {
+    text = other.text;
+    position = other.position;
+    line = other.line;
+    rowIndex = other.rowIndex;
+  }
+
+  public void reset() {
+    text = null;
+    position = Cue.DIMEN_UNSET;
+    line = Cue.DIMEN_UNSET;
+    rowIndex = 15; // bottom row is the default
+  }
+
+  public Cue build() {
+    return new Cue(text, Layout.Alignment.ALIGN_NORMAL,
+            line, Cue.LINE_TYPE_FRACTION, Cue.ANCHOR_TYPE_START,
+            position, Cue.TYPE_UNSET, Cue.DIMEN_UNSET);
+  }
+
+  public boolean isEmpty() {
+    return (text == null) || (text.length() == 0);
+  }
+
+  public Eia608CueBuilder setText(SpannableStringBuilder aText) {
+    text = aText;
+    return this;
+  }
+
+  public void setRow(int rowIdx) {
+    if ((rowIdx < 1) || (15 < rowIdx)) {
+      this.line = 0.9f;
+      return;
+    }
+
+    rowIndex = rowIdx; // saved for roll-up feature
+
+    // 10% of screen is left of for safety reasons (analog overscan)
+    // the leftover 80% is divided into 15 equal rows. The problem is that the font size
+    // must match the row line height for this, so at the moment, I scale to 90% instead, to avoid
+    // overlap of the borders around the rows.
+    // -1 as the row and column indices are 1 based in the spec
+    this.line = (rowIdx - 1) / 15f * 0.9f + 0.05f;
+  }
+
+  /**
+   * Decrease the current row and reposition the captions to the new location
+   * @return true if rolling was possible
+     */
+  public boolean rollUp() {
+    if (rowIndex <= 1) {
+      return false;
+    }
+
+    setRow(rowIndex - 1);
+    return true;
+  }
+
+  public void setColumn(int columnIdx, int additionalTabs) {
+    // the original standard defines 32 columns for the safe area of the screen (middle 80%)
+    // but it also mentions that widescreen displays should use 42 columns. As the incoming data
+    // does not know about the display size, maybe if the content uses widescreen aspect ratio,
+    // than it will contain 42 columns. I never met such, but we should not forget about it...
+    if (columnIdx < 1 || 32 < columnIdx) {
+      this.position = 0.1f;
+      return;
+    }
+
+    // -1 as the row and column indices are 1 based in the spec
+    this.position = (((columnIdx - 1 + additionalTabs) / 32f) * 0.8f) + 0.1f;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608TrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608TrackRenderer.java
@@ -26,7 +26,6 @@ import com.google.android.exoplayer.TrackRenderer;
 import com.google.android.exoplayer.text.Cue;
 import com.google.android.exoplayer.text.TextRenderer;
 import com.google.android.exoplayer.util.Assertions;
-import com.google.android.exoplayer.util.Util;
 
 import android.graphics.Color;
 import android.graphics.Typeface;
@@ -40,7 +39,10 @@ import android.text.style.StyleSpan;
 import android.text.style.UnderlineSpan;
 import android.util.Log;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.TreeSet;
 
 import static android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
@@ -57,7 +59,7 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
   private static final int CC_MODE_POP_ON = 2;
   private static final int CC_MODE_PAINT_ON = 3;
 
-  // The default number of rows to display in roll-up captions mode.
+  // The default number of rows to display in ROLL-UP captions mode.
   private static final int DEFAULT_CAPTIONS_ROW_COUNT = 4;
   // The maximum duration that captions are parsed ahead of the current position.
   private static final int MAX_SAMPLE_READAHEAD_US = 5000000;
@@ -67,15 +69,16 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
   private final Handler textRendererHandler;
   private final MediaFormatHolder formatHolder;
   private final SampleHolder sampleHolder;
-  private final SpannableStringBuilder captionStringBuilder;
+  private final SpannableStringBuilder incomingStringBuilder;
   private final TreeSet<ClosedCaptionList> pendingCaptionLists;
+  private List<Cue> cueList;
 
   private boolean inputStreamEnded;
   private int captionMode;
   private int captionRowCount;
-  private SpannableStringBuilder caption;
-  private SpannableStringBuilder lastRenderedCaption;
   private ClosedCaptionCtrl repeatableControl;
+
+  private final boolean DEBUG = false;
 
   private static final String TAG = "Eia608Captions";
 
@@ -96,10 +99,19 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
   // following variables to store information about previously received formatting instructions.
   // When we get to a point where we should end or change formatting, we can set up the spans
   // between the stored start position and the current position (new control code, end of line, etc)
-  private int styleSwitchUnderlineStartPos;
-  private int styleSwitchItalicStartPos;
-  private int styleSwitchColorStartPos;
+  private int styleSwitchUnderlineStartPos = -1;
+  private int styleSwitchItalicStartPos = -1;
+  private int styleSwitchColorStartPos = -1;
   private int styleSwitchColor;
+
+  // The safe area of the screen is divided into 15 rows, 32 columns and each column has 4 Tabs
+  // Note: Row and Column indices are 1 based!
+  private int positionBaseRow;
+  private int positionBaseColumn;
+  private int positionTabCount;
+
+  private final Eia608CueBuilder cueBuilder = new Eia608CueBuilder();
+  private final List<Eia608CueBuilder> rollingQues = new LinkedList<>();
 
   /**
    * @param source A source from which samples containing EIA-608 closed captions can be read.
@@ -118,8 +130,9 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
     eia608Parser = new Eia608Parser();
     formatHolder = new MediaFormatHolder();
     sampleHolder = new SampleHolder(SampleHolder.BUFFER_REPLACEMENT_MODE_NORMAL);
-    captionStringBuilder = new SpannableStringBuilder();
+    incomingStringBuilder = new SpannableStringBuilder();
     pendingCaptionLists = new TreeSet<>();
+    cueList = new ArrayList<>();
   }
 
   @Override
@@ -142,6 +155,7 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
     captionRowCount = DEFAULT_CAPTIONS_ROW_COUNT;
     setCaptionMode(CC_MODE_UNKNOWN);
     invokeRenderer(null);
+    clearCaptionsBuffer();
   }
 
   @Override
@@ -166,14 +180,42 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
         // We're too early to render any of the pending caption lists.
         return;
       }
+
       // Remove and consume the next caption list.
-      ClosedCaptionList nextCaptionList = pendingCaptionLists.pollFirst();
-      consumeCaptionList(nextCaptionList);
-      // Update the renderer, unless the caption list was marked for decoding only.
-      if (!nextCaptionList.decodeOnly) {
-        invokeRenderer(caption);
-      }
+      consumeCaptionList(pendingCaptionLists.pollFirst());
     }
+  }
+
+  private void sendCaptionToRenderer(boolean decodeOnly) {
+    if (DEBUG) {
+      printCurrentCueList();
+    }
+
+    if (isModeRollUp()) {
+      for (Eia608CueBuilder oneBuilder : rollingQues) {
+        // empty rows are rolling to handle line count limit correctly, but should not be sent to
+        // the renderer
+        if (!oneBuilder.isEmpty()) {
+          cueList.add(oneBuilder.build());
+        }
+      }
+    } else {
+      rollingQues.clear();
+    }
+
+    if (!decodeOnly) {
+      invokeRenderer(cueList);
+    }
+    cueList = new ArrayList<>();
+  }
+
+  // for debug use only
+  private void printCurrentCueList() {
+    Log.d(TAG, "+ + + + + + + + + + + + +");
+    for (Cue oneCue :cueList) {
+      Log.d(TAG, "Cue @" + oneCue.line + " " + oneCue.text);
+    }
+    Log.d(TAG, "-------------------------");
   }
 
   @Override
@@ -191,17 +233,15 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
     return true;
   }
 
-  private void invokeRenderer(SpannableStringBuilder text) {
-    if (Util.areEqual(lastRenderedCaption, text)) {
-      // No change.
-      return;
-    }
-    final SpannableStringBuilder textToRender = text == null ? null : new SpannableStringBuilder(text);
-    this.lastRenderedCaption = textToRender;
+  /**
+   * Update captions on the screen
+   * @param cues (list) to render. Call with null parameter to clear screen
+     */
+  private void invokeRenderer(List<Cue> cues) {
     if (textRendererHandler != null) {
-      textRendererHandler.obtainMessage(MSG_INVOKE_RENDERER, textToRender).sendToTarget();
+      textRendererHandler.obtainMessage(MSG_INVOKE_RENDERER, cues).sendToTarget();
     } else {
-      invokeRendererInternal(textToRender);
+      invokeRendererInternal(cues);
     }
   }
 
@@ -210,17 +250,17 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
   public boolean handleMessage(Message msg) {
     switch (msg.what) {
       case MSG_INVOKE_RENDERER:
-        invokeRendererInternal((SpannableStringBuilder) msg.obj);
+        invokeRendererInternal((List<Cue>) msg.obj);
         return true;
     }
     return false;
   }
 
-  private void invokeRendererInternal(CharSequence cueText) {
-    if (cueText == null) {
+  private void invokeRendererInternal(List<Cue> cues) {
+    if (cues == null) {
       textRenderer.onCues(Collections.<Cue>emptyList());
     } else {
-      textRenderer.onCues(Collections.singletonList(new Cue(cueText)));
+      textRenderer.onCues(cues);
     }
   }
 
@@ -236,10 +276,23 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
     }
   }
 
+  // for debug use only
+  private void printIncomingCaptionData(ClosedCaptionList captionList) {
+    Log.i(TAG, "****************************");
+    for (ClosedCaption oneCaption : captionList.captions) {
+      Log.i(TAG, oneCaption.toString());
+    }
+    Log.i(TAG, "-*-*-*-*-*-*-*-*-*-*-*-*-*-*-");
+  }
+
   private void consumeCaptionList(ClosedCaptionList captionList) {
     int captionBufferSize = captionList.captions.length;
     if (captionBufferSize == 0) {
       return;
+    }
+
+    if (DEBUG) {
+      printIncomingCaptionData(captionList);
     }
 
     boolean isRepeatableControl = false;
@@ -257,85 +310,149 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
           repeatableControl = captionCtrl;
         }
         if (captionCtrl.isMiscCode()) {
-          handleMiscCode(captionCtrl);
+          handleMiscCode(captionCtrl, captionList.decodeOnly);
         } else if (captionCtrl.isPreambleAddressCode()) {
+          // In ROLL-UP mode, an incoming PAC just moves the entire window (with captions intact)
+          // to the now place, but does not clear the previous captions. When there are no empty
+          // rows left, than the next Carriage Return will remove the top row from the memory, so
+          // clearing is implemented there.
+          createCueFromCurrentBuffers(!isModeRollUp());
           handlePreambleAddressCode(captionCtrl);
         } else if (captionCtrl.isMidRowCode()) {
           handleMidRowCode(captionCtrl);
+        } else if (captionCtrl.isTabOffsetCode()) {
+          handleTabOffsetCode(captionCtrl);
         }
       } else {
         handleText((ClosedCaptionText) caption);
       }
     }
-
     if (!isRepeatableControl) {
       repeatableControl = null;
     }
-    if (captionMode == CC_MODE_ROLL_UP || captionMode == CC_MODE_PAINT_ON) {
-      caption = getDisplayCaption(false);
+
+    // Pop-up mode needs to wait for the command END-OF-CAPTION to update the screen, but other
+    // modes show incoming characters immediately.
+    if (isModePaintOn() || isModeRollUp()) {
+      // We need to keep the old buffers intact, as new characters will be concatenated to the
+      // current content.
+      final boolean clearOldBuffers = false;
+      createCueFromCurrentBuffers(clearOldBuffers);
+
+      sendCaptionToRenderer(captionList.decodeOnly);
+    }
+  }
+
+  private void handleTabOffsetCode(ClosedCaptionCtrl captionCtrl) {
+    // CC1: 0x17 and 0x1F are the 2 channels.
+    // CC2: 0x21 means 1, 0x22 means 2 tab, 0x23 means 3 tabs.
+    positionTabCount = captionCtrl.cc2 - 0x20;
+
+    if (DEBUG) {
+      Log.i(TAG, "TAB: " + positionTabCount);
     }
   }
 
   private void handleText(ClosedCaptionText captionText) {
-    if (captionMode != CC_MODE_UNKNOWN) {
-      captionStringBuilder.append(captionText.text);
+    if (DEBUG) {
+      Log.i(TAG, "TEXT: " + captionText.text);
+    }
+
+    if (!isModeUnknown()) {
+      incomingStringBuilder.append(captionText.text);
+    }
+  }
+
+  /**
+   * This function should be called only to handle the Carriage Return Misc Code command in ROLL-UP
+   * Mode. When called, the current and previous (up to the number of rolling lines) rows are rolled
+   * up by one line. The "base line" (the one showing new incoming characters) will be empty.
+   */
+  private void rollUpQues() {
+    // add latest line with currently incoming characters to the rolling list first
+    setupCueBuilder(true);
+
+    // Note: there can be multiple CARRIAGE-RETURN commands coming in without character in between
+    // we need to roll up for each, so we put empty lines into the list to correctly handle the
+    // line count limit.
+    rollingQues.add(new Eia608CueBuilder(cueBuilder));
+
+    // base row is rolled up, incoming characters will be added to a blank line:
+    incomingStringBuilder.clear();
+
+    dropOldRollingQues();
+
+    for (Eia608CueBuilder oneBuilder : rollingQues) {
+      oneBuilder.rollUp();
+    }
+  }
+
+  // call this when the rolling cue list changes (resize or roll) to remove old cues
+  private void dropOldRollingQues() {
+    // we keep one less row than the allowed one, as the base row is getting the incoming characters
+    while (rollingQues.size() >= captionRowCount) {
+      rollingQues.remove(0);
     }
   }
 
   private void handleMidRowCode(ClosedCaptionCtrl captionCtrl) {
-    //Log.i(TAG, "Mid line Command code: " + captionCtrl.getMidRowCodeMeaning());
+    if (DEBUG) {
+      Log.i(TAG, "MRC: " + captionCtrl.getMidRowCodeMeaning());
+    }
 
-    //TODO: possibly add space character as:
+    // TODO: possibly add space character as:
     //"All Mid-Row Codes and the Flash On command are spacing attributes which appear in the display
     // just as if a standard space (20h) had been received"
     // https://www.law.cornell.edu/cfr/text/47/79.101
+    // This is currently skipped, as all content I met added spaces correctly
 
     int newColor = captionCtrl.getMidRowColorValue();
-    int captionLength = captionStringBuilder.length();
+    int captionLength = incomingStringBuilder.length();
 
     // The last color described in the standard is "transparent" meaning "Keep Previous Color" and
     // is used to turn on Italics with the current color unchanged. So for example a command to
     // switch to RED then TRANSPARENT would mean RED ITALIC. The first color command (RED) disables
     // all previous color settings while the second (TRANSPARENT) does not.
     if (newColor == Color.TRANSPARENT) {
-      closeOpenSpans(STYLE_PRIORITY_ITALIC, captionStringBuilder, true); // close already open spans
+      closeOpenSpans(STYLE_PRIORITY_ITALIC, true); // close already open spans
       styleSwitchItalicStartPos = captionLength;
     } else {
       // Not transparent: apply new color
-      closeOpenSpans(STYLE_PRIORITY_COLOR, captionStringBuilder, true); // close already open spans
+      closeOpenSpans(STYLE_PRIORITY_COLOR, true); // close already open spans
       styleSwitchColor = newColor;
       styleSwitchColorStartPos = captionLength;
     }
 
     // the last bit is the "Underline switch", it does not interfere with any other settings
     if (captionCtrl.isUnderline()) {
-      closeOpenSpans(STYLE_PRIORITY_UNDERLINE, captionStringBuilder, true); // close already open spans
+      closeOpenSpans(STYLE_PRIORITY_UNDERLINE, true); // close already open spans
       styleSwitchUnderlineStartPos = captionLength;
     }
-
-    // Any color or italics Mid-Row Code should turn off flashing, but let's declare that deprecated
   }
 
-  private void handleMiscCode(ClosedCaptionCtrl captionCtrl) {
+  private void handleMiscCode(ClosedCaptionCtrl captionCtrl, boolean decodeOnly) {
+    if (DEBUG) {
+      Log.i(TAG, "MISC: " + captionCtrl.getMiscControlCodeMeaning());
+    }
 
-    // TODO: when switching to "ROLL UP" mode, the default ROW value is 15, and
-    // The Roll-Up command, in normal practice, will be followed (not necessarily immediately) by a
-    // Preamble Address Code indicating the base row and the horizontal indent position. If no
-    // Preamble Address Code is received, the base row will default to Row 15 or, if a roll-up
-    // caption is currently displayed, to the same base row last received, and the cursor will be
-    // placed at Column 1. See 47 CFR Ch1 (10-1-13) 1 / ii
-
+    // the first ones are the commands setting the captioning mode. Some other commands also imply
+    // one of the modes already set, but mode setting might have been dropped (parity check) or
+    // just skipped by the provider. So we might update the mode for those (like END-OF-CAPTION is
+    // only expected in POP-ON mode), but their original purpose is not mode change, they will be
+    // handled later
     switch (captionCtrl.cc2) {
       case ClosedCaptionCtrl.ROLL_UP_CAPTIONS_2_ROWS:
         captionRowCount = 2;
         setCaptionMode(CC_MODE_ROLL_UP);
+        dropOldRollingQues(); // if row count is decreased we need to adjust
         return;
       case ClosedCaptionCtrl.ROLL_UP_CAPTIONS_3_ROWS:
         captionRowCount = 3;
         setCaptionMode(CC_MODE_ROLL_UP);
+        dropOldRollingQues(); // if row count is decreased we need to adjust
         return;
       case ClosedCaptionCtrl.ROLL_UP_CAPTIONS_4_ROWS:
-        captionRowCount = 4;
+        captionRowCount = 4; // if row count could not be more, no need to adjust the rolling list
         setCaptionMode(CC_MODE_ROLL_UP);
         return;
       case ClosedCaptionCtrl.RESUME_CAPTION_LOADING:
@@ -346,56 +463,101 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
         return;
     }
 
-    if (captionMode == CC_MODE_UNKNOWN) {
+    if (isModeUnknown()) {
+      // mode is not initialized yet, but the next codes would depend on the current mode. So we
+      // skip everything till the next command setting the mode correctly
       return;
     }
 
     switch (captionCtrl.cc2) {
       case ClosedCaptionCtrl.ERASE_DISPLAYED_MEMORY:
-        caption = null;
-        if (captionMode == CC_MODE_ROLL_UP || captionMode == CC_MODE_PAINT_ON) {
-          captionStringBuilder.clear();
+        invokeRenderer(null); // clear screen immediately.
+
+        // When POP UP mode is used, we need to handle the screen and the off-screen buffer
+        // separately. In ROLL-UP mode and PAINT-ON mode the screen is immediately updated from the
+        // buffer. So, for those modes, we clear all buffers to avoid redrawing old stuff.
+        if (isModeRollUp() || isModePaintOn()) {
+          incomingStringBuilder.clear();
         }
+        rollingQues.clear();
         return;
-      case ClosedCaptionCtrl.ERASE_NON_DISPLAYED_MEMORY:
-        captionStringBuilder.clear();
+      case ClosedCaptionCtrl.ERASE_NON_DISPLAYED_MEMORY: // clear everything not displayed
+        clearCaptionsBuffer();
         return;
       case ClosedCaptionCtrl.END_OF_CAPTION:
-        caption = getDisplayCaption(true);
-        captionStringBuilder.clear();
+        // in case the command RESUME_CAPTION_LOADING was skipped, this command needs to change
+        // captioning mode as well!
+        setCaptionMode(CC_MODE_POP_ON);
+        createCueFromCurrentBuffers(true);
+        sendCaptionToRenderer(decodeOnly);
         return;
       case ClosedCaptionCtrl.CARRIAGE_RETURN:
-        maybeAppendNewline();
+        // CARRIAGE_RETURN should not affect POP-UP and PAINT-ON captions, only ROLL-UP ones as
+        // during the analog era there were no "line break" characters sent, but the next captions
+        // were positioned to the row below the current one. So this current implementation does
+        // not really expect "new line" characters for formatting
+        if (isModeRollUp()) {
+          rollUpQues();
+        }
         return;
       case ClosedCaptionCtrl.BACKSPACE:
-        int length = captionStringBuilder.length();
+        int length = incomingStringBuilder.length();
         if (length > 0) {
-          captionStringBuilder.delete(length - 1, length);
+          incomingStringBuilder.delete(length - 1, length);
         }
         return;
     }
   }
 
+  /**
+   * For some operations we handle the screen (already shown memory) and incoming buffer
+   * separately. This function can be used to clear every internal buffers, but the currently shown
+   * captions.
+   */
+  private void clearCaptionsBuffer() {
+    incomingStringBuilder.clear();
+    cueList.clear();
+    rollingQues.clear();
+  }
+
+  /**
+   * Put the received characters with the received formatting information into a cue. This should
+   * be called just before rendering a cue. Might be mid-line, if we do not need to wait for a
+   * command to show the captions, but incoming characters should be shown immediately.
+   * @param clearStringBuilder clear previous formatting and text
+   */
+  private void createCueFromCurrentBuffers(boolean clearStringBuilder) {
+    setupCueBuilder(clearStringBuilder);
+
+    if (cueBuilder.isEmpty()) {
+      return;
+    }
+
+    cueList.add(cueBuilder.build());
+
+    // Not all modes need to clear the buffers when the captions got sent to the display.
+    // For ROLL-UP and PAINT-ON mode the old content is kept in the buffer as new characters are
+    // concatenated and sent to display immediately
+    if (clearStringBuilder) {
+      incomingStringBuilder.clear();
+    }
+  }
 
   /**
    * Spans cannot partially overlap each other, so the ordering (priority) is important
    * This function sets up every spans that are marked as currently open (has start position set)
-   * with equal or lower priority than the incoming parameter.
+   * with equal or lower priority than the incoming parameter. We only need to clear span opening
+   * data if the content currently processed is final, and the next incoming characters wont be
+   * appended to the text any more.
    * @param spanPriority limit of priority of the spans to close
-   * @param stringBuilder the new spans should be inserted into this stringBuilder
-   * @param clearSpanOpenings true if the spans currently closed should be removed
+   * @param clearSpanOpenings true if the spans currently closed should be removed from next cues
    */
-  private void closeOpenSpans(int spanPriority, SpannableStringBuilder stringBuilder,
-                              boolean clearSpanOpenings) {
-
-    // TODO: should check if closing before rather than after a new line character makes any
-    // difference. We might want to exclude the new line characters from the spans
-
-    int textLength = stringBuilder.length();
+  private void closeOpenSpans(int spanPriority, boolean clearSpanOpenings) {
+    int textLength = incomingStringBuilder.length();
 
     if (styleSwitchUnderlineStartPos != -1) {
       if (styleSwitchUnderlineStartPos < textLength) {
-        stringBuilder.setSpan(new UnderlineSpan(), styleSwitchUnderlineStartPos,
+        incomingStringBuilder.setSpan(new UnderlineSpan(), styleSwitchUnderlineStartPos,
                 textLength, SPAN_EXCLUSIVE_EXCLUSIVE);
       }
 
@@ -409,7 +571,7 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
 
     if (styleSwitchItalicStartPos != -1) {
       if (styleSwitchItalicStartPos < textLength) {
-        stringBuilder.setSpan(new StyleSpan(Typeface.ITALIC),
+        incomingStringBuilder.setSpan(new StyleSpan(Typeface.ITALIC),
                 styleSwitchItalicStartPos, textLength, SPAN_EXCLUSIVE_EXCLUSIVE);
       }
 
@@ -423,7 +585,7 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
 
     if (styleSwitchColorStartPos != -1) {
       if (styleSwitchColorStartPos < textLength) {
-        stringBuilder.setSpan(new ForegroundColorSpan(styleSwitchColor),
+        incomingStringBuilder.setSpan(new ForegroundColorSpan(styleSwitchColor),
                 styleSwitchColorStartPos, textLength, SPAN_EXCLUSIVE_EXCLUSIVE);
       }
 
@@ -433,31 +595,50 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
     }
   }
 
-  private void handlePreambleAddressCode(ClosedCaptionCtrl captionCtrl) {
-    // PAC might be skipped, but it should be the beginning of every line. So we expect a line break
-    // before every PAC.
-    maybeAppendNewline();
+  // as there are no multi-line cues allowed, every PAC should be the first command of the line
+  private void handlePreambleAddressCode(ClosedCaptionCtrl pacCommand) {
+    if (DEBUG) {
+      Log.i(TAG, "PAC: " + pacCommand.getPreambleAddressCodeMeaning());
+    }
 
-    //Log.d(TAG , captionCtrl.getPreambleAddressCodeMeaning());
+    positionBaseRow = pacCommand.getPreambleAddressCodePositionRow();
+    positionBaseColumn = pacCommand.getPreambleAddressCodePositionColumn();
 
-    // TODO: Add better handling of this with specific positioning.
-    // TODO: Read CC1 for vertical positioning information
+    // new row should receive new tab commands after this PAC, so we can reset old values here
+    positionTabCount = 0;
 
-    int currentLength = captionStringBuilder.length();
-
-    int preambleColor = captionCtrl.getPreambleColor();
+    int preambleColor = pacCommand.getPreambleColor();
     if (preambleColor != Color.WHITE) {
       styleSwitchColor = preambleColor;
-      styleSwitchColorStartPos = currentLength;
+      styleSwitchColorStartPos = 0;
     }
 
-    if (captionCtrl.isPreambleItalic()) {
-      styleSwitchItalicStartPos = currentLength;
+    if (pacCommand.isPreambleItalic()) {
+      styleSwitchItalicStartPos = 0;
     }
 
-    if (captionCtrl.isUnderline()) {
-      styleSwitchUnderlineStartPos = currentLength;
+    if (pacCommand.isUnderline()) {
+      styleSwitchUnderlineStartPos = 0;
     }
+  }
+
+  private boolean isModePopOn() {
+    return captionMode == CC_MODE_POP_ON;
+  }
+
+  private boolean isModeRollUp() {
+    return captionMode == CC_MODE_ROLL_UP;
+  }
+
+  private boolean isModePaintOn() {
+    return captionMode == CC_MODE_PAINT_ON;
+  }
+
+  // CC_MODE_UNKNOWN means uninitialized mode, as we can switch to the live steam any time not
+  // knowing what the previous commands were. Captions will be dropped till the next command
+  // correctly setting up the state arrives
+  private boolean isModeUnknown() {
+    return captionMode == CC_MODE_UNKNOWN;
   }
 
   private void setCaptionMode(int captionMode) {
@@ -466,61 +647,39 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
     }
 
     this.captionMode = captionMode;
-    // Clear the working memory.
-    captionStringBuilder.clear();
-    if (captionMode == CC_MODE_ROLL_UP || captionMode == CC_MODE_UNKNOWN) {
-      // When switching to roll-up or unknown, we also need to clear the caption.
-      caption = null;
+
+    incomingStringBuilder.clear();
+
+    if (isModeRollUp() || isModeUnknown()) {
+      // When switching to ROLL-UP or unknown, we also need to clear the captions.
+      invokeRenderer(null);
+    }
+
+    if (isModeRollUp()) {
+      // reset position to defaults. Incoming PAC will overwrite these values if necessary
+      positionBaseColumn = 1;
+      positionBaseRow = 15;
+
+      // clear rolling window as well
+      rollingQues.clear();
+      clearCaptionsBuffer();
     }
   }
 
-  private void maybeAppendNewline() {
-    closeOpenSpans(STYLE_PRIORITY_ALL, captionStringBuilder, true); //end of line should close all tags
+  private void setupCueBuilder(boolean clearSpanOpenings) {
+    cueBuilder.reset();
 
-    int buildLength = captionStringBuilder.length();
-    if (buildLength > 0 && captionStringBuilder.charAt(buildLength - 1) != '\n') {
-      captionStringBuilder.append('\n');
-    }
-  }
-
-  private SpannableStringBuilder getDisplayCaption(boolean clearSpans) {
-    int buildLength = captionStringBuilder.length();
+    int buildLength = incomingStringBuilder.length();
     if (buildLength == 0) {
-      return null;
+      return;
     }
 
-    boolean endsWithNewline = captionStringBuilder.charAt(buildLength - 1) == '\n';
-    if (buildLength == 1 && endsWithNewline) {
-      return null;
-    }
+    closeOpenSpans(STYLE_PRIORITY_ALL, clearSpanOpenings);
 
-    int endIndex = endsWithNewline ? buildLength - 1 : buildLength;
-    if (captionMode != CC_MODE_ROLL_UP) {
-      SpannableStringBuilder result = new SpannableStringBuilder(captionStringBuilder, 0, endIndex);
-      closeOpenSpans(STYLE_PRIORITY_ALL, result, clearSpans);
-      return result;
-    }
+    cueBuilder.setRow(positionBaseRow);
+    cueBuilder.setColumn(positionBaseColumn, positionTabCount);
 
-    // Show only the last X rows by searching backwards the last X line breaks in the builder and
-    // returning only what is after them.
-
-    int startIndex = 0;
-    int newLineCount = 0;
-    for (int charIdx = endIndex - 1; charIdx >= 0; --charIdx) {
-      if (captionStringBuilder.charAt(charIdx) == '\n') {
-        newLineCount++;
-      }
-
-      if (newLineCount >= captionRowCount) {
-        startIndex = charIdx + 1;  // +1 to skip the newline char
-        break;
-      }
-    }
-
-    captionStringBuilder.delete(0, startIndex);
-    SpannableStringBuilder result = new SpannableStringBuilder(captionStringBuilder);
-    closeOpenSpans(STYLE_PRIORITY_ALL, result, clearSpans);
-    return result;
+    cueBuilder.setText(new SpannableStringBuilder(incomingStringBuilder, 0, buildLength));
   }
 
   private void clearPendingSample() {
@@ -531,4 +690,5 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
   private boolean isSamplePending() {
     return sampleHolder.timeUs != C.UNKNOWN_TIME_US;
   }
+
 }

--- a/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608TrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/text/eia608/Eia608TrackRenderer.java
@@ -313,7 +313,7 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
           handleMiscCode(captionCtrl, captionList.decodeOnly);
         } else if (captionCtrl.isPreambleAddressCode()) {
           // In ROLL-UP mode, an incoming PAC just moves the entire window (with captions intact)
-          // to the now place, but does not clear the previous captions. When there are no empty
+          // to the new place, but does not clear the previous captions. When there are no empty
           // rows left, than the next Carriage Return will remove the top row from the memory, so
           // clearing is implemented there.
           createCueFromCurrentBuffers(!isModeRollUp());
@@ -336,8 +336,7 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
     if (isModePaintOn() || isModeRollUp()) {
       // We need to keep the old buffers intact, as new characters will be concatenated to the
       // current content.
-      final boolean clearOldBuffers = false;
-      createCueFromCurrentBuffers(clearOldBuffers);
+      createCueFromCurrentBuffers(false);
 
       sendCaptionToRenderer(captionList.decodeOnly);
     }
@@ -430,6 +429,14 @@ public final class Eia608TrackRenderer extends SampleSourceTrackRenderer impleme
     }
   }
 
+  /**
+   * Handles Misc Command Codes
+   * @param captionCtrl command to process
+   * @param decodeOnly set it to false to update buffers but skip sending them to the renderer
+   *                - useful after seeking to process the commands before the first update of the
+   *                   screen)
+   *                - ERASE_DISPLAYED_MEMORY should always immediately clear the screen
+   */
   private void handleMiscCode(ClosedCaptionCtrl captionCtrl, boolean decodeOnly) {
     if (DEBUG) {
       Log.i(TAG, "MISC: " + captionCtrl.getMiscControlCodeMeaning());


### PR DESCRIPTION
First patches for the missing parts of the EIA608 specification.
**Italic, Color, Underline** is supported. 
Row and Column **positioning** is not implemented yet.

Tested with
https://devimages.apple.com.edgekey.net/streaming/examples/bipbop_4x3bipbop_4x3_variant.m3u8
and a few other (not public) samples.