### PR TITLE
Change Sink to Source in license header

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/upstream/cache/CacheDataSinkFactory.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/cache/CacheDataSinkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 The Android Open Sink Project
+ * Copyright (C) 2016 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Don't mean to be an `Open Sink` hater but technically this should be `Open Source` for licensing purposes.