### PR TITLE
Fix a small mistake in opus_multistream_decoder

### DIFF
--- a/extensions/opus/src/main/jni/opus_jni.cc
+++ b/extensions/opus/src/main/jni/opus_jni.cc
@@ -110,7 +110,7 @@ DECODER_FUNC(jint, opusDecode, jlong jDecoder, jlong jTimeUs,
   int16_t* outputBufferData = reinterpret_cast<int16_t*>(
       env->GetDirectBufferAddress(jOutputBufferData));
   int sampleCount = opus_multistream_decode(decoder, inputBuffer, inputSize,
-      outputBufferData, outputSize, 0);
+      outputBufferData, inputSampleCount, 0);
   // record error code
   errorCode = (sampleCount < 0) ? sampleCount : 0;
   return (sampleCount < 0) ? sampleCount


### PR DESCRIPTION
As per documentation, frame_size should be :

> The number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120 ms; 5760 for 48kHz), this function will not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=1), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size mustbe a multiple of 2.5 m