### PR TITLE
Add interface and implementation for volume control

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer/demo/PlayerActivity.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/PlayerActivity.java
@@ -69,6 +69,7 @@ import android.widget.Button;
 import android.widget.MediaController;
 import android.widget.PopupMenu;
 import android.widget.PopupMenu.OnMenuItemClickListener;
+import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -107,6 +108,7 @@ public class PlayerActivity extends Activity implements SurfaceHolder.Callback, 
   private MediaController mediaController;
   private View debugRootView;
   private View shutterView;
+  private View volumeRootView;
   private AspectRatioFrameLayout videoFrame;
   private SurfaceView surfaceView;
   private TextView debugTextView;
@@ -116,6 +118,8 @@ public class PlayerActivity extends Activity implements SurfaceHolder.Callback, 
   private Button audioButton;
   private Button textButton;
   private Button retryButton;
+  private SeekBar volumeControl;
+  private TextView volumeValue;
 
   private DemoPlayer player;
   private DebugTextViewHelper debugViewHelper;
@@ -163,7 +167,8 @@ public class PlayerActivity extends Activity implements SurfaceHolder.Callback, 
 
     shutterView = findViewById(R.id.shutter);
     debugRootView = findViewById(R.id.controls_root);
-
+    volumeRootView = findViewById(R.id.volume_controls_root);
+    
     videoFrame = (AspectRatioFrameLayout) findViewById(R.id.video_frame);
     surfaceView = (SurfaceView) findViewById(R.id.surface_view);
     surfaceView.getHolder().addCallback(this);
@@ -179,6 +184,28 @@ public class PlayerActivity extends Activity implements SurfaceHolder.Callback, 
     videoButton = (Button) findViewById(R.id.video_controls);
     audioButton = (Button) findViewById(R.id.audio_controls);
     textButton = (Button) findViewById(R.id.text_controls);
+    volumeControl = (SeekBar) findViewById(R.id.volume_control);
+    volumeValue = (TextView) findViewById(R.id.volume_value);
+
+    volumeControl.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+      @Override
+      public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+        if (player != null) {
+          player.setVolume(progress / (float)seekBar.getMax());
+          volumeValue.setText(String.format("%.2f", player.getVolume()));
+        }
+      }
+
+      @Override
+      public void onStartTrackingTouch(SeekBar seekBar) {
+
+      }
+
+      @Override
+      public void onStopTrackingTouch(SeekBar seekBar) {
+
+      }
+    });
 
     CookieHandler currentHandler = CookieHandler.getDefault();
     if (currentHandler != defaultCookieManager) {
@@ -467,6 +494,9 @@ public class PlayerActivity extends Activity implements SurfaceHolder.Callback, 
     videoButton.setVisibility(haveTracks(DemoPlayer.TYPE_VIDEO) ? View.VISIBLE : View.GONE);
     audioButton.setVisibility(haveTracks(DemoPlayer.TYPE_AUDIO) ? View.VISIBLE : View.GONE);
     textButton.setVisibility(haveTracks(DemoPlayer.TYPE_TEXT) ? View.VISIBLE : View.GONE);
+
+    volumeValue.setText(Float.toString(player.getVolume()));
+    volumeControl.setProgress((int)(player.getVolume() * volumeControl.getMax()));
   }
 
   private boolean haveTracks(int type) {
@@ -615,6 +645,7 @@ public class PlayerActivity extends Activity implements SurfaceHolder.Callback, 
     if (mediaController.isShowing()) {
       mediaController.hide();
       debugRootView.setVisibility(View.GONE);
+      volumeRootView.setVisibility(View.GONE);
     } else {
       showControls();
     }
@@ -623,6 +654,7 @@ public class PlayerActivity extends Activity implements SurfaceHolder.Callback, 
   private void showControls() {
     mediaController.show(0);
     debugRootView.setVisibility(View.VISIBLE);
+    volumeRootView.setVisibility(View.VISIBLE);
   }
 
   // DemoPlayer.CaptionListener implementation

--- a/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
+++ b/demo/src/main/java/com/google/android/exoplayer/demo/player/DemoPlayer.java
@@ -600,4 +600,11 @@ public class DemoPlayer implements ExoPlayer.Listener, ChunkSampleSource.EventLi
     }
   }
 
+  public float getVolume() {
+    return player.getVolume();
+  }
+
+  public void setVolume(float gain) {
+    player.setVolume(gain);
+  }
 }

