### PR TITLE
Support comma separators in ISO-8601 date/time format for milliseconds

### DIFF
--- a/library/src/androidTest/java/com/google/android/exoplayer2/util/UtilTest.java
+++ b/library/src/androidTest/java/com/google/android/exoplayer2/util/UtilTest.java
@@ -142,8 +142,10 @@ public class UtilTest extends TestCase {
   public void testParseXsDateTime() throws Exception {
     assertEquals(1403219262000L, Util.parseXsDateTime("2014-06-19T23:07:42"));
     assertEquals(1407322800000L, Util.parseXsDateTime("2014-08-06T11:00:00Z"));
+    assertEquals(1407322800000L, Util.parseXsDateTime("2014-08-06T11:00:00,000Z"));
     assertEquals(1411161535000L, Util.parseXsDateTime("2014-09-19T13:18:55-08:00"));
     assertEquals(1411161535000L, Util.parseXsDateTime("2014-09-19T13:18:55-0800"));
+    assertEquals(1411161535000L, Util.parseXsDateTime("2014-09-19T13:18:55.000-0800"));
   }
 
   public void testUnescapeInvalidFileName() {

--- a/library/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -94,7 +94,7 @@ public final class Util {
   private static final String TAG = "Util";
   private static final Pattern XS_DATE_TIME_PATTERN = Pattern.compile(
       "(\\d\\d\\d\\d)\\-(\\d\\d)\\-(\\d\\d)[Tt]"
-      + "(\\d\\d):(\\d\\d):(\\d\\d)(\\.(\\d+))?"
+      + "(\\d\\d):(\\d\\d):(\\d\\d)([\\.,](\\d+))?"
       + "([Zz]|((\\+|\\-)(\\d\\d):?(\\d\\d)))?");
   private static final Pattern XS_DURATION_PATTERN =
       Pattern.compile("^(-)?P(([0-9]*)Y)?(([0-9]*)M)?(([0-9]*)D)?"


### PR DESCRIPTION
Presently the regex for parsing ISO-8601 formatted datetimes for supporting `EXT-X-PROGRAM-DATE-TIME` in HLS only supports period (`.`) separators.  Some HLS stream packagers use commas (`,`) to separate milliseconds.

Examples:

`2014-08-06T11:00:00.000Z`

`2014-08-06T11:00:00,000Z`

[ISO 8601:2004](https://www.iso.org/standard/40874.html) states that parsers should support both delineators, with a preference for commas.

[Additional information](https://en.wikipedia.org/wiki/ISO_8601)

> A decimal mark, either a comma or a dot (without any preference as stated in resolution 10 of the 22nd General Conference CGPM in 2003,[16] but with a preference for a comma according to ISO 8601:2004)