### PR TITLE
Null pointer exception fixed

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/extractor/ts/TsExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/ts/TsExtractor.java
@@ -467,7 +467,9 @@ public final class TsExtractor implements Extractor {
           pesPayloadReader = id3Reader;
         } else {
           pesPayloadReader = streamReaderFactory.createStreamReader(streamType, esInfo);
-          pesPayloadReader.init(output, new TrackIdGenerator(trackId, MAX_PID_PLUS_ONE));
+          if (pesPayloadReader != null) {
+            pesPayloadReader.init(output, new TrackIdGenerator(trackId, MAX_PID_PLUS_ONE));
+          }
         }
 
         if (pesPayloadReader != null) {


### PR DESCRIPTION
pesPayloadReader can be null here because DefaultStreamReaderFactory can return null on unknown streamId. If we have a junk transport stream in our content an exception will be thrown.