--- a/demo/src/main/res/layout/player_activity.xml
+++ b/demo/src/main/res/layout/player_activity.xml
@@ -65,10 +65,10 @@
         tools:ignore="SmallSp"/>
 
     <LinearLayout android:id="@+id/controls_root"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:visibility="gone">
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:orientation="horizontal"
+                  android:visibility="gone">
 
       <Button android:id="@+id/video_controls"
           android:layout_width="wrap_content"
@@ -107,6 +107,32 @@
           android:text="@string/retry"
           android:visibility="gone"
           style="@style/DemoButton"/>
+
+    </LinearLayout>
+
+    <LinearLayout android:id="@+id/volume_controls_root"
+                  android:orientation="horizontal"
+                  android:layout_width="match_parent"
+                  android:layout_height="wrap_content"
+                  android:visibility="gone">
+
+      <TextView android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:text="@string/volume"
+                android:id="@+id/textView"/>
+
+      <SeekBar android:id="@+id/volume_control"
+               android:layout_width="wrap_content"
+               android:layout_height="wrap_content"
+               android:max="20"
+               android:layout_weight="1"/>
+
+      <TextView android:id="@+id/volume_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:text="1.0"/>
 
     </LinearLayout>
 

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -21,6 +21,8 @@
 
   <string name="enable_background_audio">Play in background</string>
 
+  <string name="volume">Volume</string>
+
   <string name="video">Video</string>
 
   <string name="audio">Audio</string>

