### PR TITLE
Opus: use fixed max size in Opus decoding

### DIFF
--- a/extensions/opus/src/main/jni/opus_jni.cc
+++ b/extensions/opus/src/main/jni/opus_jni.cc
@@ -59,6 +59,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 }
 
 static const int kBytesPerSample = 2;  // opus fixed point uses 16 bit samples.
+static const int kMaxOpusOutputPacketSizeSamples = 960 * 6;// Maximum packet size used in Xiph's opusdec.
 static int channelCount;
 static int errorCode;
 
@@ -101,7 +102,7 @@ DECODER_FUNC(jint, opusDecode, jlong jDecoder, jlong jTimeUs,
 
   const int32_t inputSampleCount =
       opus_packet_get_nb_samples(inputBuffer, inputSize, sampleRate);
-  const jint outputSize = inputSampleCount * kBytesPerSample * channelCount;
+  const jint outputSize = kMaxOpusOutputPacketSizeSamples * kBytesPerSample * channelCount;
 
   env->CallObjectMethod(jOutputBuffer, outputBufferInit, jTimeUs, outputSize);
   const jobject jOutputBufferData = env->CallObjectMethod(jOutputBuffer,
@@ -110,7 +111,7 @@ DECODER_FUNC(jint, opusDecode, jlong jDecoder, jlong jTimeUs,
   int16_t* outputBufferData = reinterpret_cast<int16_t*>(
       env->GetDirectBufferAddress(jOutputBufferData));
   int sampleCount = opus_multistream_decode(decoder, inputBuffer, inputSize,
-      outputBufferData, outputSize, 0);
+      outputBufferData, kMaxOpusOutputPacketSizeSamples, 0);
   // record error code
   errorCode = (sampleCount < 0) ? sampleCount : 0;
   return (sampleCount < 0) ? sampleCount


### PR DESCRIPTION
 As per [documentation](http://opus-codec.org/docs/opus_api-1.1.3/group__opus__multistream.html#gaa4b89541efe01970cf52e4a336db3ad0) of the opus_multistream_decode: 
> **_frame_size_**: int: The number of samples per channel of available space in pcm. **If this is less than the maximum packet duration (120 ms; 5760 for 48kHz), this function will not be capable of decoding some packets**. In the case of PLC (data==NULL) or FEC (decode_fec=1), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet. For the PLC and FEC cases, frame_size must be a multiple of 2.5 ms. 

Sample reference code 
[https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libopusdec.c#L142](https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/libopusdec.c#L142)
[https://android.googlesource.com/platform/frameworks/av/+/master/media/libstagefright/codecs/opus/dec/SoftOpus.cpp#461](https://android.googlesource.com/platform/frameworks/av/+/master/media/libstagefright/codecs/opus/dec/SoftOpus.cpp#461)

Original pull request : #2207 
