### PR TITLE
Add timeline size check to avoid IndexOutOfBoundsException.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/source/dash/manifest/SegmentBase.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/dash/manifest/SegmentBase.java
@@ -161,7 +161,7 @@ public abstract class SegmentBase {
      * @see DashSegmentIndex#getDurationUs(int, long)
      */
     public final long getSegmentDurationUs(int sequenceNumber, long periodDurationUs) {
-      if (segmentTimeline != null) {
+      if (segmentTimeline != null && segmentTimeline.size() > sequenceNumber - startNumber) {
         long duration = segmentTimeline.get(sequenceNumber - startNumber).duration;
         return (duration * C.MICROS_PER_SECOND) / timescale;
       } else {


### PR DESCRIPTION
Closes google/ExoPlayer#1865.