--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayer.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayer.java
@@ -354,6 +354,19 @@ public interface ExoPlayer {
   public void stop();
 
   /**
+   * Sets the specified output gain value on all channels of this track.
+   * <p>Gain values are clamped to the closed interval [0.0, 1.0]
+   * A value of 0.0 results in zero gain (silence), and
+   * a value of 1.0 means unity gain (signal unchanged).
+   * The default value is 1.0 meaning unity gain.
+   * <p>The word "volume" in the API name is historical; this is actually a linear gain.
+   * Sited from {@link android.media.AudioTrack#setVolume(float)}
+   *
+   * @param gain output gain for all channels.
+   */
+  public void setVolume(float gain);
+
+  /**
    * Releases the player. This method must be called when the player is no longer required.
    * <p>
    * The player must not be used after calling this method.

--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayer.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayer.java
@@ -354,7 +354,7 @@ public interface ExoPlayer {
   public void stop();
 
   /**
-   * Sets the specified output gain value on all channels of this track.
+   * Sets the specified output gain value on all channels of audio track.
    * <p>Gain values are clamped to the closed interval [0.0, 1.0]
    * A value of 0.0 results in zero gain (silence), and
    * a value of 1.0 means unity gain (signal unchanged).
@@ -365,6 +365,18 @@ public interface ExoPlayer {
    * @param gain output gain for all channels.
    */
   public void setVolume(float gain);
+
+  /**
+   * Gets the specified output gain value on all channels of audio track.
+   * <p>Gain values are clamped to the closed interval [0.0, 1.0]
+   * A value of 0.0 results in zero gain (silence), and
+   * a value of 1.0 means unity gain (signal unchanged).
+   * The default value is 1.0 meaning unity gain.
+   * <p>The word "volume" in the API name is historical; this is actually a linear gain.
+   *
+   * @return output gain for all audio track channels
+   */
+  public float getVolume();
 
   /**
    * Releases the player. This method must be called when the player is no longer required.

--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayerImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayerImpl.java
@@ -152,6 +152,11 @@ import java.util.concurrent.CopyOnWriteArraySet;
   }
 
   @Override
+  public void setVolume(float gain) {
+    internalPlayer.setVolume(Math.max(0f, Math.min(gain, 1.0f)));
+  }
+
+  @Override
   public void release() {
     internalPlayer.release();
     eventHandler.removeCallbacksAndMessages(null);

--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayerImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayerImpl.java
@@ -157,6 +157,9 @@ import java.util.concurrent.CopyOnWriteArraySet;
   }
 
   @Override
+  public float getVolume() { return internalPlayer.getVolume(); }
+
+  @Override
   public void release() {
     internalPlayer.release();
     eventHandler.removeCallbacksAndMessages(null);

--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayerImplInternal.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayerImplInternal.java
@@ -87,6 +87,7 @@ import java.util.concurrent.atomic.AtomicInteger;
   private int customMessagesProcessed = 0;
   private long lastSeekPositionMs;
   private long elapsedRealtimeUs;
+  private float volume;
 
   private volatile long durationUs;
   private volatile long positionUs;
@@ -153,8 +154,11 @@ import java.util.concurrent.atomic.AtomicInteger;
   }
 
   public void setVolume(float gain) {
-    handler.obtainMessage(MSG_SET_VOLUME, gain).sendToTarget();
+    volume = gain;
+    handler.obtainMessage(MSG_SET_VOLUME, volume).sendToTarget();
   }
+
+  public float getVolume() { return volume; }
 
   public void setRendererSelectedTrack(int rendererIndex, int trackIndex) {
     handler.obtainMessage(MSG_SET_RENDERER_SELECTED_TRACK, rendererIndex, trackIndex)

--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayerImplInternal.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayerImplInternal.java
@@ -87,7 +87,7 @@ import java.util.concurrent.atomic.AtomicInteger;
   private int customMessagesProcessed = 0;
   private long lastSeekPositionMs;
   private long elapsedRealtimeUs;
-  private float volume;
+  private float volume = 1.0f;
 
   private volatile long durationUs;
   private volatile long positionUs;
@@ -231,7 +231,7 @@ import java.util.concurrent.atomic.AtomicInteger;
           return true;
         }
         case MSG_SET_VOLUME: {
-          setVolumeInternal(msg.arg1);
+          setVolumeInternal((float)msg.obj);
           return true;
         }
         case MSG_RELEASE: {

--- a/library/src/main/java/com/google/android/exoplayer/ExoPlayerImplInternal.java
+++ b/library/src/main/java/com/google/android/exoplayer/ExoPlayerImplInternal.java
@@ -58,6 +58,7 @@ import java.util.concurrent.atomic.AtomicInteger;
   private static final int MSG_DO_SOME_WORK = 7;
   private static final int MSG_SET_RENDERER_SELECTED_TRACK = 8;
   private static final int MSG_CUSTOM = 9;
+  private static final int MSG_SET_VOLUME = 10;
 
   private static final int PREPARE_INTERVAL_MS = 10;
   private static final int RENDERING_INTERVAL_MS = 10;
@@ -151,6 +152,10 @@ import java.util.concurrent.atomic.AtomicInteger;
     handler.sendEmptyMessage(MSG_STOP);
   }
 
+  public void setVolume(float gain) {
+    handler.obtainMessage(MSG_SET_VOLUME, gain).sendToTarget();
+  }
+
   public void setRendererSelectedTrack(int rendererIndex, int trackIndex) {
     handler.obtainMessage(MSG_SET_RENDERER_SELECTED_TRACK, rendererIndex, trackIndex)
         .sendToTarget();
@@ -219,6 +224,10 @@ import java.util.concurrent.atomic.AtomicInteger;
         }
         case MSG_STOP: {
           stopInternal();
+          return true;
+        }
+        case MSG_SET_VOLUME: {
+          setVolumeInternal(msg.arg1);
           return true;
         }
         case MSG_RELEASE: {
@@ -527,6 +536,15 @@ import java.util.concurrent.atomic.AtomicInteger;
   private void stopInternal() {
     resetInternal();
     setState(ExoPlayer.STATE_IDLE);
+  }
+
+  private void setVolumeInternal(float gain) {
+    for (int i = 0; i < enabledRenderers.size(); i++) {
+      TrackRenderer renderer = enabledRenderers.get(i);
+      if (renderer instanceof MediaCodecAudioTrackRenderer) {
+        sendMessage(renderer, MediaCodecAudioTrackRenderer.MSG_SET_VOLUME, gain);
+      }
+    }
   }
 
   private void releaseInternal() {


### PR DESCRIPTION
Someone issued google/ExoPlayer#368 regarding audio modification and a response was posted that MediaCodecAudioTrackRenderer can be used to carry out the task. But the ability to set volume for a player was thought to be a common task. The MediaPlayer provided in Android SDK also has an interface to set its volume, so an attempt was made to add interface and implementation for volume control. Only difference with MediaPlayer with volume controlling interface is that it also has a getVolume method along with setVolume.

Volume controls are added to PlayerActivity in order to demonstrate use of the interface and correct implementation.