### PR TITLE
Fix H.264 intra refresh live stream playback problem (issue #1654)

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/C.java
+++ b/library/src/main/java/com/google/android/exoplayer2/C.java
@@ -143,6 +143,11 @@ public interface C {
   int BUFFER_FLAG_DECODE_ONLY = 0x80000000;
 
   /**
+   * H.264 may be with intra-refresh enabled.
+   */
+  int BUFFER_FLAG_INTRA_REFRESH = 0x02000000;
+
+  /**
    * A return value for methods where the end of an input was encountered.
    */
   int RESULT_END_OF_INPUT = -1;

--- a/library/src/main/java/com/google/android/exoplayer2/decoder/Buffer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/decoder/Buffer.java
@@ -87,7 +87,7 @@ public abstract class Buffer {
    * @param flag The flag to check.
    * @return Whether the flag is set.
    */
-  protected final boolean getFlag(int flag) {
+  public final boolean getFlag(int flag) {
     return (flags & flag) == flag;
   }
 

--- a/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultTrackOutput.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultTrackOutput.java
@@ -521,7 +521,7 @@ public final class DefaultTrackOutput implements TrackOutput {
         pendingSplice = false;
       }
       if (needKeyframe) {
-        if ((flags & C.BUFFER_FLAG_KEY_FRAME) == 0) {
+        if ((flags & C.BUFFER_FLAG_KEY_FRAME) == 0 && (flags & C.BUFFER_FLAG_INTRA_REFRESH) == 0) {
           // TODO - As above, although this case is probably less worthwhile.
           return;
         }

--- a/library/src/main/java/com/google/android/exoplayer2/extractor/ts/TsExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/ts/TsExtractor.java
@@ -98,7 +98,7 @@ public final class TsExtractor implements Extractor {
   }
 
   public TsExtractor(PtsTimestampAdjuster ptsTimestampAdjuster) {
-    this(ptsTimestampAdjuster, 0);
+    this(ptsTimestampAdjuster, WORKAROUND_ALLOW_NON_IDR_KEYFRAMES);
   }
 
   public TsExtractor(PtsTimestampAdjuster ptsTimestampAdjuster, int workaroundFlags) {

--- a/library/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -441,6 +441,8 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     }
   }
 
+  protected final Format getFormat() { return format; }
+
   @Override
   protected void onStarted() {
     // Do nothing. Overridden to remove throws clause.
@@ -850,7 +852,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         return false;
       }
     }
-
     if (processOutputBuffer(positionUs, elapsedRealtimeUs, codec, outputBuffers[outputIndex],
         outputIndex, outputBufferInfo.flags, outputBufferInfo.presentationTimeUs,
         shouldSkipOutputBuffer)) {


### PR DESCRIPTION
Fix #1654 .

Follow @andrewlewis's suggestion to synthesize a key frame for the stream. The main limitaion is that not all resolutions that MediaCodec decoders support are also supported by MediaCodec encoders, so high resolution video stream may still not playable (the limit is ~1280x720 on my device). 

Videos with color formats other than YUV420 may also not work. I have no idea how to figure out the actually color format of an input buffer and always assume YUV420.
