### PR TITLE
improve the performance of far seek

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/C.java
+++ b/library/src/main/java/com/google/android/exoplayer2/C.java
@@ -510,6 +510,32 @@ public final class C {
   public static final int MSG_CUSTOM_BASE = 10000;
 
   /**
+   *  Represents the seek position locates within the target range and the keyframe before it is found.
+   */
+  public static final int SEEK_TARGET_OK = 0;
+
+  /**
+   *   Represents the seek position locates within the target range but the keyframe before it is NOT found.
+   */
+  public static final int SEEK_TARGET_WITHIN_THE_RANGE = -1;
+
+  /**
+   *  Represents the seek position is out of the target range and precedes the eariest timestamp within sampleQueue.
+   */
+  public static final int SEEK_TARGET_OUT_OF_RANGE_BEFORE = -2;
+
+  /**
+   *  Represents the seek position is out of the target range and coming after the latest timestamp within sampleQueue.
+   */
+  public static final int SEEK_TARGET_OUT_OF_RANGE_AFTER = -3;
+
+
+  /**
+   *  Represents whether the seek position is within the target range is unknown.
+   */
+  public static final int SEEK_TARGET_UNKNOWN = -4;
+
+  /**
    * The stereo mode for 360/3D/VR videos.
    */
   @Retention(RetentionPolicy.SOURCE)

--- a/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultTrackOutput.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultTrackOutput.java
@@ -225,6 +225,15 @@ public final class DefaultTrackOutput implements TrackOutput {
     return infoQueue.getLargestQueuedTimestampUs();
   }
 
+  public boolean skipToLastKeyframe(long timeUs) {
+    long nextOffset = infoQueue.skipToLastKeyframe(timeUs);
+    if (nextOffset <= C.SEEK_TARGET_WITHIN_THE_RANGE) {
+      return false;
+    }
+    dropDownstreamTo(nextOffset);
+    return true;
+  }
+
   /**
    * Attempts to skip to the keyframe before the specified time, if it's present in the buffer.
    *
@@ -772,6 +781,40 @@ public final class DefaultTrackOutput implements TrackOutput {
       extrasHolder.nextOffset = queueSize > 0 ? offsets[relativeReadIndex]
           : extrasHolder.offset + extrasHolder.size;
       return C.RESULT_BUFFER_READ;
+    }
+
+    public synchronized long skipToLastKeyframe(long timeUs) {
+      if (timeUs <= largestQueuedTimestampUs) {
+        if (queueSize == 0 || timeUs < timesUs[relativeReadIndex]) {
+          return C.SEEK_TARGET_OUT_OF_RANGE_BEFORE; /*in fact, this case could also be applied with optimization*/
+        } else {
+          return skipToKeyframeBefore(timeUs);
+        }
+      }
+
+      // otherwise, we locate out of the sampleQueue but within the last media chunk.
+      int lastWriteIndex = (relativeWriteIndex == 0 ? capacity : relativeWriteIndex) - 1;
+      int sampleCount = 0;
+      int searchIndex = lastWriteIndex;
+      while (searchIndex != relativeReadIndex) {
+        sampleCount++; 
+        if ((flags[searchIndex] & C.BUFFER_FLAG_KEY_FRAME) != 0) {
+          // We've found the first keyframe from upstream side.
+          break;
+        }
+        searchIndex = (searchIndex > 0 ? (searchIndex - 1) : (capacity - 1));
+      }
+
+      if (searchIndex == relativeReadIndex) {
+        return C.SEEK_TARGET_OUT_OF_RANGE_AFTER;
+      }
+
+      int dropCount = (queueSize - sampleCount);
+      queueSize = sampleCount;
+      relativeReadIndex = searchIndex;
+      absoluteReadIndex += dropCount;
+
+      return offsets[relativeReadIndex];
     }
 
     /**

--- a/library/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -202,8 +202,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   private boolean outputStreamEnded;
   private boolean waitingForKeys;
 
-  private long latestResetPosition;
-
   protected DecoderCounters decoderCounters;
 
   /**
@@ -232,7 +230,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     outputBufferInfo = new MediaCodec.BufferInfo();
     codecReconfigurationState = RECONFIGURATION_STATE_NONE;
     codecReinitializationState = REINITIALIZATION_STATE_NONE;
-    latestResetPosition = C.TIME_UNSET;
   }
 
   @Override
@@ -391,7 +388,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   protected void onPositionReset(long positionUs, boolean joining) throws ExoPlaybackException {
     inputStreamEnded = false;
     outputStreamEnded = false;
-    latestResetPosition = positionUs;
     if (codec != null) {
       flushCodec();
     }
@@ -890,11 +886,6 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         }
         return false;
       }
-    }
-
-    /*latestResetPosition works as Gstreamer's segment stop for filtering out-of-range frames at renderer*/
-    if (latestResetPosition > outputBufferInfo.presentationTimeUs) {
-      shouldSkipOutputBuffer = true;
     }
 
     if (processOutputBuffer(positionUs, elapsedRealtimeUs, codec, outputBuffers[outputIndex],

--- a/library/src/main/java/com/google/android/exoplayer2/source/chunk/ChunkSampleStream.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/chunk/ChunkSampleStream.java
@@ -114,15 +114,30 @@ public class ChunkSampleStream<T extends ChunkSource> implements SampleStream, S
     }
   }
 
