### PR TITLE
Remove break statement when end list tag found by hls playlist parser

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -306,7 +306,6 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
         segmentByterangeLength = C.LENGTH_UNBOUNDED;
       } else if (line.equals(ENDLIST_TAG)) {
         live = false;
-        break;
       }
     }
     return new HlsMediaPlaylist(baseUri, mediaSequence, targetDurationSecs, version, live,


### PR DESCRIPTION
The http live streaming draft(https://www.ietf.org/id/draft-pantos-http-live-streaming-19.txt) specifies that the EXT-X-ENDLIST may appear anywhere in the media playlist file. In case of ExoPlayer's HlsPlaylistParser's parseMediaPlaylist() would stop parsing the file when the end list tag is found due to the break statement. The end list tag may appear anywhere if the break statement is removed.