### PR TITLE
reconfigure audiotrack on format change

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/audio/SimpleDecoderAudioRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/audio/SimpleDecoderAudioRenderer.java
@@ -552,6 +552,7 @@ public abstract class SimpleDecoderAudioRenderer extends BaseRenderer implements
       // There aren't any final output buffers, so release the decoder immediately.
       releaseDecoder();
       maybeInitDecoder();
+      audioTrackNeedsConfigure = true;
     }
 
     eventDispatcher.inputFormatChanged(newFormat);


### PR DESCRIPTION
under certain circumstances (e.g. seek to a position where the input format
changed) the audio track needs a reconfigure even if there aren't any
pending buffers