### PR TITLE
Fix the issue when the sequence of PTS is out of order by bidirectional prediction for skipToKeyframeBefore()

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultTrackOutput.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultTrackOutput.java
@@ -786,9 +786,7 @@ public final class DefaultTrackOutput implements TrackOutput {
         return C.POSITION_UNSET;
       }
 
-      int lastWriteIndex = (relativeWriteIndex == 0 ? capacity : relativeWriteIndex) - 1;
-      long lastTimeUs = timesUs[lastWriteIndex];
-      if (timeUs > lastTimeUs) {
+      if (timeUs > largestQueuedTimestampUs) {
         return C.POSITION_UNSET;
       }
 


### PR DESCRIPTION

![1](https://cloud.githubusercontent.com/assets/14846473/23606977/126b44a0-029e-11e7-9666-dd0ec2de81fd.png)


The check about out-of-range is wrong if bidirectional prediction (such as B frame) happens.
It is shown by the example within the image above.
If the seek time is 7500, original check flow will return C.POSITION_UNSET by comparing 7500 with 2500. However, in fact the target frame with PTS = 7500 actually locates within the sampleQueue.
Hence discard(drop) all data will downgrade the performance.

`int lastWriteIndex = (relativeWriteIndex == 0 ? capacity : relativeWriteIndex) - 1;`
`long lastTimeUs = timesUs[lastWriteIndex];`
`if (timeUs > lastTimeUs) {`
`return C.POSITION_UNSET;`
`}`

In fact we should do check by largestQueuedTimestampUs (maybe getLargestQueuedTimestampUs()?? but I think largestQueuedTimestampUs is enough).

Even for the case as the image below where the largestQueuedTimestampUs is 7500 and the target frame with PTS = 5000 has not actually been read yet, we could do drop until the last key frame, set the time to skip and continue reading. The flow is still correct as original.

![2](https://cloud.githubusercontent.com/assets/14846473/23606989/18734fb4-029e-11e7-95ff-314033931025.png)
