### PR TITLE
Support seeking on CBR files when a partial Xing header is supplied but no Table of Contents

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/extractor/mp3/XingSeeker.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/mp3/XingSeeker.java
@@ -54,7 +54,7 @@ import com.google.android.exoplayer.util.Util;
         sampleRate);
     if ((flags & 0x06) != 0x06) {
       // If the size in bytes or table of contents is missing, the stream is not seekable.
-      return new XingSeeker(firstFramePosition, durationUs, inputLength);
+      return null;
     }
 
     long sizeBytes = frame.readUnsignedIntToInt();


### PR DESCRIPTION
Hi,

This PR makes a change in XingHeader.create() to force a fallback to ConstantBitrateSeeker (by returning NULL in XingSeeker) when the Xing/Info header field is present, but does not contain the Table of Contents (TOC) bytes.

This allows CBR files to be seekable even if the Xing/Info header is absent or does not contain the optional TOC bytes.

By returning NULL, we end up using the ConsistentBitrateSeeker via https://github.com/google/ExoPlayer/blob/master/library/src/main/java/com/google/android/exoplayer/extractor/mp3/Mp3Extractor.java#L313

In my experience, the implementation details of which players (across Chrome browser, Firefox, IE, iOS, etc) support seeking in CBR files varies, and various platforms and software packages can output files with or without these headers filled in completely.

By supporting this edge case, more audio files will become seekable when supported.