### PR TITLE
Expose NAME of transmuxed audio tracks as trackId

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/MediaFormat.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaFormat.java
@@ -15,12 +15,12 @@
  */
 package com.google.android.exoplayer;
 
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+
 import com.google.android.exoplayer.util.Assertions;
 import com.google.android.exoplayer.util.MimeTypes;
 import com.google.android.exoplayer.util.Util;
-
-import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -256,8 +256,8 @@ public final class MediaFormat {
         encoderPadding);
   }
 
-  public MediaFormat copyWithLanguage(String language) {
-    return new MediaFormat(trackId, mimeType, bitrate, maxInputSize, durationUs, width, height,
+  public MediaFormat copyWithLanguageAndName(String name, String language) {
+    return new MediaFormat(name, mimeType, bitrate, maxInputSize, durationUs, width, height,
         rotationDegrees, pixelWidthHeightRatio, channelCount, sampleRate, language,
         subsampleOffsetUs, initializationData, adaptive, maxWidth, maxHeight, encoderDelay,
         encoderPadding);

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -227,7 +227,7 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
       List<Variant> variants = new ArrayList<>();
       variants.add(new Variant(playlistUrl, format));
       masterPlaylist = new HlsMasterPlaylist(playlistUrl, variants,
-          Collections.<Variant>emptyList(), Collections.<Variant>emptyList(), null, null);
+          Collections.<Variant>emptyList(), Collections.<Variant>emptyList(), null, null, null);
     }
   }
 
@@ -306,6 +306,15 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
   public Variant getFixedTrackVariant(int index) {
     Variant[] variants = tracks.get(index).variants;
     return variants.length == 1 ? variants[0] : null;
+  }
+
+  /**
+   * Returns the name of the audio muxed into variants, or null if unknown.
+   *
+   * @return The name of the audio muxed into variants, or null if unknown.
+   */
+  public String getMuxedAudioName() {
+    return masterPlaylist.muxedAudioName;
   }
 
   /**

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsMasterPlaylist.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsMasterPlaylist.java
@@ -27,16 +27,18 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
   public final List<Variant> audios;
   public final List<Variant> subtitles;
 
+  public final String muxedAudioName;
   public final String muxedAudioLanguage;
   public final String muxedCaptionLanguage;
 
   public HlsMasterPlaylist(String baseUri, List<Variant> variants,
-      List<Variant> audios, List<Variant> subtitles, String muxedAudioLanguage,
+      List<Variant> audios, List<Variant> subtitles, String muxedAudioName, String muxedAudioLanguage,
       String muxedCaptionLanguage) {
     super(baseUri, HlsPlaylist.TYPE_MASTER);
     this.variants = Collections.unmodifiableList(variants);
     this.audios = Collections.unmodifiableList(audios);
     this.subtitles = Collections.unmodifiableList(subtitles);
+    this.muxedAudioName = muxedAudioName;
     this.muxedAudioLanguage = muxedAudioLanguage;
     this.muxedCaptionLanguage = muxedCaptionLanguage;
   }

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -150,6 +150,7 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
     int width = -1;
     int height = -1;
     String name = null;
+    String muxedAudioName = null;
     String muxedAudioLanguage = null;
     String muxedCaptionLanguage = null;
 
@@ -177,12 +178,13 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
           // We assume all audios belong to the same group.
           String language = HlsParserUtil.parseOptionalStringAttr(line, LANGUAGE_ATTR_REGEX);
           String uri = HlsParserUtil.parseOptionalStringAttr(line, URI_ATTR_REGEX);
+          String audioName = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
           if (uri != null) {
-            String audioName = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
             Format format = new Format(audioName, MimeTypes.APPLICATION_M3U8, -1, -1, -1, -1, -1,
                 -1, language, codecs);
             audios.add(new Variant(uri, format));
           } else {
+            muxedAudioName = audioName;
             muxedAudioLanguage = language;
           }
         }
@@ -224,8 +226,8 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
         expectingStreamInfUrl = false;
       }
     }
-    return new HlsMasterPlaylist(baseUri, variants, audios, subtitles, muxedAudioLanguage,
-        muxedCaptionLanguage);
+    return new HlsMasterPlaylist(baseUri, variants, audios, subtitles, muxedAudioName,
+        muxedAudioLanguage, muxedCaptionLanguage);
   }
 
   private static HlsMediaPlaylist parseMediaPlaylist(LineIterator iterator, String baseUri)

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsSampleSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsSampleSource.java
@@ -542,8 +542,10 @@ public final class HlsSampleSource implements SampleSource, SampleSourceReader, 
     int trackIndex = 0;
     for (int i = 0; i < extractorTrackCount; i++) {
       MediaFormat format = extractor.getMediaFormat(i).copyWithDurationUs(durationUs);
+      String name = null;
       String language = null;
       if (MimeTypes.isAudio(format.mimeType)) {
+        name = chunkSource.getMuxedAudioName();
         language = chunkSource.getMuxedAudioLanguage();
       } else if (MimeTypes.APPLICATION_EIA608.equals(format.mimeType)) {
         language = chunkSource.getMuxedCaptionLanguage();
@@ -559,7 +561,7 @@ public final class HlsSampleSource implements SampleSource, SampleSourceReader, 
       } else {
         extractorTrackIndices[trackIndex] = i;
         chunkSourceTrackIndices[trackIndex] = -1;
-        trackFormats[trackIndex++] = format.copyWithLanguage(language);
+        trackFormats[trackIndex++] = format.copyWithLanguageAndName(name, language);
       }
     }
   }


### PR DESCRIPTION
This change exposes the NAME of the audio rendition as trackId for transmuxed audio tracks, similar to external audio renditions.

Example:
Given the following playlist segment from "Apple master playlist advanced" in the Samples:

```
#EXTM3U
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="bipbop_audio",LANGUAGE="eng",NAME="BipBop Audio 1",AUTOSELECT=YES,DEFAULT=YES
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="bipbop_audio",LANGUAGE="eng",NAME="BipBop Audio 2",AUTOSELECT=NO,DEFAULT=NO,URI="alternate_audio_aac_sinewave/prog_index.m3u8"
```

The first audio rendition's MediaFormat.trackId would be null, and the second audio rendition's trackId would be "BipBop Audio 2". As of this change the first audio rendition's trackId will be set to "BipBop Audio 1", similar to the external audio rendition.