### PR TITLE
Implement variable playback speed.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/ExoPlayer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ExoPlayer.java
@@ -366,4 +366,13 @@ public interface ExoPlayer {
    */
   int getBufferedPercentage();
 
+  /**
+   * @return the speed factor: speed_of_playback / speed_of_real_clock
+   */
+  float getPlaybackSpeed();
+
+  /**
+   * @param speed the speed factor: speed_of_playback / speed_of_real_clock
+   */
+  void setPlaybackSpeed(float speed);
 }

--- a/library/src/main/java/com/google/android/exoplayer2/ExoPlayerImpl.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ExoPlayerImpl.java
@@ -206,6 +206,12 @@ import java.util.concurrent.CopyOnWriteArraySet;
         : (int) (duration == 0 ? 100 : (bufferedPosition * 100) / duration);
   }
 
+  @Override
+  public float getPlaybackSpeed() { return internalPlayer.getPlaybackSpeed(); }
+
+  @Override
+  public void setPlaybackSpeed(float speed) { internalPlayer.setPlaybackSpeed(speed); }
+
   // Not private so it can be called from an inner class without going through a thunk method.
   /* package */ void handleEvent(Message msg) {
     switch (msg.what) {

--- a/library/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
@@ -399,6 +399,12 @@ public final class SimpleExoPlayer implements ExoPlayer {
     return player.getBufferedPercentage();
   }
 
+  @Override
+  public float getPlaybackSpeed() { return player.getPlaybackSpeed(); }
+
+  @Override
+  public void setPlaybackSpeed(float speed) { player.setPlaybackSpeed(speed); }
+
   // Internal methods.
 
   private void buildRenderers(Context context, DrmSessionManager drmSessionManager,
@@ -613,7 +619,6 @@ public final class SimpleExoPlayer implements ExoPlayer {
         id3MetadataListener.onId3Metadata(id3Frames);
       }
     }
-
   }
 
 }

--- a/library/src/main/java/com/google/android/exoplayer2/audio/AudioTrack.java
+++ b/library/src/main/java/com/google/android/exoplayer2/audio/AudioTrack.java
@@ -325,6 +325,14 @@ public final class AudioTrack {
   }
 
   /**
+   * Returns the configured playback speed according to the used Playback Parameters. If these are
+   * not supported, 1.0f(normal speed) is returned.
+   *
+   * @return The speed factor used by the underlying {@link android.media.AudioTrack}.
+   */
+  public float getPlaybackSpeed() { return audioTrackUtil.getPlaybackSpeed(); }
+
+  /**
    * Configures (or reconfigures) the audio track, inferring a suitable buffer size automatically.
    *
    * @param mimeType The mime type.

--- a/library/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java
@@ -320,6 +320,9 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
   }
 
   @Override
+  public float getPlaybackSpeed() {  return audioTrack.getPlaybackSpeed(); }
+
+  @Override
   protected boolean processOutputBuffer(long positionUs, long elapsedRealtimeUs, MediaCodec codec,
       ByteBuffer buffer, int bufferIndex, int bufferFlags, long bufferPresentationTimeUs,
       boolean shouldSkip) throws ExoPlaybackException {

--- a/library/src/main/java/com/google/android/exoplayer2/audio/SimpleDecoderAudioRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/audio/SimpleDecoderAudioRenderer.java
@@ -101,7 +101,6 @@ public abstract class SimpleDecoderAudioRenderer extends BaseRenderer implements
     if (outputStreamEnded) {
       return;
     }
-
     // Try and read a format if we don't have one already.
     if (inputFormat == null && !readFormat()) {
       // We can't make progress without one.
@@ -290,6 +289,9 @@ public abstract class SimpleDecoderAudioRenderer extends BaseRenderer implements
     }
     return currentPositionUs;
   }
+
+  @Override
+  public float getPlaybackSpeed() { return 1.0f; }
 
   /**
    * Invoked when the audio session id becomes known. Once the id is known it will not change

--- a/library/src/main/java/com/google/android/exoplayer2/util/MediaClock.java
+++ b/library/src/main/java/com/google/android/exoplayer2/util/MediaClock.java
@@ -25,4 +25,8 @@ public interface MediaClock {
    */
   long getPositionUs();
 
+  /**
+   * @return the speed factor: speed_of_this_clock / speed_of_real_clock
+   */
+  public float getPlaybackSpeed();
 }

--- a/library/src/main/java/com/google/android/exoplayer2/util/StandaloneMediaClock.java
+++ b/library/src/main/java/com/google/android/exoplayer2/util/StandaloneMediaClock.java
@@ -26,15 +26,19 @@ public final class StandaloneMediaClock implements MediaClock {
   private boolean started;
 
   /**
-   * The media time when the clock was last set or stopped.
+   * The media time(ms) on last sync.
    */
-  private long positionUs;
+  private double lastMediaTime;
 
   /**
-   * The difference between {@link SystemClock#elapsedRealtime()} and {@link #positionUs}
-   * when the clock was last set or started.
+   * The {@link SystemClock#elapsedRealtime()} (ms) on last sync.
    */
-  private long deltaUs;
+  private long lastRealTime;
+
+  /*
+   * speed ratio between media time and real time
+   */
+  private double speed = 1.0;
 
   /**
    * Starts the clock. Does nothing if the clock is already started.
@@ -42,7 +46,7 @@ public final class StandaloneMediaClock implements MediaClock {
   public void start() {
     if (!started) {
       started = true;
-      deltaUs = elapsedRealtimeMinus(positionUs);
+      lastRealTime = SystemClock.elapsedRealtime();
     }
   }
 
@@ -51,26 +55,36 @@ public final class StandaloneMediaClock implements MediaClock {
    */
   public void stop() {
     if (started) {
-      positionUs = elapsedRealtimeMinus(deltaUs);
+      updateMediaTime();
       started = false;
     }
+  }
+
+  public float getPlaybackSpeed() { return (float)speed; }
+
+  public void setPlaybackSpeed(float newSpeed) {
+    updateMediaTime();
+    speed = newSpeed;
   }
 
   /**
    * @param timeUs The position to set in microseconds.
    */
   public void setPositionUs(long timeUs) {
-    this.positionUs = timeUs;
-    deltaUs = elapsedRealtimeMinus(timeUs);
+    lastRealTime = SystemClock.elapsedRealtime();
+    lastMediaTime = timeUs / 1000.0;
   }
 
   @Override
   public long getPositionUs() {
-    return started ? elapsedRealtimeMinus(deltaUs) : positionUs;
+    updateMediaTime();
+    return (long)(lastMediaTime * 1000);
   }
 
-  private long elapsedRealtimeMinus(long toSubtractUs) {
-    return SystemClock.elapsedRealtime() * 1000 - toSubtractUs;
+  private void updateMediaTime() {
+    if (!started) return;
+    long realTime = SystemClock.elapsedRealtime();
+    lastMediaTime = lastMediaTime + (realTime - lastRealTime) * speed;
+    lastRealTime = realTime;
   }
-
 }


### PR DESCRIPTION
Add a new API to `ExoPlayer` - `setPlaybackSpeed(fload)/getPlaybackSpeed()`, and also add `getPlaybackSpeed()` to `MediaClock` . If the media has audio and API level >= 23, `android.media.PlaybackParams` is used to change the playback speed; otherwise `StandaloneMediaClock.setPlaybackSpeed(fload)`  is used instead. If API level < 23 and speed is not 1, the audio is jumpy, though the video plays well.

Might fix #26, #1216, #571 .
