### PR TITLE
Fix the waiting process was called too much.

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
+++ b/library/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
@@ -431,7 +431,7 @@ public final class HlsPlaylistTracker implements Loader.Callback<ParsingLoadable
     private long lastSnapshotLoadMs;
     private long lastSnapshotAccessTimeMs;
     private long blacklistUntilMs;
-    private boolean isPendingLoadedPlaylist;
+    private boolean isPendingLoadPlaylist;
 
     public MediaPlaylistBundle(HlsUrl playlistUrl, long initialLastSnapshotAccessTimeMs) {
       this.playlistUrl = playlistUrl;
@@ -511,14 +511,14 @@ public final class HlsPlaylistTracker implements Loader.Callback<ParsingLoadable
 
     @Override
     public void run() {
-      isPendingLoadedPlaylist = false;
+      isPendingLoadPlaylist = false;
       loadPlaylist();
     }
 
     // Internal methods.
 
     private void processLoadedPlaylist(HlsMediaPlaylist loadedPlaylist) {
-      if (isPendingLoadedPlaylist) {
+      if (isPendingLoadPlaylist) {
         return;
       }
       HlsMediaPlaylist oldPlaylist = playlistSnapshot;
@@ -534,7 +534,7 @@ public final class HlsPlaylistTracker implements Loader.Callback<ParsingLoadable
       }
       if (refreshDelayUs != C.TIME_UNSET) {
         // See HLS spec v20, section 6.3.4 for more information on media playlist refreshing.
-        isPendingLoadedPlaylist = playlistRefreshHandler.postDelayed(this, C.usToMs(refreshDelayUs));
+        isPendingLoadPlaylist = playlistRefreshHandler.postDelayed(this, C.usToMs(refreshDelayUs));
       }
     }
 


### PR DESCRIPTION
The onLoadCompletedhls calling processLoadedPlaylist is triggered by loadPlaylist, but it fires at multiple events.
As a result, waiting for an excessive playlist rereading process not compliant with HLS spec v 20, section 6.3.4 "for more information on media playlist refreshing" was called. Therefore, since the acquisition process was excessive on the server side, measures were taken.

As for the correction contents, we implemented block processing with a flag between process wait start and wait end of processLoadedPlaylist to comply with hls reload specification.

Before:
```
22:43:52.298 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 31471e2
22:43:52.299 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:43:53.524 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 31471e2
22:43:53.524 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:43:54.013 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 31471e2
22:43:54.013 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:43:54.603 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 3bd02fc
22:43:54.603 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:43:55.416 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 31471e2
22:43:55.973 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 31471e2
22:43:55.973 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:43:56.353 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 3bd02fc
22:43:56.354 processLoadedPlaylist(postDelayed) refreshDelayUs: 6000000
22:43:56.440 processLoadedPlaylist call isPending: true MediaPlaylistBundle: 31471e2
22:43:56.440 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:43:56.607 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 31471e2
22:43:56.607 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:43:57.089 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 31471e2
22:43:57.089 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:43:57.682 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 3bd02fc
```

After:
```
22:34:40.251 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 7e327ef
22:34:40.251 processLoadedPlaylist(postDelayed) refreshDelayUs: 6000000
22:34:40.387 processLoadedPlaylist call isPending: true MediaPlaylistBundle: 68bca2e
22:34:41.434 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 68bca2e
22:34:41.978 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 68bca2e
22:34:41.978 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:34:45.066 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 68bca2e
22:34:45.557 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 68bca2e
22:34:45.557 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:34:46.338 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 7e327ef
22:34:46.338 processLoadedPlaylist(postDelayed) refreshDelayUs: 6000000
22:34:46.423 processLoadedPlaylist call isPending: true MediaPlaylistBundle: 68bca2e
22:34:48.655 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 68bca2e
22:34:48.655 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:34:51.748 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 68bca2e
22:34:52.276 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 68bca2e
22:34:52.276 processLoadedPlaylist(postDelayed) refreshDelayUs: 3000000
22:34:52.423 processLoadedPlaylist call isPending: false MediaPlaylistBundle: 7e327ef
22:34:52.423 processLoadedPlaylist(postDelayed) refreshDelayUs: 6000000
22:34:52.490 processLoadedPlaylist call isPending: true MediaPlaylistBundle: 68bca2e
```

* IsPending is the flag implemented this time when processLoadedPlaylist is executed
* RefreshDelayUs is the configured wait time at runtime
* MediaPlaylistBundle: xxxxxxx is the instance id of the running MediaPlaylistBundle
* The # EXT-X-TARGETDURATION of our playlist was set to 6.

Please note that postDelayed is running if isPending: true.