### PR TITLE
Update proguard-rules.txt

### DIFF
--- a/extensions/flac/proguard-rules.txt
+++ b/extensions/flac/proguard-rules.txt
@@ -9,3 +9,7 @@
 -keep class com.google.android.exoplayer2.ext.flac.FlacDecoderJni {
     *;
 }
+ 
+-keep class com.google.android.exoplayer2.util.FlacStreamInfo {
+    *;
+}


### PR DESCRIPTION
add a proguard rule for FlacStreamInfo.

crash without this rule:

```
02-15 22:57:10.520 28132-28132/? A/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
02-15 22:57:10.520 28132-28132/? A/DEBUG: Build fingerprint: 'google/sailfish/sailfish:7.1.1/NMF26U/3562008:user/release-keys'
02-15 22:57:10.520 28132-28132/? A/DEBUG: Revision: '0'
02-15 22:57:10.520 28132-28132/? A/DEBUG: ABI: 'arm'
02-15 22:57:10.520 28132-28132/? A/DEBUG: pid: 28075, tid: 28131, name: Loader:Extracto  >>> ornithopter.soiree <<<
02-15 22:57:10.520 28132-28132/? A/DEBUG: signal 6 (SIGABRT), code -6 (SI_TKILL), fault addr --------
02-15 22:57:10.522 28132-28132/? A/DEBUG: Abort message: 'art/runtime/java_vm_ext.cc:470] JNI DETECTED ERROR IN APPLICATION: java_class == null'
02-15 22:57:10.522 28132-28132/? A/DEBUG:     r0 00000000  r1 00006de3  r2 00000006  r3 00000008
02-15 22:57:10.522 28132-28132/? A/DEBUG:     r4 d20ff978  r5 00000006  r6 d20ff920  r7 0000010c
02-15 22:57:10.522 28132-28132/? A/DEBUG:     r8 00000000  r9 0000000a  sl 00000896  fp d2a3f300
02-15 22:57:10.522 28132-28132/? A/DEBUG:     ip 0000000b  sp d20fe550  lr f1f82537  pc f1f84da0  cpsr 600f0010
02-15 22:57:10.529 28132-28132/? A/DEBUG: backtrace:
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #00 pc 00049da0  /system/lib/libc.so (tgkill+12)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #01 pc 00047533  /system/lib/libc.so (pthread_kill+34)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #02 pc 0001d635  /system/lib/libc.so (raise+10)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #03 pc 00019181  /system/lib/libc.so (__libc_android_abort+34)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #04 pc 00017048  /system/lib/libc.so (abort+4)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #05 pc 0031b43d  /system/lib/libart.so (_ZN3art7Runtime5AbortEPKc+328)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #06 pc 000b526b  /system/lib/libart.so (_ZN3art10LogMessageD2Ev+1134)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #07 pc 0023a609  /system/lib/libart.so (_ZN3art9JavaVMExt8JniAbortEPKcS2_+1584)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #08 pc 0023a8d3  /system/lib/libart.so (_ZN3art9JavaVMExt9JniAbortFEPKcS2_z+66)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #09 pc 00265f41  /system/lib/libart.so (_ZN3art3JNI11GetMethodIDEP7_JNIEnvP7_jclassPKcS6_+524)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #10 pc 0000b490  /data/app/ornithopter.soiree-1/lib/arm/libflacJNI.so (Java_com_google_android_exoplayer2_ext_flac_FlacDecoderJni_flacDecodeMetadata+120)
02-15 22:57:10.529 28132-28132/? A/DEBUG:     #11 pc 0039e751  /data/app/ornithopter.soiree-1/oat/arm/base.odex (offset 0x379000)
```