### PR TITLE
improve the performance of short seek

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/BaseRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/BaseRenderer.java
@@ -35,6 +35,8 @@ public abstract class BaseRenderer implements Renderer, RendererCapabilities {
   private boolean readEndOfStream;
   private boolean streamIsFinal;
 
+  private long latestUpstreamSampleTime;
+
   /**
    * @param trackType The track type that the renderer handles. One of the {@link C}
    * {@code TRACK_TYPE_*} constants.
@@ -62,6 +64,16 @@ public abstract class BaseRenderer implements Renderer, RendererCapabilities {
   @Override
   public MediaClock getMediaClock() {
     return null;
+  }
+
+  @Override
+  public long getRenderedPositionUs() {
+    return C.TIME_UNSET;
+  }
+
+  @Override
+  public long getLatestUpstreamSampleTime() {
+    return latestUpstreamSampleTime;
   }
 
   @Override
@@ -267,6 +279,7 @@ public abstract class BaseRenderer implements Renderer, RendererCapabilities {
         return streamIsFinal ? C.RESULT_BUFFER_READ : C.RESULT_NOTHING_READ;
       }
       buffer.timeUs += streamOffsetUs;
+      latestUpstreamSampleTime = buffer.timeUs;
     } else if (result == C.RESULT_FORMAT_READ) {
       Format format = formatHolder.format;
       if (format.subsampleOffsetUs != Format.OFFSET_SAMPLE_RELATIVE) {

--- a/library/src/main/java/com/google/android/exoplayer2/C.java
+++ b/library/src/main/java/com/google/android/exoplayer2/C.java
@@ -510,6 +510,32 @@ public final class C {
   public static final int MSG_CUSTOM_BASE = 10000;
 
   /**
+   *  Represents the seek position locates within the target range and the keyframe before it is found.
+   */
+  public static final int SEEK_TARGET_OK = 0;
+
+  /**
+   *   Represents the seek position locates within the target range but the keyframe before it is NOT found.
+   */
+  public static final int SEEK_TARGET_WITHIN_THE_RANGE = -1;
+
+  /**
+   *  Represents the seek position is out of the target range and precedes the eariest timestamp within sampleQueue.
+   */
+  public static final int SEEK_TARGET_OUT_OF_RANGE_BEFORE = -2;
+
+  /**
+   *  Represents the seek position is out of the target range and coming after the latest timestamp within sampleQueue.
+   */
+  public static final int SEEK_TARGET_OUT_OF_RANGE_AFTER = -3;
+
+
+  /**
+   *  Represents whether the seek position is within the target range is unknown.
+   */
+  public static final int SEEK_TARGET_UNKNOWN = -4;
+
+  /**
    * The stereo mode for 360/3D/VR videos.
    */
   @Retention(RetentionPolicy.SOURCE)

--- a/library/src/main/java/com/google/android/exoplayer2/Renderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/Renderer.java
@@ -253,4 +253,18 @@ public interface Renderer extends ExoPlayerComponent {
    */
   void disable();
 
+  /**
+   * Get the latest rendered position .
+   * <p>
+   * @return The latest rendered position in us.
+   */
+  long getRenderedPositionUs();
+
+  /**
+   * Returns PTS of the latest sample read from upstream source .
+   *
+   * @return PTS of the latest sample read from upstream source.
+   */
+  long getLatestUpstreamSampleTime();
+
 }

--- a/library/src/main/java/com/google/android/exoplayer2/source/ClippingMediaPeriod.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/ClippingMediaPeriod.java
@@ -242,6 +242,11 @@ import java.io.IOException;
       stream.skipToKeyframeBefore(startUs + timeUs);
     }
 
+    @Override
+    public int isContain(long timeUs) {
+      return C.SEEK_TARGET_UNKNOWN;
+    }
+
   }
 
 }

--- a/library/src/main/java/com/google/android/exoplayer2/source/ExtractorMediaPeriod.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/ExtractorMediaPeriod.java
@@ -291,7 +291,7 @@ import java.io.IOException;
     boolean seekInsideBuffer = !isPendingReset();
     for (int i = 0; seekInsideBuffer && i < trackCount; i++) {
       if (trackEnabledStates[i]) {
-        seekInsideBuffer = sampleQueues.valueAt(i).skipToKeyframeBefore(positionUs);
+        seekInsideBuffer = (sampleQueues.valueAt(i).skipToKeyframeBefore(positionUs) == C.SEEK_TARGET_OK);
       }
     }
     // If we failed to seek within the sample queues, we need to restart.
