### PR TITLE
added a workaround for some streams that do not (cannot?) signal the correct AAC object type in their ADTS headers

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/extractor/ts/AdtsReader.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/ts/AdtsReader.java
@@ -55,6 +55,7 @@ import java.util.Collections;
   private final ParsableBitArray adtsScratch;
   private final ParsableByteArray id3HeaderBuffer;
   private final TrackOutput id3Output;
+  private final int overrideAudioObjectType;
 
   private int state;
   private int bytesRead;
@@ -79,10 +80,15 @@ import java.util.Collections;
    * @param id3Output A {@link TrackOutput} to which ID3 samples should be written.
    */
   public AdtsReader(TrackOutput output, TrackOutput id3Output) {
+    this(output, id3Output, -1);
+  }
+
+  public AdtsReader(TrackOutput output, TrackOutput id3Output, int overrideAudioObjectType) {
     super(output);
     this.id3Output = id3Output;
     id3Output.format(MediaFormat.createId3Format());
     adtsScratch = new ParsableBitArray(new byte[HEADER_SIZE + CRC_SIZE]);
+    this.overrideAudioObjectType = overrideAudioObjectType;
     id3HeaderBuffer = new ParsableByteArray(Arrays.copyOf(ID3_IDENTIFIER, ID3_HEADER_SIZE));
     setFindingSampleState();
   }
@@ -255,6 +261,9 @@ import java.util.Collections;
       adtsScratch.skipBits(1);
       int channelConfig = adtsScratch.readBits(3);
 
+      if (overrideAudioObjectType != -1) {
+        audioObjectType = overrideAudioObjectType;
+      }
       byte[] audioSpecificConfig = CodecSpecificDataUtil.buildAacAudioSpecificConfig(
           audioObjectType, sampleRateIndex, channelConfig);
       Pair<Integer, Integer> audioParams = CodecSpecificDataUtil.parseAacAudioSpecificConfig(

--- a/library/src/main/java/com/google/android/exoplayer/extractor/ts/TsExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/ts/TsExtractor.java
@@ -66,6 +66,8 @@ public final class TsExtractor implements Extractor {
 
   private final PtsTimestampAdjuster ptsTimestampAdjuster;
   private final int workaroundFlags;
+  private final int overrideAacObjectType;
+
   private final ParsableByteArray tsPacketBuffer;
   private final ParsableBitArray tsScratch;
   /* package */ final SparseArray<TsPayloadReader> tsPayloadReaders; // Indexed by pid
@@ -84,8 +86,13 @@ public final class TsExtractor implements Extractor {
   }
 
   public TsExtractor(PtsTimestampAdjuster ptsTimestampAdjuster, int workaroundFlags) {
+    this(ptsTimestampAdjuster, workaroundFlags, -1);
+  }
+
+  public TsExtractor(PtsTimestampAdjuster ptsTimestampAdjuster, int workaroundFlags, int overrideAacObjectType) {
     this.ptsTimestampAdjuster = ptsTimestampAdjuster;
     this.workaroundFlags = workaroundFlags;
+    this.overrideAacObjectType = overrideAacObjectType;
     tsPacketBuffer = new ParsableByteArray(TS_PACKET_SIZE);
     tsScratch = new ParsableBitArray(new byte[3]);
     tsPayloadReaders = new SparseArray<>();
@@ -343,7 +350,7 @@ public final class TsExtractor implements Extractor {
             break;
           case TS_STREAM_TYPE_AAC:
             pesPayloadReader = (workaroundFlags & WORKAROUND_IGNORE_AAC_STREAM) != 0 ? null
-                : new AdtsReader(output.track(TS_STREAM_TYPE_AAC), new DummyTrackOutput());
+                : new AdtsReader(output.track(TS_STREAM_TYPE_AAC), new DummyTrackOutput(), overrideAacObjectType);
             break;
           case TS_STREAM_TYPE_AC3:
             pesPayloadReader = new Ac3Reader(output.track(TS_STREAM_TYPE_AC3), false);

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -136,6 +136,7 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
   private final ArrayList<ExposedTrack> tracks;
 
   private int selectedTrackIndex;
+  private int overrideAacObjectType = -1;
 
   // A list of variants considered during playback, ordered by decreasing bandwidth. The following
   // three arrays are of the same length and are ordered in the same way (i.e. variantPlaylists[i],
@@ -229,6 +230,13 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
       masterPlaylist = new HlsMasterPlaylist(playlistUrl, variants,
           Collections.<Variant>emptyList(), Collections.<Variant>emptyList(), null, null);
     }
+  }
+
+  /**
+   * Somehow some streams have the wrong signaling and forcing the AAC object type make them works
+   */
+  public void setOverrideAacObjectType(int overrideAacObjectType) {
+    this.overrideAacObjectType = overrideAacObjectType;
   }
 
   /**
@@ -517,6 +525,7 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
         return;
       }
       int workaroundFlags = 0;
+
       String codecs = format.codecs;
       if (!TextUtils.isEmpty(codecs)) {
         // Sometimes AAC and H264 streams are declared in TS chunks even though they don't really
@@ -529,7 +538,7 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
           workaroundFlags |= TsExtractor.WORKAROUND_IGNORE_H264_STREAM;
         }
       }
-      Extractor extractor = new TsExtractor(timestampAdjuster, workaroundFlags);
+      Extractor extractor = new TsExtractor(timestampAdjuster, workaroundFlags, overrideAacObjectType);
       ExposedTrack selectedTrack = tracks.get(selectedTrackIndex);
       extractorWrapper = new HlsExtractorWrapper(trigger, format, startTimeUs, extractor,
           switchingVariantSpliced, selectedTrack.adaptiveMaxWidth, selectedTrack.adaptiveMaxHeight);


### PR DESCRIPTION
The AAC ADTS header codes objectType on 2 bits which is not enough for object types above 4 like HE-AAC (AAC_SBR = 5). This patch is certainly not a perfect solution but at least it makes some streams playable.  Some other projects have similar workarounds. For an example: https://github.com/dailymotion/hls.js/blob/ce96495c701482308d2cb57d50259bcd8e2bc506/src/demux/adts.js#L51.