+  public boolean isWithinLastChunk(long positionUs) {
+    if (isPendingReset() || loadingFinished) {
+      return false;
+    } else {
+      return ((positionUs >= getCurrentLoadPositionUs()) && (positionUs < getNextLoadPositionUs()));
+    }
+  }
+
   /**
    * Seeks to the specified position in microseconds.
    *
    * @param positionUs The seek position in microseconds.
    */
   public void seekToUs(long positionUs) {
+    boolean result;
+  
     lastSeekPositionUs = positionUs;
+    if (isWithinLastChunk(positionUs)) {
+      result = sampleQueue.skipToLastKeyframe(positionUs);
+    } else {
+      result = sampleQueue.skipToKeyframeBefore(positionUs);
+    }
     // If we're not pending a reset, see if we can seek within the sample queue.
-    boolean seekInsideBuffer = !isPendingReset() && sampleQueue.skipToKeyframeBefore(positionUs);
+    boolean seekInsideBuffer = (!isPendingReset()) && (result == true);
     if (seekInsideBuffer) {
       // We succeeded. All we need to do is discard any chunks that we've moved past.
       while (mediaChunks.size() > 1
@@ -282,6 +297,14 @@ public class ChunkSampleStream<T extends ChunkSource> implements SampleStream, S
         loadable.trackSelectionReason, loadable.trackSelectionData, loadable.startTimeUs,
         loadable.endTimeUs, elapsedRealtimeMs);
     return true;
+  }
+
+  public long getCurrentLoadPositionUs() {
+    if (isPendingReset()) {
+      return pendingResetPositionUs;
+    } else {
+      return loadingFinished ? C.TIME_END_OF_SOURCE : mediaChunks.getLast().startTimeUs;
+    }
   }
 
   @Override

--- a/library/src/main/java/com/google/android/exoplayer2/source/chunk/ChunkSampleStream.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/chunk/ChunkSampleStream.java
@@ -137,7 +137,8 @@ public class ChunkSampleStream<T extends ChunkSource> implements SampleStream, S
       result = sampleQueue.skipToKeyframeBefore(positionUs);
     }
     // If we're not pending a reset, see if we can seek within the sample queue.
-    boolean seekInsideBuffer = (!isPendingReset()) && (result == true);
+    boolean seekInsideBuffer = !isPendingReset() &&
+        sampleQueue.skipToKeyframeBefore(positionUs, isWithinLastChunk(positionUs));
     if (seekInsideBuffer) {
       // We succeeded. All we need to do is discard any chunks that we've moved past.
       while (mediaChunks.size() > 1


### PR DESCRIPTION
http://programmingmemojohnchang.blogspot.tw/2016/12/improve-performance-of-short-seek-of_22.html

#2253 

**Please read in detail by the link above which includes the result of experimental comparison**.

Here we do optimize to the upstream side.

Originally if the seek target is behind sampleQueue at the upstream side, we will clean up the whole sampleQueue. Then do refetch from the media chunk which contains the search target.

Obviously, there is a waste in downloading redundant data. As the result, if we keep the the data of the last partially downloaded media chunk, it could save some. 

If the conditions below are satisfied, we could try to locate the last key frame within sampleQueue and drop the out-of-range (decoded only) samples at renderer.
1. The search target locates within the last media chunk.
2. The nearest key frame precedes the search target has been either within sampleQueue or sent to decoded (or rendered).

To take use of this fact, we create a new function named skipToLastKeyframe(). It tries to find the last key sample within the sampleQueue. Also, we create a function named isWithinLastChunk() to check whether the seek target locates within the last media chunk.
Finally, we drop the out-of-range (decode only) samples at renderer.

The experimental result shows a speed up ~252.5%. for 4K MPEG DASH streaming source.

