### PR TITLE
PAC and Midrow code handling for EIA-608 captions

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
@@ -1,0 +1,203 @@
+package com.google.android.exoplayer2.text.eia608;
+
+import com.google.android.exoplayer2.text.Cue;
+import com.google.android.exoplayer2.util.Assertions;
+
+import android.text.Layout;
+import android.text.SpannableStringBuilder;
+import android.text.Spanned;
+import android.text.style.CharacterStyle;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.StyleSpan;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A Builder for EIA-608 cues.
+ */
+/* package */ final class Eia608CueBuilder {
+
+  private static final int BASE_ROW = 15;
+
+  /**
+   * The caption string.
+   */
+  private SpannableStringBuilder captionStringBuilder;
+
+  /**
+   * The caption styles to apply to the caption string.
+   */
+  private HashMap<Integer, CharacterStyle> captionStyles;
+
+  /**
+   * The row on which the Cue should be displayed.
+   */
+  private int row;
+
+  /**
+   * The indent of the cue - horizontal positioning.
+   */
+  private int indent;
+
+  /**
+   * The setTabOffset offset for the cue.
+   */
+  private int tabOffset;
+
+  public Eia608CueBuilder() {
+    row = BASE_ROW;
+    indent = 0;
+    tabOffset = 0;
+    captionStringBuilder = new SpannableStringBuilder();
+    captionStyles = new HashMap<>();
+  }
+
+  /**
+   * Sets the row for this cue.
+   * @param row the row to set.
+   */
+  public void setRow(int row) {
+    Assertions.checkArgument(row >= 1 && row <= 15);
+    this.row = row;
+  }
+
+  public int getRow() {
+    return row;
+  }
+
+  /**
+   * Rolls up the Cue one row.
+   * @return true if rolling was possible.
+   */
+  public boolean rollUp() {
+    if (row < 1) {
+      return false;
+    }
+    setRow(row - 1);
+    return true;
+  }
+
+  /**
+   * Sets the indent for this cue.
+   * @param indent an indent value, must be a multiple of 4 within the range [0,28]
+   */
+  public void setIndent(int indent) {
+    Assertions.checkArgument(indent % 4 == 0 && indent <= 28);
+    this.indent = indent;
+  }
+
+  public void tab(int tabs) {
+    tabOffset += tabs;
+  }
+
+  /**
+   * Indents the cue position with amountOfTabs.
+   * @param tabOffset the amount of tabs the cue position should be indented.
+   */
+  public void setTabOffset(int tabOffset) {
+    this.tabOffset = tabOffset;
+  }
+
+  /**
+   * Appends a character to the current Cue.
+   * @param character the character to append.
+   */
+  public void append(char character) {
+    captionStringBuilder.append(character);
+  }
+
+  /**
+   * Removes the last character of the caption string.
+   */
+  public void backspace() {
+    if (captionStringBuilder.length() > 0) {
+      captionStringBuilder.delete(captionStringBuilder.length() - 1, captionStringBuilder.length());
+    }
+  }
+
+  /**
+   * Opens a character style at the current cueIndex.
+   * Takes care of style priorities.
+   *
+   * @param style the style to set.
+   */
+  public void setCharacterStyle(CharacterStyle style) {
+    int startIndex = getSpanStartIndex();
+    // Close all open spans of the same type, and add a new one.
+    if (style instanceof ForegroundColorSpan) {
+      // Setting a foreground color clears the italics style.
+      closeSpan(StyleSpan.class); // Italics is a style span.
+    }
+    closeSpan(style.getClass());
+    captionStyles.put(startIndex, style);
+  }
+
+  /**
+   * Closes all open spans of the spansToApply class.
+   * @param spansToClose the class of which the spans should be closed.
+   */
+  private void closeSpan(Class<? extends CharacterStyle> spansToClose) {
+    for (Integer index : captionStyles.keySet()) {
+      CharacterStyle style = captionStyles.get(index);
+      if (spansToClose.isInstance(style)) {
+        if (index < captionStringBuilder.length()) {
+          captionStringBuilder.setSpan(style, index,
+            captionStringBuilder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+        captionStyles.remove(index);
+      }
+    }
+  }
+
+  /**
+   * Applies all currently opened spans to the SpannableStringBuilder.
+   */
+  public void closeSpans() {
+    // Check if we have to do anything.
+    if (captionStyles.size() == 0) {
+      return;
+    }
+
+    for (Integer startIndex : captionStyles.keySet()) {
+      // There may be cases, e.g. when seeking where the startIndex becomes greater
+      // than what is actually in the string builder, in that case, just discard the span.
+      if (startIndex < captionStringBuilder.length()) {
+        CharacterStyle captionStyle = captionStyles.get(startIndex);
+        captionStringBuilder.setSpan(captionStyle, startIndex,
+          captionStringBuilder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+      }
+      captionStyles.remove(startIndex);
+    }
+  }
+
+  public Cue build() {
+    closeSpans();
+    float cueLine = 10 + (5.33f * row);
+    float cuePosition = 10 + (2.5f * indent);
+    cuePosition = (tabOffset * 2.5f) + cuePosition;
+    return new Cue(captionStringBuilder, Layout.Alignment.ALIGN_NORMAL, cueLine / 100, Cue.LINE_TYPE_FRACTION,
+      Cue.ANCHOR_TYPE_START, cuePosition / 100, Cue.TYPE_UNSET, Cue.DIMEN_UNSET);
+  }
+
+  private int getSpanStartIndex() {
+    return captionStringBuilder.length() > 0 ? captionStringBuilder.length() - 1 : 0;
+  }
+
+  public static List<Cue> buildCues(List<Eia608CueBuilder> builders) {
+    if (builders.isEmpty()) {
+      return Collections.emptyList();
+    }
+    LinkedList<Cue> cues = new LinkedList<>();
+    for (Eia608CueBuilder builder : builders) {
+      if (builder.captionStringBuilder.length() == 0) {
+        continue;
+      }
+      cues.add(builder.build());
+    }
+    return cues;
+  }
+
+}

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
@@ -1,14 +1,14 @@
 package com.google.android.exoplayer2.text.eia608;
 
-import com.google.android.exoplayer2.text.Cue;
-import com.google.android.exoplayer2.util.Assertions;
-
 import android.text.Layout;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.CharacterStyle;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
+
+import com.google.android.exoplayer2.text.Cue;
+import com.google.android.exoplayer2.util.Assertions;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -73,7 +73,7 @@ import java.util.List;
    * @return true if rolling was possible.
    */
   public boolean rollUp() {
-    if (row < 1) {
+    if (row <= 1) {
       return false;
     }
     setRow(row - 1);

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
@@ -171,7 +171,7 @@ import java.util.List;
 
   public Cue build() {
     closeSpans();
-    float cueLine = 10 + (5.33f * row);
+    float cueLine = 10 + (5.33f * (row - 1));
     float cuePosition = 10 + (2.5f * indent);
     cuePosition = (tabOffset * 2.5f) + cuePosition;
     return new Cue(new SpannableStringBuilder(captionStringBuilder),

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
@@ -89,16 +89,12 @@ import java.util.List;
     this.indent = indent;
   }
 
+  /**
+   * Indents the Cue.
+   * @param tabs The amount of tabs to indent the cue with.
+   */
   public void tab(int tabs) {
     tabOffset += tabs;
-  }
-
-  /**
-   * Indents the cue position with amountOfTabs.
-   * @param tabOffset the amount of tabs the cue position should be indented.
-   */
-  public void setTabOffset(int tabOffset) {
-    this.tabOffset = tabOffset;
   }
 
   /**

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608CueBuilder.java
@@ -178,7 +178,8 @@ import java.util.List;
     float cueLine = 10 + (5.33f * row);
     float cuePosition = 10 + (2.5f * indent);
     cuePosition = (tabOffset * 2.5f) + cuePosition;
-    return new Cue(captionStringBuilder, Layout.Alignment.ALIGN_NORMAL, cueLine / 100, Cue.LINE_TYPE_FRACTION,
+    return new Cue(new SpannableStringBuilder(captionStringBuilder),
+      Layout.Alignment.ALIGN_NORMAL, cueLine / 100, Cue.LINE_TYPE_FRACTION,
       Cue.ANCHOR_TYPE_START, cuePosition / 100, Cue.TYPE_UNSET, Cue.DIMEN_UNSET);
   }
 

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
@@ -101,9 +101,6 @@ public final class Eia608Decoder implements SubtitleDecoder {
 
   private static final byte CTRL_TAB_OFFSET_CHAN_1 = 0x17;
   private static final byte CTRL_TAB_OFFSET_CHAN_2 = 0x1F;
-  private static final byte CTRL_TAB_OFFSET_1 = 0x21;
-  private static final byte CTRL_TAB_OFFSET_2 = 0x22;
-  private static final byte CTRL_TAB_OFFSET_3 = 0x23;
 
   private static final byte CTRL_BACKSPACE = 0x21;
 
@@ -181,21 +178,14 @@ public final class Eia608Decoder implements SubtitleDecoder {
   // Maps EIA-608 PAC row numbers to WebVTT cue line settings.
   // Adapted from: https://dvcs.w3.org/hg/text-tracks/raw-file/default/608toVTT/608toVTT.html#x1-preamble-address-code-pac
   private static final float[] CUE_LINE_MAP = new float[] {
+    63.33f, // Row 11
     10.00f, // Row 1
-    15.33f,
-    20.66f,
-    26.00f,
-    31.33f,
-    36.66f,
-    42.00f,
-    47.33f,
-    52.66f,
-    58.00f,
-    63.33f,
-    68.66f,
-    74.00f,
-    79.33f,
-    84.66f // Row 15
+    26.00f, // Row 4
+    68.66f, // Row 12
+    79.33f, // Row 14
+    31.33f, // Row 5
+    42.00f, // Row 7
+    52.66f, // Row 9
   };
 
   // Maps EIA-608 PAC indents to WebVTT cue position values.
@@ -228,7 +218,7 @@ public final class Eia608Decoder implements SubtitleDecoder {
   private static final int TRANSPARENCY_MASK = 0x80FFFFFF;
 
   private static final int STYLE_ITALIC = Typeface.ITALIC;
-  private static final float DEFAULT_CUE_LINE = CUE_LINE_MAP[10]; // Row 11
+  private static final float DEFAULT_CUE_LINE = CUE_LINE_MAP[4]; // Row 11
   private static final float DEFAULT_INDENT = INDENT_MAP[0]; // Indent 0
 
   private final LinkedList<SubtitleInputBuffer> availableInputBuffers;
@@ -560,49 +550,7 @@ public final class Eia608Decoder implements SubtitleDecoder {
     }
 
     // Parse the row bits
-    int row = cc1 & 0x7;
-    if (row >= 0x4) {
-      // Extended Preamble Code
-      row = row & 0x3;
-      switch (row) {
-        case 0x0:
-          // Row 14 or 15
-          cueLine = CUE_LINE_MAP[13];
-          break;
-        case 0x1:
-          // Row 5 or 6
-          cueLine = CUE_LINE_MAP[4];
-          break;
-        case 0x2:
-          // Row 7 or 8
-          cueLine = CUE_LINE_MAP[7];
-          break;
-        case 0x3:
-          // Row 9 or 10
-          cueLine = CUE_LINE_MAP[8];
-          break;
-      }
-    } else {
-      // Regular Preamble Code
-      switch (row) {
-        case 0x0:
-          // Row 11 (Default)
-          cueLine = CUE_LINE_MAP[10];
-          break;
-        case 0x1:
-          // Row 1 (Top)
-          cueLine = CUE_LINE_MAP[0];
-          break;
-        case 0x2:
-          // Row 4 (Top)
-          cueLine = CUE_LINE_MAP[3];
-          break;
-        case 0x3:
-          // Row 12 or 13 (Bottom)
-          cueLine = CUE_LINE_MAP[11];
-          break;
-      }
-    }
+    cueLine = CUE_LINE_MAP[cc1 & 0x7];
   }
 
   private void handleMidrowCode(byte cc1, byte cc2) {
@@ -628,17 +576,7 @@ public final class Eia608Decoder implements SubtitleDecoder {
     // We're ignoring any tab offsets that do not occur at the beginning of a new cue.
     // This is not conform the spec, but works in most cases.
     if (captionStringBuilder.length() == 0) {
-      switch (cc2) {
-        case CTRL_TAB_OFFSET_1:
-          tabOffset++;
-          break;
-        case CTRL_TAB_OFFSET_2:
-          tabOffset += 2;
-          break;
-        case CTRL_TAB_OFFSET_3:
-          tabOffset += 3;
-          break;
-      }
+      tabOffset = cc2 - 0x20;
     }
   }
 

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
@@ -15,6 +15,13 @@
  */
 package com.google.android.exoplayer2.text.eia608;
 
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.StyleSpan;
+import android.text.style.UnderlineSpan;
+
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.text.Cue;
 import com.google.android.exoplayer2.text.SubtitleDecoder;
@@ -24,14 +31,8 @@ import com.google.android.exoplayer2.text.SubtitleOutputBuffer;
 import com.google.android.exoplayer2.util.Assertions;
 import com.google.android.exoplayer2.util.ParsableByteArray;
 
-import android.graphics.Color;
-import android.graphics.Typeface;
-import android.text.style.BackgroundColorSpan;
-import android.text.style.ForegroundColorSpan;
-import android.text.style.StyleSpan;
-import android.text.style.UnderlineSpan;
-
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.TreeSet;
 
@@ -472,10 +473,12 @@ public final class Eia608Decoder implements SubtitleDecoder {
         // from memory and from the display. The remaining rows of text are each rolled up into the
         // next highest row in the window, leaving the base row blank and ready to accept new text.
         if (captionMode == CC_MODE_ROLL_UP) {
-          for (Eia608CueBuilder cue : cues) {
+          Iterator<Eia608CueBuilder> iterator = cues.iterator();
+          while (iterator.hasNext()) {
+            Eia608CueBuilder cue = iterator.next();
             // Roll up all the other rows.
             if (!cue.rollUp()) {
-              cues.remove(cue);
+              iterator.remove();
             }
           }
           currentCue = new Eia608CueBuilder();

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
@@ -208,7 +208,6 @@ public final class Eia608Decoder implements SubtitleDecoder {
 
   private int captionMode;
   private int captionRowCount;
-  boolean nextRowDown;
 
   // The Cue that's currently being built and decoded.
   private Eia608CueBuilder currentCue;
@@ -233,7 +232,6 @@ public final class Eia608Decoder implements SubtitleDecoder {
     ccData = new ParsableByteArray();
     subtitle = new Eia608Subtitle();
     cues = new LinkedList<>();
-    nextRowDown = false;
 
     setCaptionMode(CC_MODE_UNKNOWN);
     captionRowCount = DEFAULT_CAPTIONS_ROW_COUNT;
@@ -322,7 +320,6 @@ public final class Eia608Decoder implements SubtitleDecoder {
     playbackPositionUs = 0;
     currentCue = new Eia608CueBuilder();
     cues.clear();
-    nextRowDown = false;
     repeatableControlSet = false;
     repeatableControlCc1 = 0;
     repeatableControlCc2 = 0;
@@ -501,7 +498,7 @@ public final class Eia608Decoder implements SubtitleDecoder {
     // For PAC layout see: https://en.wikipedia.org/wiki/EIA-608#Control_commands
 
     // Parse the "next row down" toggle.
-    nextRowDown = (cc2 & 0x20) != 0;
+    boolean nextRowDown = (cc2 & 0x20) != 0;
 
     int row = ROW_INDICES[cc1 & 0x7];
     if (row != currentCue.getRow() || nextRowDown) {

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
@@ -656,9 +656,13 @@ public final class Eia608Decoder implements SubtitleDecoder {
     }
 
     for (Integer startIndex : captionStyles.keySet()) {
-      CharacterStyle captionStyle = captionStyles.get(startIndex);
-      captionStringBuilder.setSpan(captionStyle, startIndex,
-        captionStringBuilder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+      // There may be cases, e.g. when seeking where the startIndex becomes greater
+      // than what is actually in the string builder, in that case, just discard the span.
+      if (startIndex < captionStringBuilder.length()) {
+        CharacterStyle captionStyle = captionStyles.get(startIndex);
+        captionStringBuilder.setSpan(captionStyle, startIndex,
+          captionStringBuilder.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+      }
       captionStyles.remove(startIndex);
     }
   }

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
@@ -379,7 +379,7 @@ public final class Eia608Decoder implements SubtitleDecoder {
       }
 
       // Mid row changes.
-      if ((ccData1 == 0x11 || ccData1 == 0x19) && ccData2 >= 0x20 && ccData2 <= 0x2F) {
+      if ((ccData1 == 0x11 || ccData1 == 0x19) && (ccData2 >= 0x20 && ccData2 <= 0x2F)) {
         handleMidrowCode(ccData1, ccData2);
       }
 
@@ -531,13 +531,18 @@ public final class Eia608Decoder implements SubtitleDecoder {
   private void handleMidrowCode(byte cc1, byte cc2) {
     boolean transparentOrUnderline = (cc2 & 0x1) != 0;
     int attribute = cc2 >> 1 & 0xF;
-    if ((cc1 & 0x1) != 0) {
+    if ((cc1 & 0x1) == 0) {
       // Background Color
       currentCue.setCharacterStyle(new BackgroundColorSpan(transparentOrUnderline ?
         COLOR_MAP[attribute] & TRANSPARENCY_MASK : COLOR_MAP[attribute]));
     } else {
-      // Foreground color
-      currentCue.setCharacterStyle(new ForegroundColorSpan(COLOR_MAP[attribute]));
+      if (attribute < 7) {
+        // Foreground color
+        currentCue.setCharacterStyle(new ForegroundColorSpan(COLOR_MAP[attribute]));
+      } else {
+        // Italics
+        currentCue.setCharacterStyle(new StyleSpan(STYLE_ITALIC));
+      }
       if (transparentOrUnderline) {
         // Text should be underlined
         currentCue.setCharacterStyle(new UnderlineSpan());

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Decoder.java
@@ -224,7 +224,7 @@ public final class Eia608Decoder implements SubtitleDecoder {
     Color.BLACK // Only used by Mid Row style changes, for PAC an value of 0x7 means italics.
   };
 
-  // Transparency is defined in the two left most bytes of an integer.
+  // Transparency is defined in the first byte of an integer.
   private static final int TRANSPARENCY_MASK = 0x80FFFFFF;
 
   private static final int STYLE_ITALIC = Typeface.ITALIC;

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Subtitle.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Subtitle.java
@@ -18,6 +18,7 @@ package com.google.android.exoplayer2.text.eia608;
 import com.google.android.exoplayer2.text.Cue;
 import com.google.android.exoplayer2.text.Subtitle;
 
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -25,9 +26,13 @@ import java.util.List;
  */
 /* package */ final class Eia608Subtitle implements Subtitle {
 
-  private final List<Cue> cues;
+  private List<Cue> cues;
 
-  public Eia608Subtitle(List<Cue> cues) {
+  public Eia608Subtitle() {
+    cues = new LinkedList<>();
+  }
+
+  /* package */ void setCues(List<Cue> cues) {
     this.cues = cues;
   }
 

--- a/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Subtitle.java
+++ b/library/src/main/java/com/google/android/exoplayer2/text/eia608/Eia608Subtitle.java
@@ -15,10 +15,9 @@
  */
 package com.google.android.exoplayer2.text.eia608;
 
-import android.text.TextUtils;
 import com.google.android.exoplayer2.text.Cue;
 import com.google.android.exoplayer2.text.Subtitle;
-import java.util.Collections;
+
 import java.util.List;
 
 /**
@@ -26,13 +25,10 @@ import java.util.List;
  */
 /* package */ final class Eia608Subtitle implements Subtitle {
 
-  private final String text;
+  private final List<Cue> cues;
 
-  /**
-   * @param text The subtitle text.
-   */
-  public Eia608Subtitle(String text) {
-    this.text = text;
+  public Eia608Subtitle(List<Cue> cues) {
+    this.cues = cues;
   }
 
   @Override
@@ -52,11 +48,7 @@ import java.util.List;
 
   @Override
   public List<Cue> getCues(long timeUs) {
-    if (TextUtils.isEmpty(text)) {
-      return Collections.emptyList();
-    } else {
-      return Collections.singletonList(new Cue(text));
-    }
+    return cues;
   }
 
 }

--- a/library/src/main/java/com/google/android/exoplayer2/ui/SubtitlePainter.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ui/SubtitlePainter.java
@@ -117,30 +117,30 @@ import android.util.Log;
   }
 
   /**
-   * Draws the provided {@link Cue} into a canvas with the specified styling.
+   * Creates layouts so that the provided {@link Cue} can be drawn in a {@link Canvas} by calls to
+   * {@link #drawBackground(Canvas)} and {@link #drawForeground(Canvas)} with the specified styling.
    * <p>
    * A call to this method is able to use cached results of calculations made during the previous
    * call, and so an instance of this class is able to optimize repeated calls to this method in
    * which the same parameters are passed.
    *
-   * @param cue The cue to draw.
+   * @param cue The cue to layout.
    * @param applyEmbeddedStyles Whether styling embedded within the cue should be applied.
    * @param style The style to use when drawing the cue text.
    * @param textSizePx The text size to use when drawing the cue text, in pixels.
    * @param bottomPaddingFraction The bottom padding fraction to apply when {@link Cue#line} is
    *     {@link Cue#DIMEN_UNSET}, as a fraction of the viewport height
-   * @param canvas The canvas into which to draw.
    * @param cueBoxLeft The left position of the enclosing cue box.
    * @param cueBoxTop The top position of the enclosing cue box.
    * @param cueBoxRight The right position of the enclosing cue box.
    * @param cueBoxBottom The bottom position of the enclosing cue box.
    */
-  public void draw(Cue cue, boolean applyEmbeddedStyles, CaptionStyleCompat style, float textSizePx,
-      float bottomPaddingFraction, Canvas canvas, int cueBoxLeft, int cueBoxTop, int cueBoxRight,
-      int cueBoxBottom) {
+  public void layout(Cue cue, boolean applyEmbeddedStyles, CaptionStyleCompat style, float textSizePx,
+                     float bottomPaddingFraction, int cueBoxLeft, int cueBoxTop, int cueBoxRight,
+                     int cueBoxBottom) {
     CharSequence cueText = cue.text;
     if (TextUtils.isEmpty(cueText)) {
-      // Nothing to draw.
+      // Nothing to layout.
       return;
     }
     if (!applyEmbeddedStyles) {
@@ -169,7 +169,6 @@ import android.util.Log;
         && this.parentRight == cueBoxRight
         && this.parentBottom == cueBoxBottom) {
       // We can use the cached layout.
-      drawLayout(canvas);
       return;
     }
 
@@ -272,19 +271,17 @@ import android.util.Log;
     this.textLeft = textLeft;
     this.textTop = textTop;
     this.textPaddingX = textPaddingX;
-
-    drawLayout(canvas);
   }
 
   /**
-   * Draws {@link #textLayout} into the provided canvas.
+   * Draws the background of the {@link #textLayout} into the provided canvas.
    *
-   * @param canvas The canvas into which to draw.
+   * @param canvas The canvas into which to layout.
    */
-  private void drawLayout(Canvas canvas) {
+  public void drawBackground(Canvas canvas) {
     final StaticLayout layout = textLayout;
     if (layout == null) {
-      // Nothing to draw.
+      // Nothing to layout.
       return;
     }
 
@@ -311,6 +308,24 @@ import android.util.Log;
       }
     }
 
+    canvas.restoreToCount(saveCount);
+  }
+
+  /**
+   * Draws the foreground of the {@link #textLayout} into the provided canvas.
+   *
+   * @param canvas The canvas into which to layout.
+   */
+  public void drawForeground(Canvas canvas) {
+    final StaticLayout layout = textLayout;
+    if (layout == null) {
+      // Nothing to layout.
+      return;
+    }
+
+    int saveCount = canvas.save();
+    canvas.translate(textLeft, textTop);
+
     if (edgeType == CaptionStyleCompat.EDGE_TYPE_OUTLINE) {
       textPaint.setStrokeJoin(Join.ROUND);
       textPaint.setStrokeWidth(outlineWidth);
@@ -320,7 +335,7 @@ import android.util.Log;
     } else if (edgeType == CaptionStyleCompat.EDGE_TYPE_DROP_SHADOW) {
       textPaint.setShadowLayer(shadowRadius, shadowOffset, shadowOffset, edgeColor);
     } else if (edgeType == CaptionStyleCompat.EDGE_TYPE_RAISED
-        || edgeType == CaptionStyleCompat.EDGE_TYPE_DEPRESSED) {
+      || edgeType == CaptionStyleCompat.EDGE_TYPE_DEPRESSED) {
       boolean raised = edgeType == CaptionStyleCompat.EDGE_TYPE_RAISED;
       int colorUp = raised ? Color.WHITE : edgeColor;
       int colorDown = raised ? edgeColor : Color.WHITE;

--- a/library/src/main/java/com/google/android/exoplayer2/ui/SubtitlePainter.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ui/SubtitlePainter.java
@@ -15,6 +15,10 @@
  */
 package com.google.android.exoplayer2.ui;
 
+import com.google.android.exoplayer2.text.CaptionStyleCompat;
+import com.google.android.exoplayer2.text.Cue;
+import com.google.android.exoplayer2.util.Util;
+
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -30,9 +34,6 @@ import android.text.TextPaint;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
-import com.google.android.exoplayer2.text.CaptionStyleCompat;
-import com.google.android.exoplayer2.text.Cue;
-import com.google.android.exoplayer2.util.Util;
 
 /**
  * Paints subtitle {@link Cue}s.

--- a/library/src/main/java/com/google/android/exoplayer2/ui/SubtitleView.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ui/SubtitleView.java
@@ -15,6 +15,11 @@
  */
 package com.google.android.exoplayer2.ui;
 
+import com.google.android.exoplayer2.text.CaptionStyleCompat;
+import com.google.android.exoplayer2.text.Cue;
+import com.google.android.exoplayer2.text.TextRenderer;
+import com.google.android.exoplayer2.util.Util;
+
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Resources;
@@ -23,10 +28,7 @@ import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.accessibility.CaptioningManager;
-import com.google.android.exoplayer2.text.CaptionStyleCompat;
-import com.google.android.exoplayer2.text.Cue;
-import com.google.android.exoplayer2.text.TextRenderer;
-import com.google.android.exoplayer2.util.Util;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -230,7 +232,7 @@ public final class SubtitleView extends View implements TextRenderer.Output {
     int right = getRight() + getPaddingRight();
     int bottom = rawBottom - getPaddingBottom();
     if (bottom <= top || right <= left) {
-      // No space to draw subtitles.
+      // No space to layout subtitles.
       return;
     }
 
@@ -242,8 +244,12 @@ public final class SubtitleView extends View implements TextRenderer.Output {
     }
 
     for (int i = 0; i < cueCount; i++) {
-      painters.get(i).draw(cues.get(i), applyEmbeddedStyles, style, textSizePx,
-          bottomPaddingFraction, canvas, left, top, right, bottom);
+      painters.get(i).layout(cues.get(i), applyEmbeddedStyles, style, textSizePx,
+          bottomPaddingFraction, left, top, right, bottom);
+      painters.get(i).drawBackground(canvas);
+    }
+    for (int i = 0; i < cueCount; i++) {
+      painters.get(i).drawForeground(canvas);
     }
   }
 


### PR DESCRIPTION
This is an effort to implement preamble control codes and mid row style changes for EIA-608 captions.

Currently the implementation does not completely follow the EIA-608 spec, but should provide reasonable closed caption positioning and styling for most cases.

You can test this by Selecting the `Apple master playlist` stream under HLS.
