### PR TITLE
prevent null exception in case previousTsLoadable == null

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsSampleSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsSampleSource.java
@@ -756,7 +756,9 @@ public final class HlsSampleSource implements SampleSource, SampleSourceReader, 
       return pendingResetPositionUs;
     } else {
       return loadingFinished || (prepared && enabledTrackCount == 0) ? -1
-          : currentTsLoadable != null ? currentTsLoadable.endTimeUs : previousTsLoadable.endTimeUs;
+         : (currentTsLoadable  != null) ? currentTsLoadable.endTimeUs
+         : (previousTsLoadable != null) ? previousTsLoadable.endTimeUs : -1;
+
     }
   }
 


### PR DESCRIPTION
In order to avoid the following NPE:

Happens from time to time when pressing back button during playback.

 E/AndroidRuntime: FATAL EXCEPTION: ExoPlayerImplInternal:Handler
                                                                             Process: com.kaltura.basicplayerdemo, PID: 15803
                                                                             java.lang.NullPointerException: Attempt to read from field 'long com.google.android.exoplayer.chunk.MediaChunk.endTimeUs' on a null object reference
                                                                                 at com.google.android.exoplayer.hls.HlsSampleSource.getNextLoadPositionUs(HlsSampleSource.java:754)
                                                                                 at com.google.android.exoplayer.hls.HlsSampleSource.maybeStartLoading(HlsSampleSource.java:687)
                                                                                 at com.google.android.exoplayer.hls.HlsSampleSource.restartFrom(HlsSampleSource.java:665)
                                                                                 at com.google.android.exoplayer.hls.HlsSampleSource.onLoadCanceled(HlsSampleSource.java:441)
                                                                                 at com.google.android.exoplayer.upstream.Loader$LoadTask.handleMessage(Loader.java:240)
                                                                                 at android.os.Handler.dispatchMessage(Handler.java:102)
                                                                                 at android.os.Looper.loop(Looper.java:148)
                                                                                 at android.os.HandlerThread.run(HandlerThread.java:61)
                                                                                 at com.google.android.exoplayer.util.PriorityHandlerThread.run(PriorityHandlerThread.java:40)