### PR TITLE
Add missing URL's in documentation

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -439,3 +439,4 @@ additional schemes such as PlayReady. All Android TV devices support PlayReady.
 [`AudioTrack`]: {{ site.sdkurl }}/android/media/AudioTrack.html
 [`MediaDrm`]: {{ site.sdkurl }}/android/media/MediaDrm.html
 [Bintray]: https://bintray.com/google/exoplayer/exoplayer
+[Releases]: https://github.com/google/ExoPlayer/releases

--- a/guide.md
+++ b/guide.md
@@ -438,3 +438,4 @@ additional schemes such as PlayReady. All Android TV devices support PlayReady.
 [`MediaCodec`]: {{ site.sdkurl }}/android/media/MediaCodec.html
 [`AudioTrack`]: {{ site.sdkurl }}/android/media/AudioTrack.html
 [`MediaDrm`]: {{ site.sdkurl }}/android/media/MediaDrm.html
+[Bintray]: https://bintray.com/google/exoplayer/exoplayer


### PR DESCRIPTION
Title said everything :)
Bintray and Releases URL was missing. I've fixed it ;)
