### PR TITLE
Add default artwork support to SimpleExoPlayerView

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/ui/SimpleExoPlayerView.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ui/SimpleExoPlayerView.java
@@ -179,6 +179,7 @@ public final class SimpleExoPlayerView extends FrameLayout {
   private SimpleExoPlayer player;
   private boolean useController;
   private boolean useArtwork;
+  private Bitmap defaultArtwork;
   private int controllerShowTimeoutMs;
 
   public SimpleExoPlayerView(Context context) {
@@ -194,6 +195,7 @@ public final class SimpleExoPlayerView extends FrameLayout {
 
     int playerLayoutId = R.layout.exo_simple_player_view;
     boolean useArtwork = true;
+    int defaultArtwork = 0;
     boolean useController = true;
     int surfaceType = SURFACE_TYPE_SURFACE_VIEW;
     int resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT;
@@ -205,6 +207,8 @@ public final class SimpleExoPlayerView extends FrameLayout {
         playerLayoutId = a.getResourceId(R.styleable.SimpleExoPlayerView_player_layout_id,
             playerLayoutId);
         useArtwork = a.getBoolean(R.styleable.SimpleExoPlayerView_use_artwork, useArtwork);
+        defaultArtwork = a.getResourceId(R.styleable.SimpleExoPlayerView_default_artwork,
+                defaultArtwork);
         useController = a.getBoolean(R.styleable.SimpleExoPlayerView_use_controller, useController);
         surfaceType = a.getInt(R.styleable.SimpleExoPlayerView_surface_type, surfaceType);
         resizeMode = a.getInt(R.styleable.SimpleExoPlayerView_resize_mode, resizeMode);
@@ -246,6 +250,11 @@ public final class SimpleExoPlayerView extends FrameLayout {
     // Artwork view.
     artworkView = (ImageView) findViewById(R.id.exo_artwork);
     this.useArtwork = useArtwork && artworkView != null;
+    if (defaultArtwork != 0) {
+      this.defaultArtwork = BitmapFactory.decodeResource(context.getResources(), defaultArtwork);
+    } else {
+      this.defaultArtwork = null;
+    }
 
     // Subtitle view.
     subtitleView = (SubtitleView) findViewById(R.id.exo_subtitles);
@@ -347,6 +356,26 @@ public final class SimpleExoPlayerView extends FrameLayout {
     Assertions.checkState(!useArtwork || artworkView != null);
     if (this.useArtwork != useArtwork) {
       this.useArtwork = useArtwork;
+      updateForCurrentTrackSelections();
+    }
+  }
+
+  /**
+   * Returns the default artwork to display.
+   */
+  public Bitmap getDefaultArtwork() {
+    return defaultArtwork;
+  }
+
+  /**
+   * Sets the default artwork to display if {@code useArtwork} is {@code true} and no artwork is
+   * present in the media.
+   *
+   * @param defaultArtwork the default artwork to display.
+   */
+  public void setDefaultArtwork(Bitmap defaultArtwork) {
+    if (this.defaultArtwork != defaultArtwork) {
+      this.defaultArtwork = defaultArtwork;
       updateForCurrentTrackSelections();
     }
   }
@@ -569,6 +598,9 @@ public final class SimpleExoPlayerView extends FrameLayout {
           }
         }
       }
+      if (setArtworkFromBitmap(defaultArtwork)) {
+        return;
+      }
     }
     // Artwork disabled or unavailable.
     hideArtwork();
@@ -580,18 +612,23 @@ public final class SimpleExoPlayerView extends FrameLayout {
       if (metadataEntry instanceof ApicFrame) {
         byte[] bitmapData = ((ApicFrame) metadataEntry).pictureData;
         Bitmap bitmap = BitmapFactory.decodeByteArray(bitmapData, 0, bitmapData.length);
-        if (bitmap != null) {
-          int bitmapWidth = bitmap.getWidth();
-          int bitmapHeight = bitmap.getHeight();
-          if (bitmapWidth > 0 && bitmapHeight > 0) {
-            if (contentFrame != null) {
-              contentFrame.setAspectRatio((float) bitmapWidth / bitmapHeight);
-            }
-            artworkView.setImageBitmap(bitmap);
-            artworkView.setVisibility(VISIBLE);
-            return true;
-          }
+        return setArtworkFromBitmap(bitmap);
+      }
+    }
+    return false;
+  }
+
+  private boolean setArtworkFromBitmap(Bitmap bitmap) {
+    if (bitmap != null) {
+      int bitmapWidth = bitmap.getWidth();
+      int bitmapHeight = bitmap.getHeight();
+      if (bitmapWidth > 0 && bitmapHeight > 0) {
+        if (contentFrame != null) {
+          contentFrame.setAspectRatio((float) bitmapWidth / bitmapHeight);
         }
+        artworkView.setImageBitmap(bitmap);
+        artworkView.setVisibility(VISIBLE);
+        return true;
       }
     }
     return false;

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -37,6 +37,7 @@
 
   <declare-styleable name="SimpleExoPlayerView">
     <attr name="use_artwork" format="boolean"/>
+    <attr name="default_artwork" format="reference"/>
     <attr name="use_controller" format="boolean"/>
     <attr name="surface_type"/>
     <attr name="show_timeout"/>


### PR DESCRIPTION
Add support for a default artwork image that is displayed if no artwork can be found in the metadata.