### PR TITLE
Fix the issue when the sequence of PTS is out of order by bidirectional prediction for skipToKeyframeBefore()

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultTrackOutput.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultTrackOutput.java
@@ -786,9 +786,7 @@ public final class DefaultTrackOutput implements TrackOutput {
         return C.POSITION_UNSET;
       }
 
-      int lastWriteIndex = (relativeWriteIndex == 0 ? capacity : relativeWriteIndex) - 1;
-      long lastTimeUs = timesUs[lastWriteIndex];
-      if (timeUs > lastTimeUs) {
+      if (timeUs > largestQueuedTimestampUs) {
         return C.POSITION_UNSET;
       }
 


### PR DESCRIPTION
https://2.bp.blogspot.com/-3dBR9aIu0Z4/WE4O75B0AUI/AAAAAAAAAyU/2QGb-8A6BpInSOK8D1keSt4hw51fPTG0QCLcB/s1600/%25E5%259C%2596%25E7%2589%25871.pngT

The check about out-of-range is wrong if bidirectional prediction (such as B frame) happens.
It is shown by the example within the image above.
If the seek time is 7500, original check flow will return **C.POSITION_UNSET** by comparing 7500 with 2500. However, in fact the target frame with PTS = 7500 actually locates within the sampleQueue. 
Hence discard(drop) all data will **downgrade the performance.**

`int lastWriteIndex = (relativeWriteIndex == 0 ? capacity : relativeWriteIndex) - 1;`
`long lastTimeUs = timesUs[lastWriteIndex];`
`if (timeUs > lastTimeUs) {`
`return C.POSITION_UNSET;`
`}`

In fact we should do check by **largestQueuedTimestampUs** (maybe getLargestQueuedTimestampUs()?? but I think largestQueuedTimestampUs is enough).

Even for the case as the image below where the largestQueuedTimestampUs is 7500 and  **the target frame with PTS = 5000 has not actually been read yet**, we could do drop until the last key frame, set the time to skip and continue reading.  The flow is still correct as original.   

https://1.bp.blogspot.com/-9y72lX_9poc/WE4SnCNowzI/AAAAAAAAAyo/uxyveV6MX5gnF0xJgkoAYPVJbgUA6f5wwCEw/s1600/%25E5%259C%2596%25E7%2589%25872.png