### PR TITLE
Allow derived classes of `HlsChuckSource` to override the default ada…

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -626,17 +626,11 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
       }
     });
 
-    int defaultVariantIndex = 0;
+    int defaultVariantIndex = computeDefaultVariantIndex(playlist, variants, bandwidthMeter);
     int maxWidth = -1;
     int maxHeight = -1;
 
-    int minOriginalVariantIndex = Integer.MAX_VALUE;
     for (int i = 0; i < variants.length; i++) {
-      int originalVariantIndex = playlist.variants.indexOf(variants[i]);
-      if (originalVariantIndex < minOriginalVariantIndex) {
-        minOriginalVariantIndex = originalVariantIndex;
-        defaultVariantIndex = i;
-      }
       Format variantFormat = variants[i].format;
       maxWidth = Math.max(variantFormat.width, maxWidth);
       maxHeight = Math.max(variantFormat.height, maxHeight);
@@ -653,6 +647,21 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
     tracks.add(new ExposedTrack(variant));
   }
 
+  protected int computeDefaultVariantIndex(HlsMasterPlaylist playlist, Variant[] variants, BandwidthMeter bandwidthMeter) {
+    int defaultVariantIndex = 0;
+    int minOriginalVariantIndex = Integer.MAX_VALUE;
+
+    for (int i = 0; i < variants.length; i++) {
+      int originalVariantIndex = playlist.variants.indexOf(variants[i]);
+      if (originalVariantIndex < minOriginalVariantIndex) {
+        minOriginalVariantIndex = originalVariantIndex;
+        defaultVariantIndex = i;
+      }
+    }
+
+    return  defaultVariantIndex;
+  }
+  
   // Private methods.
 
   private int getNextVariantIndex(TsChunk previousTsChunk, long playbackPositionUs) {

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -647,7 +647,8 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
     tracks.add(new ExposedTrack(variant));
   }
 
-  protected int computeDefaultVariantIndex(HlsMasterPlaylist playlist, Variant[] variants, BandwidthMeter bandwidthMeter) {
+  protected int computeDefaultVariantIndex(HlsMasterPlaylist playlist, Variant[] variants,
+      BandwidthMeter bandwidthMeter) {
     int defaultVariantIndex = 0;
     int minOriginalVariantIndex = Integer.MAX_VALUE;
 


### PR DESCRIPTION
Allow derived classes of `HlsChuckSource` to override the default adaptive variant index.  e.g. when wanting to make the default adaptive stream a function of the current bandwidth meter instead of the initial (suggested) stream.