### PR TITLE
Make DrmSessionException constructor public to enable creating custom DrmSessionManager implementations.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/drm/DrmSession.java
+++ b/library/src/main/java/com/google/android/exoplayer2/drm/DrmSession.java
@@ -31,7 +31,7 @@ public interface DrmSession<T extends ExoMediaCrypto> {
   /** Wraps the exception which is the cause of the error state. */
   class DrmSessionException extends Exception {
 
-    DrmSessionException(Exception e) {
+    public DrmSessionException(Exception e) {
       super(e);
     }
 


### PR DESCRIPTION
I noticed that in the current dev-v2 branch it is not possible to implement a custom `DrmSessionManager` which implements the `DrmSession` interface in a reasonable way.
The problem is that DrmSessionException has a package-local constructor, which means that the implementation of `DrmSession.onError` can't return anything other than `null` (unless, of course, the implementation would be in the same package, like `DefaultDrmSessionManager`).