### PR TITLE
UdpDataSource: use Uri's methods to access host, port parts

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/upstream/UdpDataSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/upstream/UdpDataSource.java
@@ -82,9 +82,8 @@ public final class UdpDataSource implements UriDataSource {
   @Override
   public long open(DataSpec dataSpec) throws UdpDataSourceException {
     this.dataSpec = dataSpec;
-    String uri = dataSpec.uri.toString();
-    String host = uri.substring(0, uri.indexOf(':'));
-    int port = Integer.parseInt(uri.substring(uri.indexOf(':') + 1));
+    String host = dataSpec.uri.getHost();
+    int port = dataSpec.uri.getPort();
 
     try {
       address = InetAddress.getByName(host);


### PR DESCRIPTION
Current implementation doesn't work at least for udp://@239.0.1.2:1234, moreover parsing is already done by Uri