### PR TITLE
[FIXED] Switch width & height of vertical video when checking the capability of video

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -185,18 +185,28 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
       return FORMAT_UNSUPPORTED_SUBTYPE;
     }
 
+    // If vertical video, width & height is reversed.
+    // So we need to switch them when checking capability to decode.
+    // Please see MediaCodecInfo.VideoCapabilities.isSizeSupported()
+    int width = format.width, height = format.height;
+    if (width < height) {
+      int tempWidth = width;
+      width = height;
+      height = tempWidth;
+    }
+
     boolean decoderCapable;
-    if (format.width > 0 && format.height > 0) {
+    if (width > 0 && height > 0) {
       if (Util.SDK_INT >= 21) {
         if (format.frameRate > 0) {
-          decoderCapable = decoderInfo.isVideoSizeAndRateSupportedV21(format.width, format.height,
-              format.frameRate);
+          decoderCapable = decoderInfo.isVideoSizeAndRateSupportedV21(width, height,
+                  format.frameRate);
         } else {
-          decoderCapable = decoderInfo.isVideoSizeSupportedV21(format.width, format.height);
+          decoderCapable = decoderInfo.isVideoSizeSupportedV21(width, height);
         }
         decoderCapable &= decoderInfo.isCodecSupported(format.codecs);
       } else {
-        decoderCapable = format.width * format.height <= MediaCodecUtil.maxH264DecodableFrameSize();
+        decoderCapable = width * height <= MediaCodecUtil.maxH264DecodableFrameSize();
       }
     } else {
       // We don't know any better, so assume true.


### PR DESCRIPTION
When playing a vertical video that has a RESOLUTION as 720x1280,
width & height of that video need to be reversed when calling MediaCodecInfo.VideoCapabilities.areSizeAndRateSupported() & MediaCodecInfo.VideoCapabilities.isSizeSupported().

You can see the problem at the below example.

The playlist of input video. (HLS)
# EXTM3U
# EXT-X-VERSION:3
# EXT-X-STREAM-INF:BANDWIDTH=1813682,CODECS="avc1.66.31,mp4a.40.2",RESOLUTION=720x1280

blahblahblah.m3u8

Especially, a **Sony Experia M4** can decode up to 1920 x 1088 according to VideoCapability's info,
but supportFormat() method returns false if the video size is 720 x 1280.

Thanks.

ps. Actually ExoPlayer v1.x also has this problem. So if you think that this is acceptable, then you need to look at VideoFormatSelectorUtil.isFormatPlayable() in  ExoPlayer v1.x.
