### PR TITLE
Add support to identify VobSub/PGS tracks from MKV

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/MediaFormat.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaFormat.java
@@ -182,6 +182,13 @@ public final class MediaFormat {
         NO_VALUE, NO_VALUE, NO_VALUE);
   }
 
+  public static MediaFormat createImageFormat(String trackId, String mimeType, int bitrate,
+      long durationUs, List<byte[]> initializationData, String language) {
+    return new MediaFormat(trackId, mimeType, bitrate, NO_VALUE, durationUs, NO_VALUE, NO_VALUE,
+        NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE, language, OFFSET_SAMPLE_RELATIVE, initializationData, false, NO_VALUE,
+        NO_VALUE, NO_VALUE, NO_VALUE);
+  }
+
   public static MediaFormat createFormatForMimeType(String trackId, String mimeType, int bitrate,
       long durationUs) {
     return new MediaFormat(trackId, mimeType, bitrate, NO_VALUE, durationUs, NO_VALUE, NO_VALUE,

--- a/library/src/main/java/com/google/android/exoplayer/extractor/webm/WebmExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/webm/WebmExtractor.java
@@ -82,6 +82,8 @@ public final class WebmExtractor implements Extractor {
   private static final String CODEC_ID_DTS_LOSSLESS = "A_DTS/LOSSLESS";
   private static final String CODEC_ID_FLAC = "A_FLAC";
   private static final String CODEC_ID_SUBRIP = "S_TEXT/UTF8";
+  private static final String CODEC_ID_VOBSUB = "S_VOBSUB";
+  private static final String CODEC_ID_PGS = "S_HDMV/PGS";
 
   private static final int VORBIS_MAX_INPUT_SIZE = 8192;
   private static final int OPUS_MAX_INPUT_SIZE = 5760;
@@ -1068,7 +1070,9 @@ public final class WebmExtractor implements Extractor {
         || CODEC_ID_DTS_EXPRESS.equals(codecId)
         || CODEC_ID_DTS_LOSSLESS.equals(codecId)
         || CODEC_ID_FLAC.equals(codecId)
-        || CODEC_ID_SUBRIP.equals(codecId);
+        || CODEC_ID_SUBRIP.equals(codecId)
+        || CODEC_ID_VOBSUB.equals(codecId)
+        || CODEC_ID_PGS.equals(codecId);
   }
 
   /**
@@ -1254,6 +1258,13 @@ public final class WebmExtractor implements Extractor {
         case CODEC_ID_SUBRIP:
           mimeType = MimeTypes.APPLICATION_SUBRIP;
           break;
+        case CODEC_ID_VOBSUB:
+          mimeType = MimeTypes.APPLICATION_VOBSUB;
+          initializationData = Collections.singletonList(codecPrivate);
+          break;
+        case CODEC_ID_PGS:
+          mimeType = MimeTypes.APPLICATION_PGS;
+          break;
         default:
           throw new ParserException("Unrecognized codec identifier.");
       }
@@ -1280,6 +1291,9 @@ public final class WebmExtractor implements Extractor {
       } else if (MimeTypes.APPLICATION_SUBRIP.equals(mimeType)) {
         format = MediaFormat.createTextFormat(Integer.toString(trackId), mimeType,
             MediaFormat.NO_VALUE, durationUs, language);
+      } else if (MimeTypes.APPLICATION_VOBSUB.equals(mimeType) || MimeTypes.APPLICATION_PGS.equals(mimeType)) {
+        format = MediaFormat.createImageFormat(Integer.toString(trackId), mimeType,
+            MediaFormat.NO_VALUE, durationUs, initializationData, language);
       } else {
         throw new ParserException("Unexpected MIME type.");
       }

--- a/library/src/main/java/com/google/android/exoplayer/util/MimeTypes.java
+++ b/library/src/main/java/com/google/android/exoplayer/util/MimeTypes.java
@@ -68,6 +68,8 @@ public final class MimeTypes {
   public static final String APPLICATION_M3U8 = BASE_TYPE_APPLICATION + "/x-mpegURL";
   public static final String APPLICATION_TX3G = BASE_TYPE_APPLICATION + "/x-quicktime-tx3g";
   public static final String APPLICATION_MP4VTT = BASE_TYPE_APPLICATION + "/x-mp4vtt";
+  public static final String APPLICATION_VOBSUB = BASE_TYPE_APPLICATION + "/vobsub";
+  public static final String APPLICATION_PGS = BASE_TYPE_APPLICATION + "/pgs";
 
   private MimeTypes() {}
 


### PR DESCRIPTION
This change adds identification of PGS/VobSub tracks to MKV. With this inclusion, it's possible for applications to provide their own `TrackRenderer`s in order to handle these MimeTypes.

You'll notice that VobSub requires us to later consume the `codecPrivate` data. As mentioned by the spec (https://www.matroska.org/technical/specs/subtitles/images.html), in the case for VobSub, this contains the IDX manifest.