@@ -554,6 +554,11 @@ import java.io.IOException;
     @Override
     public void skipToKeyframeBefore(long timeUs) {
       sampleQueues.valueAt(track).skipToKeyframeBefore(timeUs);
+    }
+
+    @Override
+    public int isContain(long timeUs) {
+      return sampleQueues.valueAt(track).isContain(timeUs);
     }
 
   }

--- a/library/src/main/java/com/google/android/exoplayer2/source/SampleStream.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/SampleStream.java
@@ -61,4 +61,16 @@ public interface SampleStream {
    */
   void skipToKeyframeBefore(long timeUs);
 
+  /**
+   * To see if the sample stream contains the target time or not.
+   *
+   * @param timeUs The specified time.
+   * @return The offset of the keyframe's data if the keyframe was present.
+   *	  otherwise, return  {@link C#SEEK_TARGET_OUT_OF_RANGE_BEFORE}	if the seek time is out of the target range and precedes the eariest timestamp within sampleQueue;
+   *	  return {@link C#SEEK_TARGET_OUT_OF_RANGE_AFTER} if the seek time is out of the target range and coming after the latest timestamp within sampleQueue.
+   *	  return {@link C#SEEK_TARGET_WITHIN_THE_RANGE} if the seek time is within the range.
+   *   or return {@link C#SEEK_TARGET_UNKNOWN} if the relationship is undefined.
+   */
+  public int isContain(long timeUs);
+
 }

--- a/library/src/main/java/com/google/android/exoplayer2/source/SingleSampleMediaPeriod.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/SingleSampleMediaPeriod.java
@@ -232,6 +232,11 @@ import java.util.Arrays;
       // Do nothing.
     }
 
+    @Override
+    public int isContain(long timeUs) {
+      return C.SEEK_TARGET_UNKNOWN;
+    }
+
   }
 
   /* package */ static final class SourceLoadable implements Loadable {

--- a/library/src/main/java/com/google/android/exoplayer2/source/hls/HlsSampleStream.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/hls/HlsSampleStream.java
@@ -18,6 +18,7 @@ package com.google.android.exoplayer2.source.hls;
 import com.google.android.exoplayer2.FormatHolder;
 import com.google.android.exoplayer2.decoder.DecoderInputBuffer;
 import com.google.android.exoplayer2.source.SampleStream;
+import com.google.android.exoplayer2.C;
 import java.io.IOException;
 
 /**
@@ -54,4 +55,9 @@ import java.io.IOException;
     sampleStreamWrapper.skipToKeyframeBefore(group, timeUs);
   }
 
+  @Override
+  public int isContain(long timeUs) {
+    // TODO:
+    return C.SEEK_TARGET_UNKNOWN;
+  }
 }


### PR DESCRIPTION
http://programmingmemojohnchang.blogspot.tw/2016/12/improve-performance-of-short-seek-of.html

**Please read in detail by the link above which includes the result of experimental comparison.**

For streaming, current flow may hit the case where the whole pre-loaded data will be flushed. However, sometimes it is unnecessary to do so. An example is the short seek to the place a little ahead current playback position (ex, current playback time is 15 second & seek to 18 seconds).

Once all pre-loaded data is flushed, ex: for 4K movie, a painful delay will happen.
Also, it hurts for users who do not have unlimited network data plan.

Some MPEG DASH links such as YouTube are made according to the settings of the max interval between key frames is over 5 seconds. Hence the short seek may probably hit the claimed case.

To improve it, we may take the same way applied in GStreamer which filters the decoded-only samples at renderer.

The experimental result shows:
1. We save a lot of data download compared to original flow.
2. The seek response time is near to be the same as seamless; compared to originally it has a noticeable delay.

**The experiment is based on branch = release-v2.**
The only problem is that I DO NOT understand the flow in branch dev-v2 which forces to add RENDERER_TIMESTAMP_OFFSET_US to renderer offset. 
Hence we will get a biased value from onProcessedOutputBuffer.
Since I believe we should report the right time instead, I still put the patch here **without taking the offset into account in this patch.**

Thanks.