### PR TITLE
TsExtractor support for language code in the audio tracks.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/extractor/ts/Ac3Reader.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/ts/Ac3Reader.java
@@ -33,6 +33,8 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
 
   private static final int HEADER_SIZE = 8;
 
+  private String language;
+
   private final ParsableBitArray headerScratchBits;
   private final ParsableByteArray headerScratchBytes;
 
@@ -57,10 +59,21 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
    * @param output Track output for extracted samples.
    */
   public Ac3Reader(TrackOutput output) {
+    this(output, null);
+  }
+
+  /**
+   * Constructs a new reader for (E-)AC-3 elementary streams.
+   *
+   * @param output Track output for extracted samples.
+   * @param language Track language.
+   */
+  public Ac3Reader(TrackOutput output, String language) {
     super(output);
     headerScratchBits = new ParsableBitArray(new byte[HEADER_SIZE]);
     headerScratchBytes = new ParsableByteArray(headerScratchBits.data);
     state = STATE_FINDING_SYNC;
+    this.language = language;
   }
 
   @Override
@@ -163,8 +176,8 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
       headerScratchBits.skipBits(40);
       isEac3 = headerScratchBits.readBits(5) == 16;
       headerScratchBits.setPosition(headerScratchBits.getPosition() - 45);
-      format = isEac3 ? Ac3Util.parseEac3SyncframeFormat(headerScratchBits, null, null, null)
-          : Ac3Util.parseAc3SyncframeFormat(headerScratchBits, null, null, null);
+      format = isEac3 ? Ac3Util.parseEac3SyncframeFormat(headerScratchBits, null, language, null)
+          : Ac3Util.parseAc3SyncframeFormat(headerScratchBits, null, language, null);
       output.format(format);
     }
     sampleSize = isEac3 ? Ac3Util.parseEAc3SyncframeSize(headerScratchBits.data)

--- a/library/src/main/java/com/google/android/exoplayer2/extractor/ts/AdtsReader.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/ts/AdtsReader.java
@@ -42,6 +42,8 @@ import java.util.Collections;
   private static final int HEADER_SIZE = 5;
   private static final int CRC_SIZE = 2;
 
+  private String language;
+
   // Match states used while looking for the next sample
   private static final int MATCH_STATE_VALUE_SHIFT = 8;
   private static final int MATCH_STATE_START = 1 << MATCH_STATE_VALUE_SHIFT;
@@ -80,6 +82,15 @@ import java.util.Collections;
    * @param id3Output A {@link TrackOutput} to which ID3 samples should be written.
    */
   public AdtsReader(TrackOutput output, TrackOutput id3Output) {
+    this(output, id3Output, null);
+  }
+
+  /**
+   * @param output A {@link TrackOutput} to which AAC samples should be written.
+   * @param id3Output A {@link TrackOutput} to which ID3 samples should be written.
+   * @param language Track language.
+   */
+  public AdtsReader(TrackOutput output, TrackOutput id3Output, String language) {
     super(output);
     this.id3Output = id3Output;
     id3Output.format(Format.createSampleFormat(null, MimeTypes.APPLICATION_ID3, null,
@@ -87,6 +98,7 @@ import java.util.Collections;
     adtsScratch = new ParsableBitArray(new byte[HEADER_SIZE + CRC_SIZE]);
     id3HeaderBuffer = new ParsableByteArray(Arrays.copyOf(ID3_IDENTIFIER, ID3_HEADER_SIZE));
     setFindingSampleState();
+    this.language = language;
   }
 
   @Override
@@ -278,7 +290,7 @@ import java.util.Collections;
 
       Format format = Format.createAudioSampleFormat(null, MimeTypes.AUDIO_AAC, null,
           Format.NO_VALUE, Format.NO_VALUE, audioParams.second, audioParams.first,
-          Collections.singletonList(audioSpecificConfig), null, 0, null);
+          Collections.singletonList(audioSpecificConfig), null, 0, language);
       // In this class a sample is an access unit, but the MediaFormat sample rate specifies the
       // number of PCM audio samples per second.
       sampleDurationUs = (C.MICROS_PER_SECOND * 1024) / format.sampleRate;

--- a/library/src/main/java/com/google/android/exoplayer2/extractor/ts/DtsReader.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/ts/DtsReader.java
@@ -34,6 +34,8 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
   private static final int SYNC_VALUE = 0x7FFE8001;
   private static final int SYNC_VALUE_SIZE = 4;
 
+  private String language;
+
   private final ParsableByteArray headerScratchBytes;
 
   private int state;
@@ -56,6 +58,16 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
    * @param output Track output for extracted samples.
    */
   public DtsReader(TrackOutput output) {
+    this(output, null);
+  }
+
+  /**
+   * Constructs a new reader for DTS elementary streams.
+   *
+   * @param output Track output for extracted samples.
+   * @param language Track language.
+   */
+  public DtsReader(TrackOutput output, String language) {
     super(output);
     headerScratchBytes = new ParsableByteArray(new byte[HEADER_SIZE]);
     headerScratchBytes.data[0] = (byte) ((SYNC_VALUE >> 24) & 0xFF);
@@ -63,6 +75,7 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
     headerScratchBytes.data[2] = (byte) ((SYNC_VALUE >> 8) & 0xFF);
     headerScratchBytes.data[3] = (byte) (SYNC_VALUE & 0xFF);
     state = STATE_FINDING_SYNC;
+    this.language = language;
   }
 
   @Override
@@ -155,7 +168,7 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
   private void parseHeader() {
     byte[] frameData = headerScratchBytes.data;
     if (format == null) {
-      format = DtsUtil.parseDtsFormat(frameData, null, null, null);
+      format = DtsUtil.parseDtsFormat(frameData, null, language, null);
       output.format(format);
     }
     sampleSize = DtsUtil.getDtsFrameSize(frameData);

--- a/library/src/main/java/com/google/android/exoplayer2/extractor/ts/MpegAudioReader.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/ts/MpegAudioReader.java
@@ -32,6 +32,8 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
 
   private static final int HEADER_SIZE = 4;
 
+  private String language;
+
   private final ParsableByteArray headerScratch;
   private final MpegAudioHeader header;
 
@@ -50,12 +52,17 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
   private long timeUs;
 
   public MpegAudioReader(TrackOutput output) {
+    this(output, null);
+  }
+
+  public MpegAudioReader(TrackOutput output, String language) {
     super(output);
     state = STATE_FINDING_HEADER;
     // The first byte of an MPEG Audio frame header is always 0xFF.
     headerScratch = new ParsableByteArray(4);
     headerScratch.data[0] = (byte) 0xFF;
     header = new MpegAudioHeader();
+    this.language = language;
   }
 
   @Override
@@ -164,7 +171,7 @@ import com.google.android.exoplayer2.util.ParsableByteArray;
       frameDurationUs = (C.MICROS_PER_SECOND * header.samplesPerFrame) / header.sampleRate;
       Format format = Format.createAudioSampleFormat(null, header.mimeType, null, Format.NO_VALUE,
           MpegAudioHeader.MAX_FRAME_SIZE_BYTES, header.channels, header.sampleRate, null, null, 0,
-          null);
+          language);
       output.format(format);
       hasOutputFormat = true;
     }


### PR DESCRIPTION
We add support to display the language code of the audio tracks in MP2T streams allowing the player applications to display meaningful track names in the audio track selectors.
