### PR TITLE
Handle 0 width and height in AspectRatioFrameLayout

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/ui/AspectRatioFrameLayout.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ui/AspectRatioFrameLayout.java
@@ -74,7 +74,7 @@ public final class AspectRatioFrameLayout extends FrameLayout {
       return;
     }
 
-    if (aspectDeformation > 0) {
+    if (height == 0 || (width > 0 && aspectDeformation > 0)) {
       height = (int) (width / videoAspectRatio);
     } else {
       width = (int) (height * videoAspectRatio);


### PR DESCRIPTION
When in vertical or horizontal list views with wrap_content as a parameter, the height or width will be measured as 0. In this case the dimension should be calculated off of the non zero width or height.
