### PR TITLE
Fix ArrayIndexOutOfBoundsException when switching variants

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -408,6 +408,11 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
       if (previousTsChunk == null) {
         chunkMediaSequence = getLiveStartChunkSequenceNumber(selectedVariantIndex);
       } else {
+        if (previousTsChunk.chunkIndex < variantPlaylists[previousChunkVariantIndex].mediaSequence) {
+          fatalError = new BehindLiveWindowException();
+          return;
+        }
+
         chunkMediaSequence = getLiveNextChunkSequenceNumber(previousTsChunk.chunkIndex,
             previousChunkVariantIndex, selectedVariantIndex);
         if (chunkMediaSequence < mediaPlaylist.mediaSequence) {


### PR DESCRIPTION
Sometimes HlsChunkSource::getLiveNextChunkSequenceNumber throws ArrayIndexOutOfBoundsException

Stack trace:
Fatal Exception: java.lang.ArrayIndexOutOfBoundsException: length=12; index=-1
       at java.util.ArrayList.get(ArrayList.java:310)
       at java.util.Collections$UnmodifiableList.get(Collections.java:1050)
       at com.google.android.exoplayer.hls.HlsChunkSource.getLiveNextChunkSequenceNumber(HlsChunkSource.java:700)
       at com.google.android.exoplayer.hls.HlsChunkSource.getChunkOperation(HlsChunkSource.java:411)
       at com.restream.viewrightplayer.VmxHlsChunkSource.getChunkOperation(VmxHlsChunkSource.java:111)
       at com.google.android.exoplayer.hls.HlsSampleSource.maybeStartLoading(HlsSampleSource.java:711)
       at com.google.android.exoplayer.hls.HlsSampleSource.onLoadCompleted(HlsSampleSource.java:436)
       at com.google.android.exoplayer.upstream.Loader$LoadTask.handleMessage(Loader.java:258)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:145)
       at android.os.HandlerThread.run(HandlerThread.java:61)
       at com.google.android.exoplayer.util.PriorityHandlerThread.run(PriorityHandlerThread.java:40)