### PR TITLE
Fix crash on pre-api-21 devices.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/ui/PlaybackControlView.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ui/PlaybackControlView.java
@@ -97,7 +97,11 @@ public class PlaybackControlView extends FrameLayout {
   }
 
   public PlaybackControlView(Context context, AttributeSet attrs) {
-    super(context, attrs);
+    this(context, attrs, 0);
+  }
+
+  public PlaybackControlView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
 
     currentWindow = new Timeline.Window();
     formatBuilder = new StringBuilder();

--- a/library/src/main/java/com/google/android/exoplayer2/ui/SimpleExoPlayerView.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ui/SimpleExoPlayerView.java
@@ -64,12 +64,7 @@ public final class SimpleExoPlayerView extends FrameLayout {
   }
 
   public SimpleExoPlayerView(Context context, AttributeSet attrs, int defStyleAttr) {
-    this(context, attrs, defStyleAttr, 0);
-  }
-
-  public SimpleExoPlayerView(Context context, AttributeSet attrs, int defStyleAttr,
-      int defStyleRes) {
-    super(context, attrs, defStyleAttr, defStyleRes);
+    super(context, attrs, defStyleAttr);
 
     boolean useTextureView = false;
     if (attrs != null) {
@@ -86,7 +81,6 @@ public final class SimpleExoPlayerView extends FrameLayout {
     }
 
     LayoutInflater.from(context).inflate(R.layout.exoplayer_video_view, this);
-
     componentListener = new ComponentListener();
     layout = (AspectRatioFrameLayout) findViewById(R.id.video_frame);
     controller = (PlaybackControlView) findViewById(R.id.control);


### PR DESCRIPTION
The four-arg constructor didn't exist in ViewGroup for
earlier API levels. I think it can probably be safely
omitted, unless you know otherwise?

Issue: #1820

---

Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=133156975
