### PR TITLE
Add RTMP support

### DIFF
--- a/demo/src/main/assets/media.exolist.json
+++ b/demo/src/main/assets/media.exolist.json
@@ -340,6 +340,10 @@
     "name": "Misc",
     "samples": [
       {
+        "name": "HKS-TV RTMP live stream",
+        "uri": "rtmp://live.hkstv.hk.lxdns.com/live/hks"
+      },
+      {
         "name": "Dizzy",
         "uri": "http://html5demos.com/assets/dizzy.mp4"
       },

--- a/demo/src/main/java/com/google/android/exoplayer2/demo/DemoApplication.java
+++ b/demo/src/main/java/com/google/android/exoplayer2/demo/DemoApplication.java
@@ -21,6 +21,8 @@ import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
+import com.google.android.exoplayer2.upstream.RtmpDataSource;
+import com.google.android.exoplayer2.upstream.RtmpDataSourceFactory;
 import com.google.android.exoplayer2.util.Util;
 
 /**
@@ -43,6 +45,10 @@ public class DemoApplication extends Application {
 
   public HttpDataSource.Factory buildHttpDataSourceFactory(DefaultBandwidthMeter bandwidthMeter) {
     return new DefaultHttpDataSourceFactory(userAgent, bandwidthMeter);
+  }
+
+  public RtmpDataSource.Factory buildRtmpDataSourceFactory(DefaultBandwidthMeter bandwidthMeter) {
+    return new RtmpDataSourceFactory(bandwidthMeter);
   }
 
   public boolean useExtensionRenderers() {

--- a/library/src/main/java/com/google/android/exoplayer2/C.java
+++ b/library/src/main/java/com/google/android/exoplayer2/C.java
@@ -279,7 +279,7 @@ public final class C {
    * Represents a streaming or other media type.
    */
   @Retention(RetentionPolicy.SOURCE)
-  @IntDef({TYPE_DASH, TYPE_SS, TYPE_HLS, TYPE_OTHER})
+  @IntDef({TYPE_DASH, TYPE_SS, TYPE_HLS, TYPE_RTMP, TYPE_OTHER})
   public @interface ContentType {}
   /**
    * Value returned by {@link Util#inferContentType(String)} for DASH manifests.
@@ -294,10 +294,14 @@ public final class C {
    */
   public static final int TYPE_HLS = 2;
   /**
-   * Value returned by {@link Util#inferContentType(String)} for files other than DASH, HLS or
+   * Value returned by {@link Util#inferContentType(String)} for RTMP manifests.
+   */
+  public static final int TYPE_RTMP = 3;
+  /**
+   * Value returned by {@link Util#inferContentType(String)} for files other than DASH, HLS, RTMP or
    * Smooth Streaming manifests.
    */
-  public static final int TYPE_OTHER = 3;
+  public static final int TYPE_OTHER = 4;
 
   /**
    * A return value for methods where the end of an input was encountered.

--- a/library/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -484,8 +484,8 @@ import java.io.IOException;
         && (playingPeriodDurationUs == C.TIME_UNSET
         || playingPeriodDurationUs <= playbackInfo.positionUs)
         && playingPeriodHolder.isLast) {
-      setState(ExoPlayer.STATE_ENDED);
-      stopRenderers();
+      // setState(ExoPlayer.STATE_ENDED);
+      // stopRenderers();
     } else if (state == ExoPlayer.STATE_BUFFERING) {
       boolean isNewlyReady = enabledRenderers.length > 0
           ? (allRenderersReadyOrEnded && haveSufficientBuffer(rebuffering))

--- a/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultExtractorsFactory.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/DefaultExtractorsFactory.java
@@ -32,6 +32,7 @@ import java.util.List;
  * <li>MPEG TS ({@link com.google.android.exoplayer2.extractor.ts.TsExtractor})</li>
  * <li>MPEG PS ({@link com.google.android.exoplayer2.extractor.ts.PsExtractor})</li>
  * <li>FLV ({@link com.google.android.exoplayer2.extractor.flv.FlvExtractor})</li>
+ * <li>FLV STREAM ({@link com.google.android.exoplayer2.extractor.flv.FlvStreamExtractor})</li>
  * <li>WAV ({@link com.google.android.exoplayer2.extractor.wav.WavExtractor})</li>
  * <li>FLAC (only available if the FLAC extension is built and included)</li>
  * </ul>
@@ -104,6 +105,13 @@ public final class DefaultExtractorsFactory implements ExtractorsFactory {
         try {
           extractorClasses.add(
               Class.forName("com.google.android.exoplayer2.extractor.flv.FlvExtractor")
+                  .asSubclass(Extractor.class));
+        } catch (ClassNotFoundException e) {
+          // Extractor not found.
+        }
+        try {
+          extractorClasses.add(
+              Class.forName("com.google.android.exoplayer2.extractor.flv.FlvStreamExtractor")
                   .asSubclass(Extractor.class));
         } catch (ClassNotFoundException e) {
           // Extractor not found.

--- a/library/src/main/java/com/google/android/exoplayer2/extractor/flv/FlvStreamExtractor.java
+++ b/library/src/main/java/com/google/android/exoplayer2/extractor/flv/FlvStreamExtractor.java
@@ -1,0 +1,221 @@
+package com.google.android.exoplayer2.extractor.flv;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.extractor.Extractor;
+import com.google.android.exoplayer2.extractor.ExtractorInput;
+import com.google.android.exoplayer2.extractor.ExtractorOutput;
+import com.google.android.exoplayer2.extractor.ExtractorsFactory;
+import com.google.android.exoplayer2.extractor.PositionHolder;
+import com.google.android.exoplayer2.extractor.SeekMap;
+import com.google.android.exoplayer2.util.ParsableByteArray;
+import com.google.android.exoplayer2.util.Util;
+
+import java.io.IOException;
+
+/**
+ * Facilitates the extraction of data from the FLV streaming.
+ */
+public class FlvStreamExtractor implements Extractor, SeekMap {
+
+  /**
+   * Factory for {@link FlvStreamExtractor} instances.
+   */
+  public static final ExtractorsFactory FACTORY = new ExtractorsFactory() {
+
+      @Override
+      public Extractor[] createExtractors() {
+        return new Extractor[] {new FlvStreamExtractor()};
+      }
+
+  };
+
+  // Parser states.
+  private static final int STATE_READING_FLV_HEADER = 1;
+  private static final int STATE_READING_TAG_HEADER = 2;
+  private static final int STATE_READING_TAG_DATA = 3;
+
+  // Tag types.
+  private static final int TAG_TYPE_AUDIO = 8;
+  private static final int TAG_TYPE_VIDEO = 9;
+
+  // FLV streaming identifier.
+  private static final int FLV_STREAMING_TAG = Util.getIntegerCodeForString("RTMP");
+  private static final int FLV_STREAMING_TAG_SIZE = 4;
+
+  // Temporary buffers.
+  private final ParsableByteArray scratch;
+  private final ParsableByteArray headerBuffer;
+  private final ParsableByteArray tagHeaderBuffer;
+  private final ParsableByteArray tagData;
+
+  // Extractor outputs.
+  private ExtractorOutput extractorOutput;
+
+  // State variables.
+  private int parserState;
+  public int tagType;
+  public int tagDataSize;
+  public long tagTimestampUs;
+
+    // Tags readers.
+  private AudioTagPayloadReader audioReader;
+  private VideoTagPayloadReader videoReader;
+
+  public FlvStreamExtractor() {
+    scratch = new ParsableByteArray(FLV_STREAMING_TAG_SIZE);
+    headerBuffer = new ParsableByteArray(FLV_STREAMING_TAG_SIZE);
+    tagHeaderBuffer = new ParsableByteArray(9);
+    tagData = new ParsableByteArray();
+    parserState = STATE_READING_FLV_HEADER;
+  }
+
+  @Override
+  public boolean sniff(ExtractorInput input) throws IOException, InterruptedException {
+    // Check if file starts with "RTMP" tag
+    input.peekFully(scratch.data, 0, FLV_STREAMING_TAG_SIZE);
+    scratch.setPosition(0);
+    if (Util.getIntegerCodeForString(scratch.readString(FLV_STREAMING_TAG_SIZE)) != FLV_STREAMING_TAG) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public void init(ExtractorOutput output) {
+    this.extractorOutput = output;
+  }
+
+  @Override
+  public void seek(long position, long timeUs) {
+    parserState = STATE_READING_FLV_HEADER;
+  }
+
+  @Override
+  public void release() {
+    // Do nothing
+  }
+
+  @Override
+  public int read(ExtractorInput input, PositionHolder seekPosition) throws IOException,
+            InterruptedException {
+    while (true) {
+      switch (parserState) {
+        case STATE_READING_FLV_HEADER:
+          if (!readFlvHeader(input)) {
+            return RESULT_END_OF_INPUT;
+          }
+          break;
+        case STATE_READING_TAG_HEADER:
+          if (!readTagHeader(input)) {
+            return RESULT_END_OF_INPUT;
+          }
+          break;
+        case STATE_READING_TAG_DATA:
+          if (readTagData(input)) {
+            return RESULT_CONTINUE;
+          }
+          break;
+      }
+    }
+  }
+
+  /**
+   * Reads an FLV container header from the provided {@link ExtractorInput}.
+   *
+   * @return True if header was read successfully. False if the end of stream was reached.
+   * @throws IOException If an error occurred reading or parsing data from the source.
+   * @throws InterruptedException If the thread was interrupted.
+   */
+  private boolean readFlvHeader(ExtractorInput input) throws IOException, InterruptedException {
+    if (!input.readFully(headerBuffer.data, 0, FLV_STREAMING_TAG_SIZE, true)) {
+      // We've reached the end of the stream.
+      return false;
+    }
+
+    if (audioReader == null) {
+      audioReader = new AudioTagPayloadReader(extractorOutput.track(TAG_TYPE_AUDIO, C.TRACK_TYPE_AUDIO));
+    }
+    if (videoReader == null) {
+      videoReader = new VideoTagPayloadReader(extractorOutput.track(TAG_TYPE_VIDEO, C.TRACK_TYPE_VIDEO));
+    }
+    extractorOutput.endTracks();
+    extractorOutput.seekMap(this);
+
+    parserState = STATE_READING_TAG_HEADER;
+    return true;
+  }
+
+  /**
+   * Reads a tag header from the provided {@link ExtractorInput}.
+   *
+   * @param input The {@link ExtractorInput} from which to read.
+   * @return True if tag header was read successfully. Otherwise, false.
+   * @throws IOException If an error occurred reading or parsing data from the source.
+   * @throws InterruptedException If the thread was interrupted.
+   */
+  private boolean readTagHeader(ExtractorInput input) throws IOException, InterruptedException {
+    if (!input.readFully(tagHeaderBuffer.data, 0, tagHeaderBuffer.limit(), true)) {
+      // We've reached the end of the stream.
+      return false;
+    }
+
+    tagHeaderBuffer.setPosition(0);
+    tagType = tagHeaderBuffer.readUnsignedByte();
+    tagDataSize = tagHeaderBuffer.readInt();
+    tagTimestampUs = tagHeaderBuffer.readInt() * 1000L;
+    parserState = STATE_READING_TAG_DATA;
+    return true;
+  }
+
+  /**
+   * Reads the body of a tag from the provided {@link ExtractorInput}.
+   *
+   * @param input The {@link ExtractorInput} from which to read.
+   * @return True if the data was consumed by a reader. False if it was skipped.
+   * @throws IOException If an error occurred reading or parsing data from the source.
+   * @throws InterruptedException If the thread was interrupted.
+   */
+  private boolean readTagData(ExtractorInput input) throws IOException, InterruptedException {
+    boolean wasConsumed = true;
+    if (tagType == TAG_TYPE_AUDIO && audioReader != null) {
+      audioReader.consume(prepareTagData(input), tagTimestampUs);
+    } else if (tagType == TAG_TYPE_VIDEO && videoReader != null) {
+      videoReader.consume(prepareTagData(input), tagTimestampUs);
+    } else {
+      input.skipFully(tagDataSize);
+      wasConsumed = false;
+    }
+    parserState = STATE_READING_TAG_HEADER;
+    return wasConsumed;
+  }
+
+  private ParsableByteArray prepareTagData(ExtractorInput input) throws IOException,
+      InterruptedException {
+    if (tagDataSize > tagData.capacity()) {
+      tagData.reset(new byte[Math.max(tagData.capacity() * 2, tagDataSize)], 0);
+    } else {
+      tagData.setPosition(0);
+    }
+    tagData.setLimit(tagDataSize);
+    input.readFully(tagData.data, 0, tagDataSize);
+    return tagData;
+  }
+
+  // SeekMap implementation.
+
+  @Override
+  public boolean isSeekable() {
+    return false;
+  }
+
+  @Override
+  public long getDurationUs() {
+    return C.TIME_UNSET;
+  }
+
+  @Override
+  public long getPosition(long timeUs) {
+    return 0;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/RtmpDataSource.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/RtmpDataSource.java
@@ -1,0 +1,151 @@
+package com.google.android.exoplayer2.upstream;
+
+import android.net.Uri;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.upstream.rtmp.DefaultRtmpPlayer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * An RTMP {@link DataSource}.
+ */
+public final class RtmpDataSource implements DataSource {
+
+  /**
+   * A factory for {@link RtmpDataSource} instances.
+   */
+  public interface Factory extends DataSource.Factory {
+
+    @Override
+    RtmpDataSource createDataSource();
+
+  }
+
+  /**
+   * Thrown when an error is encountered when trying to read from a {@link RtmpDataSource}.
+   */
+  public static final class RtmpDataSourceException extends IOException {
+
+    public RtmpDataSourceException(String msg) {
+      super(msg);
+    }
+
+    public RtmpDataSourceException(IOException cause) {
+      super(cause);
+    }
+
+    public RtmpDataSourceException(String msg, IOException cause) {
+      super(msg, cause);
+    }
+
+  }
+
+  /**
+   * The default connection timeout, in milliseconds.
+   */
+  public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 3 * 1000;
+
+  /**
+   * The default read timeout, in milliseconds.
+   */
+  public static final int DEFAULT_READ_TIMEOUT_MILLIS = 8 * 1000;
+
+  private final TransferListener<? super RtmpDataSource> listener;
+
+  private Uri uri;
+  private final int connectTimeoutMillis;
+  private final int readTimeoutMillis;
+  private final static byte[] sniffHeader = new byte[] { 'R', 'T', 'M', 'P' };
+  private boolean needToSniff = false;
+  private boolean opened = false;
+  private DefaultRtmpPlayer player = new DefaultRtmpPlayer();
+  private ByteBuffer mediaData;
+
+  /**
+   * @param listener An optional listener.
+   */
+  public RtmpDataSource(TransferListener<? super RtmpDataSource> listener) {
+    this(listener, DEFAULT_CONNECT_TIMEOUT_MILLIS, DEFAULT_READ_TIMEOUT_MILLIS);
+  }
+
+  /**
+   * @param listener An optional listener.
+   * @param connectTimeoutMillis The connection timeout, in milliseconds. A timeout of zero is
+   *     interpreted as an infinite timeout.
+   * @param readTimeoutMillis The read timeout, in milliseconds. A timeout of zero is interpreted
+   *     as an infinite timeout.
+   */
+  public RtmpDataSource(TransferListener<? super RtmpDataSource> listener, int connectTimeoutMillis,
+                        int readTimeoutMillis) {
+    this.listener = listener;
+    this.connectTimeoutMillis = connectTimeoutMillis;
+    this.readTimeoutMillis = readTimeoutMillis;
+  }
+    
+  @Override
+  public long open(DataSpec dataSpec) throws RtmpDataSourceException {
+    uri = dataSpec.uri;
+    try {
+      player.connect(uri.toString(), connectTimeoutMillis);
+    } catch (IOException ioe) {
+        throw new RtmpDataSourceException("Unable to connect to " + uri.toString(), ioe);
+    }
+
+    needToSniff = true;
+    opened = true;
+    if (listener != null) {
+      listener.onTransferStart(this, dataSpec);
+    }
+    return C.LENGTH_UNSET;
+  }
+
+  @Override
+  public int read(byte[] buffer, int offset, int readLength) throws RtmpDataSourceException {
+    int bytes = 0;
+
+    if (needToSniff) {
+      System.arraycopy(sniffHeader, 0, buffer, offset, sniffHeader.length);
+      needToSniff = false;
+      return sniffHeader.length;
+    }
+
+    if (mediaData == null || mediaData.remaining() == 0) {
+      mediaData = player.poll();
+    }
+
+    if (mediaData != null) {
+      bytes = mediaData.remaining() >= readLength ? readLength : mediaData.remaining();
+      mediaData.get(buffer, offset, bytes);
+    }
+
+    if (listener != null) {
+      listener.onBytesTransferred(this, 0);
+    }
+    return bytes;
+  }
+
+  @Override
+  public Uri getUri() {
+    return uri;
+  }
+
+  @Override
+  public void close() throws RtmpDataSourceException {
+    try {
+      player.close();
+    } catch (IllegalStateException e) {
+      // Ignore illegal state.
+    } catch (IOException ioe) {
+      ioe.printStackTrace();
+    } finally {
+      if (opened) {
+        opened = false;
+        if (listener != null) {
+          listener.onTransferEnd(this);
+        }
+      }
+    }
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/RtmpDataSourceFactory.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/RtmpDataSourceFactory.java
@@ -1,0 +1,53 @@
+package com.google.android.exoplayer2.upstream;
+
+import com.google.android.exoplayer2.upstream.RtmpDataSource.Factory;
+
+/** A {@link Factory} that produces {@link RtmpDataSource} instances. */
+public class RtmpDataSourceFactory implements Factory {
+
+  private final TransferListener<? super DataSource> listener;
+  private final int connectTimeoutMillis;
+  private final int readTimeoutMillis;
+
+  /**
+   * Constructs a RtmpDataSourceFactory. Sets {@link
+   * RtmpDataSource#DEFAULT_CONNECT_TIMEOUT_MILLIS} as the connection timeout, {@link
+   * RtmpDataSource#DEFAULT_READ_TIMEOUT_MILLIS} as the read timeout.
+   *
+   */
+  public RtmpDataSourceFactory() {
+        this(null);
+    }
+
+  /**
+   * Constructs a RtmpDataSourceFactory. Sets {@link
+   * RtmpDataSource#DEFAULT_CONNECT_TIMEOUT_MILLIS} as the connection timeout, {@link
+   * RtmpDataSource#DEFAULT_READ_TIMEOUT_MILLIS} as the read timeout and disables
+   * cross-protocol redirects.
+   *
+   * @param listener An optional listener.
+   * @see #RtmpDataSourceFactory(TransferListener, int, int)
+   */
+  public RtmpDataSourceFactory(TransferListener<? super DataSource> listener) {
+    this(listener, RtmpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, RtmpDataSource.DEFAULT_READ_TIMEOUT_MILLIS);
+  }
+
+  /**
+   * @param listener An optional listener.
+   * @param connectTimeoutMillis The connection timeout that should be used when requesting remote
+   *     data, in milliseconds. A timeout of zero is interpreted as an infinite timeout.
+   * @param readTimeoutMillis The read timeout that should be used when requesting remote data, in
+   *     milliseconds. A timeout of zero is interpreted as an infinite timeout.
+   */
+  public RtmpDataSourceFactory(TransferListener<? super DataSource> listener,
+                               int connectTimeoutMillis,int readTimeoutMillis) {
+    this.listener = listener;
+    this.connectTimeoutMillis = connectTimeoutMillis;
+    this.readTimeoutMillis = readTimeoutMillis;
+  }
+
+  @Override
+  public RtmpDataSource createDataSource() {
+    return new RtmpDataSource(listener, connectTimeoutMillis, readTimeoutMillis);
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/Crypto.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/Crypto.java
@@ -1,0 +1,73 @@
+package com.google.android.exoplayer2.upstream.rtmp;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import android.util.Log;
+
+/**
+ * Some helper utilities for SHA256, mostly (used during handshake)
+ * This is separated in order to be more easily replaced on platforms that
+ * do not have the javax.crypto.* and/or java.security.* packages
+ * <p>
+ * This implementation is directly inspired by the RTMPHandshake class of the
+ * Red5  Open Source Flash Server project
+ *
+ * @author francois
+ */
+public class Crypto {
+
+  private static final String TAG = "Crypto";
+
+  private Mac hmacSHA256;
+
+  public Crypto() {
+    try {
+      hmacSHA256 = Mac.getInstance("HmacSHA256");
+    } catch (SecurityException e) {
+      Log.e(TAG, "Security exception when getting HMAC", e);
+    } catch (NoSuchAlgorithmException e) {
+      Log.e(TAG, "HMAC SHA256 does not exist");
+    }
+  }
+
+  /**
+   * Calculates an HMAC SHA256 hash using a default key length.
+   *
+   * @param input
+   * @param key
+   * @return hmac hashed bytes
+   */
+  public byte[] calculateHmacSHA256(byte[] input, byte[] key) {
+    byte[] output = null;
+    try {
+      hmacSHA256.init(new SecretKeySpec(key, "HmacSHA256"));
+      output = hmacSHA256.doFinal(input);
+    } catch (InvalidKeyException e) {
+      Log.e(TAG, "Invalid key", e);
+    }
+    return output;
+  }
+
+  /**
+   * Calculates an HMAC SHA256 hash using a set key length.
+   *
+   * @param input
+   * @param key
+   * @param length
+   * @return hmac hashed bytes
+   */
+  public byte[] calculateHmacSHA256(byte[] input, byte[] key, int length) {
+    byte[] output = null;
+    try {
+      hmacSHA256.init(new SecretKeySpec(key, 0, length, "HmacSHA256"));
+      output = hmacSHA256.doFinal(input);
+    } catch (InvalidKeyException e) {
+      Log.e(TAG, "Invalid key", e);
+    }
+    return output;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/DefaultRtmpPlayer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/DefaultRtmpPlayer.java
@@ -1,0 +1,54 @@
+package com.google.android.exoplayer2.upstream.rtmp;
+
+import com.google.android.exoplayer2.upstream.rtmp.io.RtmpConnection;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Simple RTMP player, using vanilla Java networking (no NIO)
+ * This was created primarily to address a NIO bug in Android 2.2 when
+ * used with Apache Mina, but also to provide an easy-to-use way to access
+ * RTMP streams
+ *
+ * @author leo
+ */
+public class DefaultRtmpPlayer implements RtmpPlayer {
+
+  private RtmpConnection rtmpConnection = new RtmpConnection();
+  private boolean connected = false;
+
+  @Override
+  public void connect(String url, int timeout) throws IOException {
+    if (!connected) {
+      rtmpConnection.connect(url, timeout);
+      connected = true;
+    }
+  }
+
+  @Override
+  public ByteBuffer poll() {
+    return connected ? rtmpConnection.poll() : null;
+  }
+
+  @Override
+  public void close() throws IllegalStateException, IOException {
+    rtmpConnection.close();
+    connected = false;
+  }
+
+  @Override
+  public final String getServerIpAddr() {
+    return rtmpConnection.getServerIpAddr();
+  }
+
+  @Override
+  public final int getServerPid() {
+    return rtmpConnection.getServerPid();
+  }
+
+  @Override
+  public final int getServerId() {
+    return rtmpConnection.getServerId();
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/RtmpPlayer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/RtmpPlayer.java
@@ -1,0 +1,45 @@
+package com.google.android.exoplayer2.upstream.rtmp;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Simple RTMP player, using vanilla Java networking
+ * This was created primarily to address a NIO bug in Android 2.2 when
+ * used with Apache Mina, but also to provide an easy-to-use way to access
+ * RTMP streams
+ *
+ * @author francois, leo
+ */
+public interface RtmpPlayer {
+
+  /**
+   * Connect to the RTMP server and create the stream and wait for the meta data.
+   */
+  void connect(String url, int timeout) throws IOException;
+
+  /**
+   * Poll RTMP media cache and return the first byte buffer.
+   */
+  ByteBuffer poll();
+
+  /**
+   * Stops and closes the current RTMP stream
+   */
+  void close() throws IllegalStateException, IOException;
+
+  /**
+   * obtain the IP address of the peer if any
+   */
+  String getServerIpAddr();
+
+  /**
+   * obtain the PID of the peer if any
+   */
+  int getServerPid();
+
+  /**
+   * obtain the ID of the peer if any
+   */
+  int getServerId();
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/Util.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/Util.java
@@ -1,0 +1,139 @@
+package com.google.android.exoplayer2.upstream.rtmp;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Misc utility method
+ *
+ * @author francois
+ */
+public class Util {
+
+  private static final String HEXES = "0123456789ABCDEF";
+
+  public static void writeUnsignedInt32(OutputStream out, int value) throws IOException {
+    out.write((byte) (value >>> 24));
+    out.write((byte) (value >>> 16));
+    out.write((byte) (value >>> 8));
+    out.write((byte) value);
+  }
+
+  public static int readUnsignedInt32(InputStream in) throws IOException {
+    return ((in.read() & 0xff) << 24) | ((in.read() & 0xff) << 16) | ((in.read() & 0xff) << 8) | (in.read() & 0xff);
+  }
+
+  public static int readUnsignedInt24(InputStream in) throws IOException {
+    return ((in.read() & 0xff) << 16) | ((in.read() & 0xff) << 8) | (in.read() & 0xff);
+  }
+
+  public static int readUnsignedInt16(InputStream in) throws IOException {
+    return ((in.read() & 0xff) << 8) | (in.read() & 0xff);
+  }
+
+  public static void writeUnsignedInt24(OutputStream out, int value) throws IOException {
+    out.write((byte) (value >>> 16));
+    out.write((byte) (value >>> 8));
+    out.write((byte) value);
+  }
+
+  public static void writeUnsignedInt16(OutputStream out, int value) throws IOException {
+    out.write((byte) (value >>> 8));
+    out.write((byte) value);
+  }
+
+  public static int toUnsignedInt32(byte[] bytes) {
+    return (((int) bytes[0] & 0xff) << 24) | (((int) bytes[1] & 0xff) << 16) | (((int) bytes[2] & 0xff) << 8) | ((int) bytes[3] & 0xff);
+  }
+
+  public static int toUnsignedInt32LittleEndian(byte[] bytes) {
+    return ((bytes[3] & 0xff) << 24) | ((bytes[2] & 0xff) << 16) | ((bytes[1] & 0xff) << 8) | (bytes[0] & 0xff);
+  }
+
+  public static void writeUnsignedInt32LittleEndian(OutputStream out, int value) throws IOException {
+    out.write((byte) value);
+    out.write((byte) (value >>> 8));
+    out.write((byte) (value >>> 16));
+    out.write((byte) (value >>> 24));
+  }
+
+  public static int toUnsignedInt24(byte[] bytes) {
+    return ((bytes[1] & 0xff) << 16) | ((bytes[2] & 0xff) << 8) | (bytes[3] & 0xff);
+  }
+
+  public static int toUnsignedInt16(byte[] bytes) {
+    return ((bytes[2] & 0xff) << 8) | (bytes[3] & 0xff);
+  }
+
+  public static String toHexString(byte[] raw) {
+    if (raw == null) {
+      return null;
+    }
+    final StringBuilder hex = new StringBuilder(2 * raw.length);
+    for (final byte b : raw) {
+      hex.append(HEXES.charAt((b & 0xF0) >> 4)).append(HEXES.charAt((b & 0x0F)));
+    }
+    return hex.toString();
+  }
+
+  public static String toHexString(byte b) {
+    return new StringBuilder().append(HEXES.charAt((b & 0xF0) >> 4)).append(HEXES.charAt((b & 0x0F))).toString();
+  }
+
+  /**
+   * Reads bytes from the specified inputstream into the specified target buffer until it is filled up
+   */
+  public static void readBytesUntilFull(InputStream in, byte[] targetBuffer) throws IOException {
+    int totalBytesRead = 0;
+    int read;
+    final int targetBytes = targetBuffer.length;
+    do {
+      read = in.read(targetBuffer, totalBytesRead, (targetBytes - totalBytesRead));
+      if (read != -1) {
+        totalBytesRead += read;
+      } else {
+        throw new IOException("Unexpected EOF reached before read buffer was filled");
+      }
+    } while (totalBytesRead < targetBytes);
+  }
+
+  public static byte[] toByteArray(double d) {
+    long l = Double.doubleToRawLongBits(d);
+    return new byte[]{
+        (byte) ((l >> 56) & 0xff),
+        (byte) ((l >> 48) & 0xff),
+        (byte) ((l >> 40) & 0xff),
+        (byte) ((l >> 32) & 0xff),
+        (byte) ((l >> 24) & 0xff),
+        (byte) ((l >> 16) & 0xff),
+        (byte) ((l >> 8) & 0xff),
+        (byte) (l & 0xff),};
+  }
+
+  public static byte[] unsignedInt32ToByteArray(int value) throws IOException {
+    return new byte[]{
+        (byte) (value >>> 24),
+        (byte) (value >>> 16),
+        (byte) (value >>> 8),
+        (byte) value};
+  }
+
+  public static double readDouble(InputStream in) throws IOException {
+    long bits = ((long) (in.read() & 0xff) << 56) | ((long) (in.read() & 0xff) << 48) | ((long) (in.read() & 0xff) << 40) | ((long) (in.read() & 0xff) << 32) | ((in.read() & 0xff) << 24) | ((in.read() & 0xff) << 16) | ((in.read() & 0xff) << 8) | (in.read() & 0xff);
+    return Double.longBitsToDouble(bits);
+  }
+
+  public static void writeDouble(OutputStream out, double d) throws IOException {
+    long l = Double.doubleToRawLongBits(d);
+    out.write(new byte[]{
+        (byte) ((l >> 56) & 0xff),
+        (byte) ((l >> 48) & 0xff),
+        (byte) ((l >> 40) & 0xff),
+        (byte) ((l >> 32) & 0xff),
+        (byte) ((l >> 24) & 0xff),
+        (byte) ((l >> 16) & 0xff),
+        (byte) ((l >> 8) & 0xff),
+        (byte) (l & 0xff)});
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfArray.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfArray.java
@@ -1,0 +1,69 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+
+/**
+ * AMF Array
+ *
+ * @author francois
+ */
+public class AmfArray implements AmfData {
+
+  private List<AmfData> items;
+  private int size = -1;
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  @Override
+  public void readFrom(InputStream in) throws IOException {
+    // Skip data type byte (we assume it's already read)
+    int length = Util.readUnsignedInt32(in);
+    size = 5; // 1 + 4
+    items = new ArrayList<AmfData>(length);
+    for (int i = 0; i < length; i++) {
+      AmfData dataItem = AmfDecoder.readFrom(in);
+      size += dataItem.getSize();
+      items.add(dataItem);
+    }
+  }
+
+  @Override
+  public int getSize() {
+    if (size == -1) {
+      size = 5; // 1 + 4
+      if (items != null) {
+        for (AmfData dataItem : items) {
+          size += dataItem.getSize();
+        }
+      }
+    }
+    return size;
+  }
+
+  /**
+   * @return the amount of items in this the array
+   */
+  public int getLength() {
+    return items != null ? items.size() : 0;
+  }
+
+  public List<AmfData> getItems() {
+    if (items == null) {
+      items = new ArrayList<AmfData>();
+    }
+    return items;
+  }
+
+  public void addItem(AmfData dataItem) {
+    getItems().add(this);
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfBoolean.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfBoolean.java
@@ -1,0 +1,49 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * @author francois
+ */
+public class AmfBoolean implements AmfData {
+
+  private boolean value;
+
+  public boolean isValue() {
+    return value;
+  }
+
+  public void setValue(boolean value) {
+    this.value = value;
+  }
+
+  public AmfBoolean(boolean value) {
+    this.value = value;
+  }
+
+  public AmfBoolean() {
+  }
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    out.write(AmfType.BOOLEAN.getValue());
+    out.write(value ? 0x01 : 0x00);
+  }
+
+  @Override
+  public void readFrom(InputStream in) throws IOException {
+    value = (in.read() == 0x01) ? true : false;
+  }
+
+  public static boolean readBooleanFrom(InputStream in) throws IOException {
+    // Skip data type byte (we assume it's already read)
+    return (in.read() == 0x01) ? true : false;
+  }
+
+  @Override
+  public int getSize() {
+    return 2;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfData.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfData.java
@@ -1,0 +1,33 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Base AMF data object. All other AMF data type instances derive from this
+ * (including AmfObject)
+ *
+ * @author francois
+ */
+public interface AmfData {
+
+  /**
+   * Write/Serialize this AMF data intance (Object/string/integer etc) to
+   * the specified OutputStream
+   */
+  void writeTo(OutputStream out) throws IOException;
+
+  /**
+   * Read and parse bytes from the specified input stream to populate this
+   * AMFData instance (deserialize)
+   *
+   * @return the amount of bytes read
+   */
+  void readFrom(InputStream in) throws IOException;
+
+  /**
+   * @return the amount of bytes required for this object
+   */
+  int getSize();
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfDecoder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfDecoder.java
@@ -1,0 +1,47 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @author francois
+ */
+public class AmfDecoder {
+
+  public static AmfData readFrom(InputStream in) throws IOException {
+
+    byte amfTypeByte = (byte) in.read();
+    AmfType amfType = AmfType.valueOf(amfTypeByte);
+
+    AmfData amfData;
+    switch (amfType) {
+      case NUMBER:
+        amfData = new AmfNumber();
+        break;
+      case BOOLEAN:
+        amfData = new AmfBoolean();
+        break;
+      case STRING:
+        amfData = new AmfString();
+        break;
+      case OBJECT:
+        amfData = new AmfObject();
+        break;
+      case NULL:
+        return new AmfNull();
+      case UNDEFINED:
+        return new AmfUndefined();
+      case MAP:
+        amfData = new AmfMap();
+        break;
+      case ARRAY:
+        amfData = new AmfArray();
+        break;
+      default:
+        throw new IOException("Unknown/unimplemented AMF data type: " + amfType);
+    }
+
+    amfData.readFrom(in);
+    return amfData;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfMap.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfMap.java
@@ -1,0 +1,53 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+
+/**
+ * AMF map; that is, an "object"-like structure of key/value pairs, but with
+ * an array-like size indicator at the start (which is seemingly always 0)
+ *
+ * @author francois
+ */
+public class AmfMap extends AmfObject {
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    // Begin the map/object/array/whatever exactly this is
+    out.write(AmfType.MAP.getValue());
+
+    // Write the "array size"
+    Util.writeUnsignedInt32(out, properties.size());
+
+    // Write key/value pairs in this object
+    for (Map.Entry<String, AmfData> entry : properties.entrySet()) {
+      // The key must be a STRING type, and thus the "type-definition" byte is implied (not included in message)
+      AmfString.writeStringTo(out, entry.getKey(), true);
+      entry.getValue().writeTo(out);
+    }
+
+    // End the object
+    out.write(OBJECT_END_MARKER);
+  }
+
+  @Override
+  public void readFrom(InputStream in) throws IOException {
+    // Skip data type byte (we assume it's already read)
+    int length = Util.readUnsignedInt32(in); // Seems this is always 0
+    super.readFrom(in);
+    size += 4; // Add the bytes read for parsing the array size (length)
+  }
+
+  @Override
+  public int getSize() {
+    if (size == -1) {
+      size = super.getSize();
+      size += 4; // array length bytes
+    }
+    return size;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfNull.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfNull.java
@@ -1,0 +1,34 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * @author francois
+ */
+public class AmfNull implements AmfData {
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    out.write(AmfType.NULL.getValue());
+  }
+
+  @Override
+  public void readFrom(InputStream in) throws IOException {
+    // Skip data type byte (we assume it's already read)
+  }
+
+  public static void writeNullTo(OutputStream out) throws IOException {
+    out.write(AmfType.NULL.getValue());
+  }
+
+  @Override
+  public int getSize() {
+    return 1;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfNumber.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfNumber.java
@@ -1,0 +1,65 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+
+/**
+ * AMF0 Number data type
+ *
+ * @author francois
+ */
+public class AmfNumber implements AmfData {
+
+  double value;
+  /**
+   * Size of an AMF number, in bytes (including type bit)
+   */
+  public static final int SIZE = 9;
+
+  public AmfNumber(double value) {
+    this.value = value;
+  }
+
+  public AmfNumber() {
+  }
+
+  public double getValue() {
+    return value;
+  }
+
+  public void setValue(double value) {
+    this.value = value;
+  }
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    out.write(AmfType.NUMBER.getValue());
+    Util.writeDouble(out, value);
+  }
+
+  @Override
+  public void readFrom(InputStream in) throws IOException {
+    // Skip data type byte (we assume it's already read)
+    value = Util.readDouble(in);
+  }
+
+  public static double readNumberFrom(InputStream in) throws IOException {
+    // Skip data type byte
+    in.read();
+    return Util.readDouble(in);
+  }
+
+  public static void writeNumberTo(OutputStream out, double number) throws IOException {
+    out.write(AmfType.NUMBER.getValue());
+    Util.writeDouble(out, number);
+  }
+
+  @Override
+  public int getSize() {
+    return SIZE;
+  }
+
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfObject.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfObject.java
@@ -1,0 +1,111 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * AMF object
+ *
+ * @author francois
+ */
+public class AmfObject implements AmfData {
+
+  protected Map<String, AmfData> properties = new LinkedHashMap<String, AmfData>();
+  protected int size = -1;
+  /**
+   * Byte sequence that marks the end of an AMF object
+   */
+  protected static final byte[] OBJECT_END_MARKER = new byte[]{0x00, 0x00, 0x09};
+
+  public AmfObject() {
+  }
+
+  public AmfData getProperty(String key) {
+    return properties.get(key);
+  }
+
+  public void setProperty(String key, AmfData value) {
+    properties.put(key, value);
+  }
+
+  public void setProperty(String key, boolean value) {
+    properties.put(key, new AmfBoolean(value));
+  }
+
+  public void setProperty(String key, String value) {
+    properties.put(key, new AmfString(value, false));
+  }
+
+  public void setProperty(String key, int value) {
+    properties.put(key, new AmfNumber(value));
+  }
+
+  public void setProperty(String key, double value) {
+    properties.put(key, new AmfNumber(value));
+  }
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    // Begin the object
+    out.write(AmfType.OBJECT.getValue());
+
+    // Write key/value pairs in this object
+    for (Map.Entry<String, AmfData> entry : properties.entrySet()) {
+      // The key must be a STRING type, and thus the "type-definition" byte is implied (not included in message)
+      AmfString.writeStringTo(out, entry.getKey(), true);
+      entry.getValue().writeTo(out);
+    }
+
+    // End the object
+    out.write(OBJECT_END_MARKER);
+
+  }
+
+  @Override
+  public void readFrom(InputStream in) throws IOException {
+    // Skip data type byte (we assume it's already read)
+    size = 1;
+    InputStream markInputStream = in.markSupported() ? in : new BufferedInputStream(in);
+
+    while (true) {
+      // Look for the 3-byte object end marker [0x00 0x00 0x09]
+      markInputStream.mark(3);
+      byte[] endMarker = new byte[3];
+      markInputStream.read(endMarker);
+
+      if (endMarker[0] == OBJECT_END_MARKER[0] && endMarker[1] == OBJECT_END_MARKER[1] && endMarker[2] == OBJECT_END_MARKER[2]) {
+        // End marker found
+        size += 3;
+        return;
+      } else {
+        // End marker not found; reset the stream to the marked position and read an AMF property
+        markInputStream.reset();
+        // Read the property key...
+        String key = AmfString.readStringFrom(in, true);
+        size += AmfString.sizeOf(key, true);
+        // ...and the property value
+        AmfData value = AmfDecoder.readFrom(markInputStream);
+        size += value.getSize();
+        properties.put(key, value);
+      }
+    }
+  }
+
+  @Override
+  public int getSize() {
+    if (size == -1) {
+      size = 1; // object marker
+      for (Map.Entry<String, AmfData> entry : properties.entrySet()) {
+        size += AmfString.sizeOf(entry.getKey(), true);
+        size += entry.getValue().getSize();
+      }
+      size += 3; // end of object marker
+
+    }
+    return size;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfString.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfString.java
@@ -1,0 +1,131 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.String;
+
+import android.util.Log;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+
+/**
+ * @author francois
+ */
+public class AmfString implements AmfData {
+
+  private static final String TAG = "AmfString";
+
+  private String value;
+  private boolean key;
+  private int size = -1;
+
+  public AmfString() {
+  }
+
+  public AmfString(String value, boolean isKey) {
+    this.value = value;
+    this.key = isKey;
+  }
+
+  public AmfString(String value) {
+    this(value, false);
+  }
+
+  public AmfString(boolean isKey) {
+    this.key = isKey;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public boolean isKey() {
+    return key;
+  }
+
+  public void setKey(boolean key) {
+    this.key = key;
+  }
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    // Strings are ASCII encoded
+    byte[] byteValue = this.value.getBytes("ASCII");
+    // Write the STRING data type definition (except if this String is used as a key)
+    if (!key) {
+      out.write(AmfType.STRING.getValue());
+    }
+    // Write 2 bytes indicating string length
+    Util.writeUnsignedInt16(out, byteValue.length);
+    // Write string
+    out.write(byteValue);
+  }
+
+  @Override
+  public void readFrom(InputStream in) throws IOException {
+    // Skip data type byte (we assume it's already read)
+    int length = Util.readUnsignedInt16(in);
+    size = 3 + length; // 1 + 2 + length
+    // Read string value
+    byte[] byteValue = new byte[length];
+    Util.readBytesUntilFull(in, byteValue);
+    value = new String(byteValue, "ASCII");
+  }
+
+  public static String readStringFrom(InputStream in, boolean isKey) throws IOException {
+    if (!isKey) {
+      // Read past the data type byte
+      in.read();
+    }
+    int length = Util.readUnsignedInt16(in);
+    // Read string value
+    byte[] byteValue = new byte[length];
+    Util.readBytesUntilFull(in, byteValue);
+    return new String(byteValue, "ASCII");
+  }
+
+  public static void writeStringTo(OutputStream out, String string, boolean isKey) throws IOException {
+    // Strings are ASCII encoded
+    byte[] byteValue = string.getBytes("ASCII");
+    // Write the STRING data type definition (except if this String is used as a key)
+    if (!isKey) {
+      out.write(AmfType.STRING.getValue());
+    }
+    // Write 2 bytes indicating string length
+    Util.writeUnsignedInt16(out, byteValue.length);
+    // Write string
+    out.write(byteValue);
+  }
+
+  @Override
+  public int getSize() {
+    if (size == -1) {
+      try {
+        size = (isKey() ? 0 : 1) + 2 + value.getBytes("ASCII").length;
+      } catch (UnsupportedEncodingException ex) {
+        Log.e(TAG, "AmfString.getSize(): caught exception", ex);
+        throw new RuntimeException(ex);
+      }
+    }
+    return size;
+  }
+
+  /**
+   * @return the byte size of the resulting AMF string of the specified value
+   */
+  public static int sizeOf(String string, boolean isKey) {
+    try {
+      int size = (isKey ? 0 : 1) + 2 + string.getBytes("ASCII").length;
+      return size;
+    } catch (UnsupportedEncodingException ex) {
+      Log.e(TAG, "AmfString.SizeOf(): caught exception", ex);
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfType.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfType.java
@@ -1,0 +1,53 @@
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AMF0 data type enum
+ *
+ * @author francois
+ */
+public enum AmfType {
+
+  /**
+   * Number (encoded as IEEE 64-bit double precision floating point number)
+   */
+  NUMBER(0x00),
+  /**
+   * Boolean (Encoded as a single byte of value 0x00 or 0x01)
+   */
+  BOOLEAN(0x01),
+  /**
+   * String (ASCII encoded)
+   */
+  STRING(0x02),
+  /**
+   * Object - set of key/value pairs
+   */
+  OBJECT(0x03),
+  NULL(0x05),
+  UNDEFINED(0x06),
+  MAP(0x08),
+  ARRAY(0x0A);
+  private byte value;
+  private static final Map<Byte, AmfType> quickLookupMap = new HashMap<Byte, AmfType>();
+
+  static {
+    for (AmfType amfType : AmfType.values()) {
+      quickLookupMap.put(amfType.getValue(), amfType);
+    }
+  }
+
+  private AmfType(int intValue) {
+    this.value = (byte) intValue;
+  }
+
+  public byte getValue() {
+    return value;
+  }
+
+  public static AmfType valueOf(byte amfTypeByte) {
+    return quickLookupMap.get(amfTypeByte);
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfUndefined.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/amf/AmfUndefined.java
@@ -1,0 +1,34 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.google.android.exoplayer2.upstream.rtmp.amf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * @author leoma
+ */
+public class AmfUndefined implements AmfData {
+
+  @Override
+  public void writeTo(OutputStream out) throws IOException {
+    out.write(AmfType.UNDEFINED.getValue());
+  }
+
+  @Override
+  public void readFrom(InputStream in) throws IOException {
+    // Skip data type byte (we assume it's already read)
+  }
+
+  public static void writeUndefinedTo(OutputStream out) throws IOException {
+    out.write(AmfType.UNDEFINED.getValue());
+  }
+
+  @Override
+  public int getSize() {
+    return 1;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/ChunkStreamInfo.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/ChunkStreamInfo.java
@@ -1,0 +1,110 @@
+package com.google.android.exoplayer2.upstream.rtmp.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+import com.google.android.exoplayer2.upstream.rtmp.packets.RtmpHeader;
+
+/**
+ * Chunk stream channel information
+ *
+ * @author francois, leo
+ */
+public class ChunkStreamInfo {
+
+  public static final byte RTMP_CID_PROTOCOL_CONTROL = 0x02;
+  public static final byte RTMP_CID_OVER_CONNECTION = 0x03;
+  public static final byte RTMP_CID_OVER_CONNECTION2 = 0x04;
+  public static final byte RTMP_CID_OVER_STREAM = 0x05;
+  public static final byte RTMP_CID_VIDEO = 0x06;
+  public static final byte RTMP_CID_AUDIO = 0x07;
+  public static final byte RTMP_CID_OVER_STREAM2 = 0x08;
+  private RtmpHeader prevHeaderRx;
+  private RtmpHeader prevHeaderTx;
+  private static long sessionBeginTimestamp;
+  private long realLastTimestamp = System.nanoTime() / 1000000;  // Do not use wall time!
+  private ByteArrayOutputStream baos = new ByteArrayOutputStream(1024 * 128);
+
+  /**
+   * @return the previous header that was received on this channel, or <code>null</code> if no previous header was received
+   */
+  public RtmpHeader prevHeaderRx() {
+    return prevHeaderRx;
+  }
+
+  /**
+   * Sets the previous header that was received on this channel, or <code>null</code> if no previous header was sent
+   */
+  public void setPrevHeaderRx(RtmpHeader previousHeader) {
+    this.prevHeaderRx = previousHeader;
+  }
+
+  /**
+   * @return the previous header that was transmitted on this channel
+   */
+  public RtmpHeader getPrevHeaderTx() {
+    return prevHeaderTx;
+  }
+
+  public boolean canReusePrevHeaderTx(RtmpHeader.MessageType forMessageType) {
+    return (prevHeaderTx != null && prevHeaderTx.getMessageType() == forMessageType);
+  }
+
+  /**
+   * Sets the previous header that was transmitted on this channel
+   */
+  public void setPrevHeaderTx(RtmpHeader prevHeaderTx) {
+    this.prevHeaderTx = prevHeaderTx;
+  }
+
+  /**
+   * Sets the session beginning timestamp for all chunks
+   */
+  public static void markSessionBeginTimestamp() {
+    sessionBeginTimestamp = System.nanoTime() / 1000000;
+  }
+
+  /**
+   * Utility method for calculating & synchronizing transmitted timestamps
+   */
+  public static long markAbsoluteTimestamp() {
+    return System.nanoTime() / 1000000 - sessionBeginTimestamp;
+  }
+
+  /**
+   * Utility method for calculating & synchronizing transmitted timestamp deltas
+   */
+  public long markDeltaTimestamp() {
+    long currentTimestamp = System.nanoTime() / 1000000;
+    long diffTimestamp = currentTimestamp - realLastTimestamp;
+    realLastTimestamp = currentTimestamp;
+    return diffTimestamp;
+  }
+
+  /**
+   * @return <code>true</code> if all packet data has been stored, or <code>false</code> if not
+   */
+  public boolean storePacketChunk(InputStream in, int chunkSize) throws IOException {
+    final int remainingBytes = prevHeaderRx.getPacketLength() - baos.size();
+    byte[] chunk = new byte[Math.min(remainingBytes, chunkSize)];
+    Util.readBytesUntilFull(in, chunk);
+    baos.write(chunk);
+    return (baos.size() == prevHeaderRx.getPacketLength());
+  }
+
+  public ByteArrayInputStream getStoredPacketInputStream() {
+    ByteArrayInputStream bis = new ByteArrayInputStream(baos.toByteArray());
+    baos.reset();
+    return bis;
+  }
+
+  /**
+   * Clears all currently-stored packet chunks (used when an ABORT packet is received)
+   */
+  public void clearStoredChunks() {
+    baos.reset();
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/RtmpConnection.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/RtmpConnection.java
@@ -1,0 +1,478 @@
+package com.google.android.exoplayer2.upstream.rtmp.io;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import android.util.Log;
+
+import com.google.android.exoplayer2.upstream.rtmp.RtmpPlayer;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfNull;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfNumber;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfObject;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfString;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Abort;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Audio;
+import com.google.android.exoplayer2.upstream.rtmp.packets.ContentData;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Data;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Command;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Handshake;
+import com.google.android.exoplayer2.upstream.rtmp.packets.RtmpPacket;
+import com.google.android.exoplayer2.upstream.rtmp.packets.SetPeerBandwidth;
+import com.google.android.exoplayer2.upstream.rtmp.packets.UserControl;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Video;
+import com.google.android.exoplayer2.upstream.rtmp.packets.WindowAckSize;
+
+/**
+ * Main RTMP connection implementation class
+ *
+ * @author francois, leoma
+ */
+public class RtmpConnection implements RtmpPlayer {
+
+  private static final String TAG = "RtmpConnection";
+  private static final Pattern rtmpUrlPattern = Pattern.compile("^rtmp://([^/:]+)(:(\\d+))*/([^/]+)(/(.*))*$");
+
+  private String appName;
+  private String streamName;
+  private String swfUrl;
+  private String tcUrl;
+  private String pageUrl;
+  private Socket socket;
+  private RtmpSessionInfo rtmpSessionInfo;
+  private RtmpDecoder rtmpDecoder = new RtmpDecoder(rtmpSessionInfo);
+  private BufferedInputStream inputStream;
+  private BufferedOutputStream outputStream;
+  private final ConcurrentLinkedQueue<ByteBuffer> mediaDataQueue = new ConcurrentLinkedQueue<>();
+  private final Object mediaDataLock = new Object();
+  private volatile boolean active = false;
+  private volatile boolean connected = false;
+  private AtomicInteger videoFrameCacheNumber = new AtomicInteger(0);
+  private int currentStreamId = 0;
+  private int transactionIdCounter = 0;
+  private AmfString serverIpAddr;
+  private AmfNumber serverPid;
+  private AmfNumber serverId;
+
+  private void handshake(InputStream in, OutputStream out) throws IOException {
+    Handshake handshake = new Handshake();
+    handshake.writeC0(out);
+    handshake.writeC1(out); // Write C1 without waiting for S0
+    out.flush();
+    handshake.readS0(in);
+    handshake.readS1(in);
+    handshake.writeC2(out);
+    handshake.readS2(in);
+  }
+
+  @Override
+  public void connect(String url, int timeout) throws IOException {
+    int port;
+    String host;
+    Matcher matcher = rtmpUrlPattern.matcher(url);
+    if (matcher.matches()) {
+      tcUrl = url.substring(0, url.lastIndexOf('/'));
+      swfUrl = "";
+      pageUrl = "";
+      host = matcher.group(1);
+      String portStr = matcher.group(3);
+      port = portStr != null ? Integer.parseInt(portStr) : 1935;
+      appName = matcher.group(4);
+      streamName = matcher.group(6);
+    } else {
+      throw new IllegalArgumentException("Invalid RTMP URL. Must be in format:" +
+          "rtmp://host[:port]/application[/streamName]");
+    }
+
+    // socket connection
+    Log.d(TAG, "connect() called. Host: " + host + ", port: " + port + ", appName: " + appName +
+        ", playPath: " + streamName);
+    // Note the chunk size must be reset as 128 on each connection.
+    rtmpSessionInfo = new RtmpSessionInfo();
+    rtmpDecoder = new RtmpDecoder(rtmpSessionInfo);
+    socket = new Socket();
+    SocketAddress socketAddress = new InetSocketAddress(host, port);
+    socket.connect(socketAddress, timeout);
+    inputStream = new BufferedInputStream(socket.getInputStream());
+    outputStream = new BufferedOutputStream(socket.getOutputStream());
+    Log.d(TAG, "connect(): socket connection established, doing handhake...");
+    handshake(inputStream, outputStream);
+    active = true;
+    Log.d(TAG, "connect(): handshake done");
+
+    // Start the "main" handling thread
+    new Thread(new Runnable() {
+
+      @Override
+      public void run() {
+        try {
+          Log.d(TAG, "starting main rx handler loop");
+          handleRxPacketLoop();
+        } catch (IOException ex) {
+          Logger.getLogger(RtmpConnection.class.getName()).log(Level.SEVERE, null, ex);
+        }
+      }
+    }).start();
+
+    rtmpConnect();
+  }
+
+  private void rtmpConnect() throws IOException, IllegalStateException {
+    if (connected) {
+      throw new IllegalStateException("Already connected or connecting to RTMP server");
+    }
+
+    // Mark session timestamp of all chunk stream information on connection.
+    ChunkStreamInfo.markSessionBeginTimestamp();
+
+    Log.d(TAG, "rtmpConnect(): Building 'connect' invoke packet");
+    ChunkStreamInfo chunkStreamInfo = rtmpSessionInfo.getChunkStreamInfo(ChunkStreamInfo.RTMP_CID_OVER_CONNECTION);
+    Command invoke = new Command("connect", ++transactionIdCounter, chunkStreamInfo);
+    invoke.getHeader().setMessageStreamId(0);
+    AmfObject args = new AmfObject();
+    args.setProperty("app", appName);
+    args.setProperty("flashVer", "LNX 11,2,202,233"); // Flash player OS: Linux, version: 11.2.202.233
+    args.setProperty("swfUrl", swfUrl);
+    args.setProperty("tcUrl", tcUrl);
+    args.setProperty("fpad", false);
+    args.setProperty("capabilities", 239);
+    args.setProperty("audioCodecs", 3575);
+    args.setProperty("videoCodecs", 252);
+    args.setProperty("videoFunction", 1);
+    args.setProperty("pageUrl", pageUrl);
+    args.setProperty("objectEncoding", 0);
+    invoke.addData(args);
+    sendRtmpPacket(invoke);
+  }
+
+  private void createStream() throws IllegalStateException, IOException {
+    if (!connected) {
+      throw new IllegalStateException("Not connected to RTMP server");
+    }
+    if (currentStreamId != 0) {
+      throw new IllegalStateException("Current stream object has existed");
+    }
+
+    Log.d(TAG, "createStream(): Sending createStream command...");
+    ChunkStreamInfo chunkStreamInfo = rtmpSessionInfo.getChunkStreamInfo(ChunkStreamInfo.RTMP_CID_OVER_CONNECTION);
+    // transactionId == 2
+    Command createStream = new Command("createStream", ++transactionIdCounter, chunkStreamInfo);
+    createStream.addData(new AmfNull());
+    sendRtmpPacket(createStream);
+  }
+
+  private void _checkbw() throws IllegalStateException, IOException {
+    if (!connected) {
+      throw new IllegalStateException("Not connected to RTMP server");
+    }
+    if (currentStreamId != 0) {
+      throw new IllegalStateException("Current stream object has existed");
+    }
+
+    Log.d(TAG, "_checkbw(): Sending _checkbw command...");
+    ChunkStreamInfo chunkStreamInfo = rtmpSessionInfo.getChunkStreamInfo(ChunkStreamInfo.RTMP_CID_OVER_CONNECTION);
+    // transactionId == 3
+    Command _checkbw = new Command("_checkbw", ++transactionIdCounter, chunkStreamInfo);
+    _checkbw.addData(new AmfNull());
+    sendRtmpPacket(_checkbw);
+  }
+
+  private void play() throws IOException {
+    Log.d(TAG, "play(): Sending play command...");
+    // transactionId == 3
+    Command play = new Command("play", ++transactionIdCounter);
+    play.getHeader().setChunkStreamId(ChunkStreamInfo.RTMP_CID_OVER_STREAM);
+    play.getHeader().setMessageStreamId(currentStreamId);
+    play.addData(new AmfNull());  // command object: null for "play"
+    play.addData(streamName);
+    play.addData(-1);
+    sendRtmpPacket(play);
+
+    setBufferLength();
+  }
+
+  private void setBufferLength() throws IllegalStateException, IOException {
+    if (!connected) {
+      throw new IllegalStateException("Not connected to RTMP server");
+    }
+
+    Log.d(TAG, "setBufferLength(): Sending setBufferLength command...");
+    ChunkStreamInfo chunkStreamInfo = rtmpSessionInfo.getChunkStreamInfo(ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL);
+    UserControl setBufferLength = new UserControl(UserControl.Type.SET_BUFFER_LENGTH, chunkStreamInfo);
+    setBufferLength.setEventData(currentStreamId, 3000);
+    sendRtmpPacket(setBufferLength);
+  }
+
+  @Override
+  public ByteBuffer poll() {
+    while (active) {
+      while (!mediaDataQueue.isEmpty()) {
+        return mediaDataQueue.poll();
+      }
+      // Wait for next received packet
+      synchronized (mediaDataLock) {
+        try {
+          mediaDataLock.wait(500);
+        } catch (InterruptedException ex) {
+          // Ignore
+        }
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public void close() throws IllegalStateException, IOException {
+    if (socket != null) {
+      closeStream();
+    }
+    shutdown();
+  }
+
+  private void closeStream() throws IOException {
+    if (!connected) {
+      throw new IllegalStateException("Not connected to RTMP server");
+    }
+    if (currentStreamId == 0) {
+      throw new IllegalStateException("No current stream object exists");
+    }
+    Log.d(TAG, "closeStream(): setting current stream ID to 0");
+    Command closeStream = new Command("closeStream", 0);
+    closeStream.getHeader().setChunkStreamId(ChunkStreamInfo.RTMP_CID_OVER_STREAM);
+    closeStream.getHeader().setMessageStreamId(currentStreamId);
+    closeStream.addData(new AmfNull());
+    sendRtmpPacket(closeStream);
+  }
+
+  private void shutdown() {
+    // shutdown handleRxPacketLoop
+    active = false;
+    mediaDataQueue.clear();
+    synchronized (mediaDataLock) {
+      mediaDataLock.notifyAll();
+    }
+
+    // shutdown socket as well as its input and output stream
+    if (socket != null) {
+      try {
+        socket.shutdownInput();
+        socket.shutdownOutput();
+        socket.close();
+        Log.d(TAG, "socket closed");
+      } catch (IOException ex) {
+        ex.printStackTrace();
+      }
+    }
+
+    reset();
+  }
+
+  private void reset() {
+    active = false;
+    connected = false;
+    tcUrl = null;
+    swfUrl = null;
+    pageUrl = null;
+    appName = null;
+    streamName = null;
+    currentStreamId = 0;
+    transactionIdCounter = 0;
+    videoFrameCacheNumber.set(0);
+    serverIpAddr = null;
+    serverPid = null;
+    serverId = null;
+    rtmpSessionInfo = null;
+    rtmpDecoder = null;
+  }
+
+  /** Transmit the specified RTMP packet */
+  private void sendRtmpPacket(RtmpPacket rtmpPacket) throws IOException {
+    ChunkStreamInfo chunkStreamInfo = rtmpSessionInfo.getChunkStreamInfo(rtmpPacket.getHeader().getChunkStreamId());
+    chunkStreamInfo.setPrevHeaderTx(rtmpPacket.getHeader());
+    if (!(rtmpPacket instanceof Video || rtmpPacket instanceof Audio)) {
+      rtmpPacket.getHeader().setAbsoluteTimestamp((int) ChunkStreamInfo.markAbsoluteTimestamp());
+    }
+    rtmpPacket.writeTo(outputStream, rtmpSessionInfo.getTxChunkSize(), chunkStreamInfo);
+    Log.d(TAG, "wrote packet: " + rtmpPacket + ", size: " + rtmpPacket.getHeader().getPacketLength());
+    if (rtmpPacket instanceof Command) {
+      rtmpSessionInfo.addInvokedCommand(((Command) rtmpPacket).getTransactionId(), ((Command) rtmpPacket).getCommandName());
+    }
+    outputStream.flush();
+  }
+
+  private void handleRxPacketLoop() throws IOException {
+    // Handle all queued received RTMP packets
+    while (active) {
+      try {
+        // It will be blocked when no data in input stream buffer
+        RtmpPacket rtmpPacket = rtmpDecoder.readPacket(inputStream);
+        if (rtmpPacket != null) {
+          //Log.d(TAG, "handleRxPacketLoop(): RTMP rx packet message type: " + rtmpPacket.getHeader().getMessageType());
+          switch (rtmpPacket.getHeader().getMessageType()) {
+            case ABORT:
+              rtmpSessionInfo.getChunkStreamInfo(((Abort) rtmpPacket).getChunkStreamId()).clearStoredChunks();
+              break;
+            case USER_CONTROL_MESSAGE:
+              UserControl user = (UserControl) rtmpPacket;
+              switch (user.getType()) {
+                case STREAM_BEGIN:
+                  if (currentStreamId != user.getFirstEventData()) {
+                    throw new IllegalStateException("Current stream ID error!");
+                  }
+                  break;
+                case PING_REQUEST:
+                  ChunkStreamInfo channelInfo = rtmpSessionInfo.getChunkStreamInfo(ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL);
+                  Log.d(TAG, "handleRxPacketLoop(): Sending PONG reply..");
+                  UserControl pong = new UserControl(user, channelInfo);
+                  sendRtmpPacket(pong);
+                  break;
+                case STREAM_EOF:
+                  Log.i(TAG, "handleRxPacketLoop(): Stream EOF reached, closing RTMP writer...");
+                  break;
+                default:
+                  // Ignore...
+                  break;
+              }
+              break;
+            case WINDOW_ACKNOWLEDGEMENT_SIZE:
+              WindowAckSize windowAckSize = (WindowAckSize) rtmpPacket;
+              int size = windowAckSize.getAcknowledgementWindowSize();
+              Log.d(TAG, "handleRxPacketLoop(): Setting acknowledgement window size: " + size);
+              rtmpSessionInfo.setAcknowledgmentWindowSize(size);
+              break;
+            case SET_PEER_BANDWIDTH:
+              SetPeerBandwidth bw = (SetPeerBandwidth) rtmpPacket;
+              rtmpSessionInfo.setAcknowledgmentWindowSize(bw.getAcknowledgementWindowSize());
+              int acknowledgementWindowsize = rtmpSessionInfo.getAcknowledgementWindowSize();
+              ChunkStreamInfo chunkStreamInfo = rtmpSessionInfo.getChunkStreamInfo(ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL);
+              Log.d(TAG, "handleRxPacketLoop(): Send acknowledgement window size: " + acknowledgementWindowsize);
+              sendRtmpPacket(new WindowAckSize(acknowledgementWindowsize, chunkStreamInfo));
+              // Set socket option
+              socket.setSendBufferSize(acknowledgementWindowsize);
+              break;
+            case DATA_AMF0:
+              Log.d(TAG, "handleRxPacketLoop(): " + ((Data) rtmpPacket).getType());
+              break;
+            case COMMAND_AMF0:
+              handleRxInvoke((Command) rtmpPacket);
+              break;
+            case VIDEO:
+            case AUDIO:
+              ByteBuffer mediaData = collectMediaData(rtmpPacket);
+              mediaData.position(0);
+              mediaDataQueue.add(mediaData);
+              synchronized (mediaDataLock) {
+                mediaDataLock.notifyAll();
+              }
+              break;
+            default:
+              Log.w(TAG, "handleRxPacketLoop(): Not handling unimplemented/unknown packet of type: " + rtmpPacket.getHeader().getMessageType());
+              break;
+          }
+        }
+      } catch (EOFException eof) {
+        active = false;
+      } catch (SocketException se) {
+        se.printStackTrace();
+      } catch (IOException ioe) {
+        ioe.printStackTrace();
+      }
+    }
+  }
+
+  private ByteBuffer collectMediaData(RtmpPacket packet) {
+    int length = ((ContentData) packet).getData().length;
+    ByteBuffer mediaData = ByteBuffer.allocate(9 + length);
+    mediaData.position(0);
+    mediaData.put(packet.getHeader().getMessageType().getValue());
+    mediaData.putInt(length);
+    mediaData.putInt(packet.getHeader().getAbsoluteTimestamp());
+    mediaData.put(((ContentData) packet).getData());
+    return mediaData;
+  }
+
+  private void handleRxInvoke(Command invoke) throws IOException {
+    String commandName = invoke.getCommandName();
+
+    if (commandName.equals("_result")) {
+      // This is the result of one of the methods invoked by us
+      String method = rtmpSessionInfo.takeInvokedCommand(invoke.getTransactionId());
+
+      Log.d(TAG, "handleRxInvoke: Got result for invoked method: " + method);
+      if ("connect".equals(method)) {
+        // Capture server ip/pid/id information if any
+        onSrsServerInfo(invoke);
+        // We can now send createStream commands
+        String code = ((AmfString) ((AmfObject) invoke.getData().get(1)).getProperty("code")).getValue();
+        if (code.equals("NetConnection.Connect.Success")) {
+          connected = true;
+          setBufferLength();
+          createStream();
+          _checkbw();
+        }
+      } else if ("createStream".contains(method)) {
+        // Get stream id
+        currentStreamId = (int) ((AmfNumber) invoke.getData().get(1)).getValue();
+        Log.d(TAG, "handleRxInvoke(): Stream ID to play: " + currentStreamId);
+        play();
+      } else if ("play".contains(method)) {
+        Log.d(TAG, "handleRxInvoke(): response play");
+      } else {
+        Log.w(TAG, "handleRxInvoke(): '_result' message received for unknown method: " + method);
+      }
+    } else if (commandName.equals("onBWDone")) {
+      Log.d(TAG, "handleRxInvoke(): 'onBWDone'");
+    } else if (commandName.equals("onStatus")) {
+      String code = ((AmfString) ((AmfObject) invoke.getData().get(1)).getProperty("code")).getValue();
+      Log.d(TAG, "handleRxInvoke(): 'onStatus' code :" + code);
+    } else {
+      Log.e(TAG, "handleRxInvoke(): Unknown/unhandled server invoke: " + invoke);
+    }
+  }
+
+  private String onSrsServerInfo(Command invoke) {
+    // SRS server special information
+    AmfObject objData = (AmfObject) invoke.getData().get(1);
+    if ((objData).getProperty("data") instanceof AmfObject) {
+      objData = ((AmfObject) objData.getProperty("data"));
+      serverIpAddr = (AmfString) objData.getProperty("srs_server_ip");
+      serverPid = (AmfNumber) objData.getProperty("srs_pid");
+      serverId = (AmfNumber) objData.getProperty("srs_id");
+    }
+    String info = "";
+    info += serverIpAddr == null ? "" : " ip: " + serverIpAddr.getValue();
+    info += serverPid == null ? "" : " pid: " + (int) serverPid.getValue();
+    info += serverId == null ? "" : " id: " + (int) serverId.getValue();
+    return info;
+  }
+
+  @Override
+  public final String getServerIpAddr() {
+    return serverIpAddr == null ? null : serverIpAddr.getValue();
+  }
+
+  @Override
+  public final int getServerPid() {
+    return serverPid == null ? 0 : (int) serverPid.getValue();
+  }
+
+  @Override
+  public final int getServerId() {
+    return serverId == null ? 0 : (int) serverId.getValue();
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/RtmpDecoder.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/RtmpDecoder.java
@@ -1,0 +1,95 @@
+package com.google.android.exoplayer2.upstream.rtmp.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import android.util.Log;
+
+import com.google.android.exoplayer2.upstream.rtmp.packets.Abort;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Audio;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Command;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Data;
+import com.google.android.exoplayer2.upstream.rtmp.packets.RtmpHeader;
+import com.google.android.exoplayer2.upstream.rtmp.packets.RtmpPacket;
+import com.google.android.exoplayer2.upstream.rtmp.packets.SetChunkSize;
+import com.google.android.exoplayer2.upstream.rtmp.packets.SetPeerBandwidth;
+import com.google.android.exoplayer2.upstream.rtmp.packets.UserControl;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Video;
+import com.google.android.exoplayer2.upstream.rtmp.packets.WindowAckSize;
+import com.google.android.exoplayer2.upstream.rtmp.packets.Acknowledgement;
+
+/**
+ * @author francois
+ */
+public class RtmpDecoder {
+
+  private static final String TAG = "RtmpDecoder";
+
+  private RtmpSessionInfo rtmpSessionInfo;
+
+  public RtmpDecoder(RtmpSessionInfo rtmpSessionInfo) {
+    this.rtmpSessionInfo = rtmpSessionInfo;
+  }
+
+  public RtmpPacket readPacket(InputStream in) throws IOException {
+
+    RtmpHeader header = RtmpHeader.readHeader(in, rtmpSessionInfo);
+    //Log.d(TAG, "readPacket(): header.messageType: " + header.getMessageType());
+
+    ChunkStreamInfo chunkStreamInfo = rtmpSessionInfo.getChunkStreamInfo(header.getChunkStreamId());
+    chunkStreamInfo.setPrevHeaderRx(header);
+
+    if (header.getPacketLength() > rtmpSessionInfo.getRxChunkSize()) {
+      // If the packet consists of more than one chunk,
+      // store the chunks in the chunk stream until everything is read
+      if (!chunkStreamInfo.storePacketChunk(in, rtmpSessionInfo.getRxChunkSize())) {
+        // return null because of incomplete packet
+        return null;
+      } else {
+        // stored chunks complete packet, get the input stream of the chunk stream;
+        in = chunkStreamInfo.getStoredPacketInputStream();
+      }
+    }
+
+    RtmpPacket rtmpPacket;
+    switch (header.getMessageType()) {
+      case SET_CHUNK_SIZE:
+        SetChunkSize setChunkSize = new SetChunkSize(header);
+        setChunkSize.readBody(in);
+        Log.d(TAG, "readPacket(): Setting chunk size to: " + setChunkSize.getChunkSize());
+        rtmpSessionInfo.setRxChunkSize(setChunkSize.getChunkSize());
+        return null;
+      case ABORT:
+        rtmpPacket = new Abort(header);
+        break;
+      case USER_CONTROL_MESSAGE:
+        rtmpPacket = new UserControl(header);
+        break;
+      case WINDOW_ACKNOWLEDGEMENT_SIZE:
+        rtmpPacket = new WindowAckSize(header);
+        break;
+      case SET_PEER_BANDWIDTH:
+        rtmpPacket = new SetPeerBandwidth(header);
+        break;
+      case AUDIO:
+        rtmpPacket = new Audio(header);
+        break;
+      case VIDEO:
+        rtmpPacket = new Video(header);
+        break;
+      case COMMAND_AMF0:
+        rtmpPacket = new Command(header);
+        break;
+      case DATA_AMF0:
+        rtmpPacket = new Data(header);
+        break;
+      case ACKNOWLEDGEMENT:
+        rtmpPacket = new Acknowledgement(header);
+        break;
+      default:
+        throw new IOException("No packet body implementation for message type: " + header.getMessageType());
+    }
+    rtmpPacket.readBody(in);
+    return rtmpPacket;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/RtmpSessionInfo.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/RtmpSessionInfo.java
@@ -1,0 +1,90 @@
+package com.google.android.exoplayer2.upstream.rtmp.io;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.android.exoplayer2.upstream.rtmp.packets.RtmpPacket;
+
+/**
+ * @author francois
+ */
+public class RtmpSessionInfo {
+
+  /**
+   * The (total) number of bytes read for this window (resets to 0 if the agreed-upon RTMP window acknowledgement size is reached)
+   */
+  private int windowBytesRead;
+  /**
+   * The window acknowledgement size for this RTMP session, in bytes; default to max to avoid unnecessary "Acknowledgment" messages from being sent
+   */
+  private int acknowledgementWindowSize = Integer.MAX_VALUE;
+  /**
+   * Used internally to store the total number of bytes read (used when sending Acknowledgement messages)
+   */
+  private int totalBytesRead = 0;
+
+  /**
+   * Default chunk size is 128 bytes
+   */
+  private int rxChunkSize = 128;
+  private int txChunkSize = 128;
+  private Map<Integer, ChunkStreamInfo> chunkChannels = new HashMap<Integer, ChunkStreamInfo>();
+  private Map<Integer, String> invokedMethods = new ConcurrentHashMap<Integer, String>();
+
+  public ChunkStreamInfo getChunkStreamInfo(int chunkStreamId) {
+    ChunkStreamInfo chunkStreamInfo = chunkChannels.get(chunkStreamId);
+    if (chunkStreamInfo == null) {
+      chunkStreamInfo = new ChunkStreamInfo();
+      chunkChannels.put(chunkStreamId, chunkStreamInfo);
+    }
+    return chunkStreamInfo;
+  }
+
+  public String takeInvokedCommand(int transactionId) {
+    return invokedMethods.remove(transactionId);
+  }
+
+  public String addInvokedCommand(int transactionId, String commandName) {
+    return invokedMethods.put(transactionId, commandName);
+  }
+
+  public int getRxChunkSize() {
+    return rxChunkSize;
+  }
+
+  public void setRxChunkSize(int chunkSize) {
+    this.rxChunkSize = chunkSize;
+  }
+
+  public int getTxChunkSize() {
+    return txChunkSize;
+  }
+
+  public void setTxChunkSize(int chunkSize) {
+    this.txChunkSize = chunkSize;
+  }
+
+  public int getAcknowledgementWindowSize() {
+    return acknowledgementWindowSize;
+  }
+
+  public void setAcknowledgmentWindowSize(int acknowledgementWindowSize) {
+    this.acknowledgementWindowSize = acknowledgementWindowSize;
+  }
+
+  /**
+   * Add the specified amount of bytes to the total number of bytes read for this RTMP window;
+   *
+   * @param numBytes the number of bytes to add
+   * @return <code>true</code> if an "acknowledgement" packet should be sent, <code>false</code> otherwise
+   */
+  public final void addToWindowBytesRead(final int numBytes, final RtmpPacket packet) throws WindowAckRequired {
+    windowBytesRead += numBytes;
+    totalBytesRead += numBytes;
+    if (windowBytesRead >= acknowledgementWindowSize) {
+      windowBytesRead -= acknowledgementWindowSize;
+      throw new WindowAckRequired(totalBytesRead, packet);
+    }
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/WindowAckRequired.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/io/WindowAckRequired.java
@@ -1,0 +1,40 @@
+package com.google.android.exoplayer2.upstream.rtmp.io;
+
+import com.google.android.exoplayer2.upstream.rtmp.packets.RtmpPacket;
+
+/**
+ * Thrown by RTMP read thread when an Acknowledgement packet needs to be sent
+ * to acknowledge the RTMP window size. It contains the RTMP packet that was
+ * read when this event occurred (if any).
+ *
+ * @author francois
+ */
+public class WindowAckRequired extends Exception {
+
+  private RtmpPacket rtmpPacket;
+  private int bytesRead;
+
+  /**
+   * Used when the window acknowledgement size was reached, whilst fully reading
+   * an RTMP packet or not. If a packet is present, it should still be handled as if it was returned
+   * by the RTMP decoder.
+   *
+   * @param bytesReadThusFar The (total) number of bytes received so far
+   * @param rtmpPacket       The packet that was read (and thus should be handled), can be <code>null</code>
+   */
+  public WindowAckRequired(int bytesReadThusFar, RtmpPacket rtmpPacket) {
+    this.rtmpPacket = rtmpPacket;
+    this.bytesRead = bytesReadThusFar;
+  }
+
+  /**
+   * @return The RTMP packet that should be handled, or <code>null</code> if no full packet is available
+   */
+  public RtmpPacket getRtmpPacket() {
+    return rtmpPacket;
+  }
+
+  public int getBytesRead() {
+    return bytesRead;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Abort.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Abort.java
@@ -1,0 +1,52 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * A "Abort" RTMP control message, received on chunk stream ID 2 (control channel)
+ *
+ * @author francois
+ */
+public class Abort extends RtmpPacket {
+
+  private int chunkStreamId;
+
+  public Abort(RtmpHeader header) {
+    super(header);
+  }
+
+  public Abort(int chunkStreamId) {
+    super(new RtmpHeader(RtmpHeader.ChunkType.TYPE_1_RELATIVE_LARGE, ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL, RtmpHeader.MessageType.SET_CHUNK_SIZE));
+    this.chunkStreamId = chunkStreamId;
+  }
+
+  /**
+   * @return the ID of the chunk stream to be aborted
+   */
+  public int getChunkStreamId() {
+    return chunkStreamId;
+  }
+
+  /**
+   * Sets the ID of the chunk stream to be aborted
+   */
+  public void setChunkStreamId(int chunkStreamId) {
+    this.chunkStreamId = chunkStreamId;
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    // Value is received in the 4 bytes of the body
+    chunkStreamId = Util.readUnsignedInt32(in);
+  }
+
+  @Override
+  protected void writeBody(OutputStream out) throws IOException {
+    Util.writeUnsignedInt32(out, chunkStreamId);
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Acknowledgement.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Acknowledgement.java
@@ -1,0 +1,67 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * (Window) Acknowledgement
+ * <p>
+ * The client or the server sends the acknowledgment to the peer after
+ * receiving bytes equal to the window size. The window size is the
+ * maximum number of bytes that the sender sends without receiving
+ * acknowledgment from the receiver. The server sends the window size to
+ * the client after application connects. This message specifies the
+ * sequence number, which is the number of the bytes received so far.
+ *
+ * @author francois
+ */
+public class Acknowledgement extends RtmpPacket {
+
+  private int sequenceNumber;
+
+  public Acknowledgement(RtmpHeader header) {
+    super(header);
+  }
+
+  public Acknowledgement(int numBytesReadThusFar) {
+    super(new RtmpHeader(RtmpHeader.ChunkType.TYPE_0_FULL, ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL, RtmpHeader.MessageType.ACKNOWLEDGEMENT));
+    this.sequenceNumber = numBytesReadThusFar;
+  }
+
+  public int getAcknowledgementWindowSize() {
+    return sequenceNumber;
+  }
+
+  /**
+   * @return the sequence number, which is the number of the bytes received so far
+   */
+  public int getSequenceNumber() {
+    return sequenceNumber;
+  }
+
+  /**
+   * Sets the sequence number, which is the number of the bytes received so far
+   */
+  public void setSequenceNumber(int numBytesRead) {
+    this.sequenceNumber = numBytesRead;
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    sequenceNumber = Util.readUnsignedInt32(in);
+  }
+
+  @Override
+  protected void writeBody(OutputStream out) throws IOException {
+    Util.writeUnsignedInt32(out, sequenceNumber);
+  }
+
+  @Override
+  public String toString() {
+    return "RTMP Acknowledgment (sequence number: " + sequenceNumber + ")";
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Audio.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Audio.java
@@ -1,0 +1,24 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * Audio data packet
+ *
+ * @author francois
+ */
+public class Audio extends ContentData {
+
+  public Audio(RtmpHeader header) {
+    super(header);
+  }
+
+  public Audio() {
+    super(new RtmpHeader(RtmpHeader.ChunkType.TYPE_0_FULL, ChunkStreamInfo.RTMP_CID_AUDIO, RtmpHeader.MessageType.AUDIO));
+  }
+
+  @Override
+  public String toString() {
+    return "RTMP Audio";
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Command.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Command.java
@@ -1,0 +1,84 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfNumber;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfString;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * Encapsulates an command/"invoke" RTMP packet
+ * <p>
+ * Invoke/command packet structure (AMF encoded):
+ * (String) <commmand name>
+ * (Number) <Transaction ID>
+ * (Mixed) <Argument> ex. Null, String, Object: {key1:value1, key2:value2 ... }
+ *
+ * @author francois
+ */
+public class Command extends VariableBodyRtmpPacket {
+
+  private static final String TAG = "Command";
+
+  private String commandName;
+  private int transactionId;
+
+  public Command(RtmpHeader header) {
+    super(header);
+  }
+
+  public Command(String commandName, int transactionId, ChunkStreamInfo channelInfo) {
+    super(new RtmpHeader((channelInfo.canReusePrevHeaderTx(RtmpHeader.MessageType.COMMAND_AMF0) ?
+        RtmpHeader.ChunkType.TYPE_1_RELATIVE_LARGE : RtmpHeader.ChunkType.TYPE_0_FULL),
+        ChunkStreamInfo.RTMP_CID_OVER_CONNECTION, RtmpHeader.MessageType.COMMAND_AMF0));
+    this.commandName = commandName;
+    this.transactionId = transactionId;
+  }
+
+  public Command(String commandName, int transactionId) {
+    super(new RtmpHeader(RtmpHeader.ChunkType.TYPE_0_FULL, ChunkStreamInfo.RTMP_CID_OVER_CONNECTION,
+        RtmpHeader.MessageType.COMMAND_AMF0));
+    this.commandName = commandName;
+    this.transactionId = transactionId;
+  }
+
+  public String getCommandName() {
+    return commandName;
+  }
+
+  public void setCommandName(String commandName) {
+    this.commandName = commandName;
+  }
+
+  public int getTransactionId() {
+    return transactionId;
+  }
+
+  public void setTransactionId(int transactionId) {
+    this.transactionId = transactionId;
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    // The command name and transaction ID are always present (AMF string followed by number)
+    commandName = AmfString.readStringFrom(in, false);
+    transactionId = (int) AmfNumber.readNumberFrom(in);
+    int bytesRead = AmfString.sizeOf(commandName, false) + AmfNumber.SIZE;
+    readVariableData(in, bytesRead);
+  }
+
+  @Override
+  protected void writeBody(OutputStream out) throws IOException {
+    AmfString.writeStringTo(out, commandName, false);
+    AmfNumber.writeNumberTo(out, transactionId);
+    // Write body data
+    writeVariableData(out);
+  }
+
+  @Override
+  public String toString() {
+    return "RTMP Command (command: " + commandName + ", transaction ID: " + transactionId + ")";
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/ContentData.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/ContentData.java
@@ -1,0 +1,45 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+
+/**
+ * Content (audio/video) data packet base
+ *
+ * @author francois
+ */
+public abstract class ContentData extends RtmpPacket {
+
+  protected byte[] data;
+
+  public ContentData(RtmpHeader header) {
+    super(header);
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+
+  public void setData(byte[] data) {
+    this.data = data;
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    data = new byte[this.header.getPacketLength()];
+    Util.readBytesUntilFull(in, data);
+  }
+
+  /**
+   * Method is public for content (audio/video)
+   * Write this packet body without chunking;
+   * useful for dumping audio/video streams
+   */
+  @Override
+  public void writeBody(OutputStream out) throws IOException {
+    out.write(data);
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Data.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Data.java
@@ -1,0 +1,60 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfString;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * AMF Data packet
+ * <p>
+ * Also known as NOTIFY in some RTMP implementations.
+ * <p>
+ * The client or the server sends this message to send Metadata or any user data
+ * to the peer. Metadata includes details about the data (audio, video etc.)
+ * like creation time, duration, theme and so on.
+ *
+ * @author francois
+ */
+public class Data extends VariableBodyRtmpPacket {
+
+  private String type;
+
+  public Data(RtmpHeader header) {
+    super(header);
+  }
+
+  public Data(String type) {
+    super(new RtmpHeader(RtmpHeader.ChunkType.TYPE_0_FULL, ChunkStreamInfo.RTMP_CID_OVER_CONNECTION, RtmpHeader.MessageType.DATA_AMF0));
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    // Read notification type
+    type = AmfString.readStringFrom(in, false);
+    int bytesRead = AmfString.sizeOf(type, false);
+    // Read data body
+    readVariableData(in, bytesRead);
+  }
+
+  /**
+   * This method is public for Data to make it easy to dump its contents to
+   * another output stream
+   */
+  @Override
+  public void writeBody(OutputStream out) throws IOException {
+    AmfString.writeStringTo(out, type, false);
+    writeVariableData(out);
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Handshake.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Handshake.java
@@ -1,0 +1,229 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Random;
+
+import android.util.Log;
+
+import com.google.android.exoplayer2.upstream.rtmp.Crypto;
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+
+/**
+ * Handles the RTMP handshake song 'n dance
+ * <p>
+ * Thanks to http://thompsonng.blogspot.com/2010/11/rtmp-part-10-handshake.html for some very useful information on
+ * the the hidden "features" of the RTMP handshake
+ *
+ * @author francois
+ */
+public final class Handshake {
+  private static final String TAG = "Handshake";
+  /**
+   * S1 as sent by the server
+   */
+  private byte[] s1;
+  private static final int PROTOCOL_VERSION = 0x03;
+  private static final int HANDSHAKE_SIZE = 1536;
+  private static final int SHA256_DIGEST_SIZE = 32;
+
+  private static final int DIGEST_OFFSET_INDICATOR_POS = 772; // should either be byte 772 or byte 8
+
+  private static final byte[] GENUINE_FP_KEY = {
+      (byte) 0x47, (byte) 0x65, (byte) 0x6E, (byte) 0x75, (byte) 0x69, (byte) 0x6E, (byte) 0x65, (byte) 0x20,
+      (byte) 0x41, (byte) 0x64, (byte) 0x6F, (byte) 0x62, (byte) 0x65, (byte) 0x20, (byte) 0x46, (byte) 0x6C,
+      (byte) 0x61, (byte) 0x73, (byte) 0x68, (byte) 0x20, (byte) 0x50, (byte) 0x6C, (byte) 0x61, (byte) 0x79,
+      (byte) 0x65, (byte) 0x72, (byte) 0x20, (byte) 0x30, (byte) 0x30, (byte) 0x31, // Genuine Adobe Flash Player 001
+      (byte) 0xF0, (byte) 0xEE, (byte) 0xC2, (byte) 0x4A, (byte) 0x80, (byte) 0x68, (byte) 0xBE, (byte) 0xE8,
+      (byte) 0x2E, (byte) 0x00, (byte) 0xD0, (byte) 0xD1, (byte) 0x02, (byte) 0x9E, (byte) 0x7E, (byte) 0x57,
+      (byte) 0x6E, (byte) 0xEC, (byte) 0x5D, (byte) 0x2D, (byte) 0x29, (byte) 0x80, (byte) 0x6F, (byte) 0xAB,
+      (byte) 0x93, (byte) 0xB8, (byte) 0xE6, (byte) 0x36, (byte) 0xCF, (byte) 0xEB, (byte) 0x31, (byte) 0xAE};
+
+  /**
+   * Generates and writes the first handshake packet (C0)
+   */
+  public final void writeC0(OutputStream out) throws IOException {
+    Log.d(TAG, "writeC0");
+    out.write(PROTOCOL_VERSION);
+  }
+
+  public final void readS0(InputStream in) throws IOException {
+    Log.d(TAG, "readS0");
+    byte s0 = (byte) in.read();
+    if (s0 != PROTOCOL_VERSION) {
+      if (s0 == -1) {
+        throw new IOException("InputStream closed");
+      } else {
+        throw new IOException("Invalid RTMP protocol version; expected " + PROTOCOL_VERSION + ", got " + s0);
+      }
+    }
+  }
+
+  /**
+   * Generates and writes the second handshake packet (C1)
+   */
+  public final void writeC1(OutputStream out) throws IOException {
+    Log.d(TAG, "writeC1");
+//        Util.writeUnsignedInt32(out, (int) (System.currentTimeMillis() / 1000)); // Bytes 0 - 3 bytes: current epoch (timestamp)
+    //out.write(new byte[]{0x09, 0x00, 0x7c, 0x02}); // Bytes 4 - 7: Flash player version: 9.0.124.2
+
+//        out.write(new byte[]{(byte) 0x80, 0x00, 0x07, 0x02}); // Bytes 4 - 7: Flash player version: 11.2.202.233
+
+
+    Log.d(TAG, "writeC1(): Calculating digest offset");
+    Random random = new Random();
+    // Since we are faking a real Flash Player handshake, include a digest in C1
+    // Choose digest offset point (scheme 1; that is, offset is indicated by bytes 772 - 775 (4 bytes) )
+    final int digestOffset = random.nextInt(HANDSHAKE_SIZE - DIGEST_OFFSET_INDICATOR_POS - 4 - 8 - SHA256_DIGEST_SIZE); //random.nextInt(DIGEST_OFFSET_INDICATOR_POS - SHA256_DIGEST_SIZE);
+
+    final int absoluteDigestOffset = ((digestOffset % 728) + DIGEST_OFFSET_INDICATOR_POS + 4);
+    Log.d(TAG, "writeC1(): (real value of) digestOffset: " + digestOffset);
+
+
+    Log.d(TAG, "writeC1(): recalculated digestOffset: " + absoluteDigestOffset);
+
+    int remaining = digestOffset;
+    final byte[] digestOffsetBytes = new byte[4];
+    for (int i = 3; i >= 0; i--) {
+      if (remaining > 255) {
+        digestOffsetBytes[i] = (byte) 255;
+        remaining -= 255;
+      } else {
+        digestOffsetBytes[i] = (byte) remaining;
+        remaining -= remaining;
+      }
+    }
+
+
+    // Calculate the offset value that will be written
+    //inal byte[] digestOffsetBytes = Util.unsignedInt32ToByteArray(digestOffset);// //((digestOffset - DIGEST_OFFSET_INDICATOR_POS) % 728)); // Thanks to librtmp for the mod 728
+    Log.d(TAG, "writeC1(): digestOffsetBytes: " + Util.toHexString(digestOffsetBytes));  //Util.unsignedInt32ToByteArray((digestOffset % 728))));
+
+    // Create random bytes up to the digest offset point
+    byte[] partBeforeDigest = new byte[absoluteDigestOffset];
+    Log.d(TAG, "partBeforeDigest(): size: " + partBeforeDigest.length);
+    random.nextBytes(partBeforeDigest);
+
+    Log.d(TAG, "writeC1(): Writing timestamp and Flash Player version");
+    byte[] timeStamp = Util.unsignedInt32ToByteArray((int) (System.currentTimeMillis() / 1000));
+    System.arraycopy(timeStamp, 0, partBeforeDigest, 0, 4); // Bytes 0 - 3 bytes: current epoch timestamp
+    System.arraycopy(new byte[]{(byte) 0x80, 0x00, 0x07, 0x02}, 0, partBeforeDigest, 4, 4); // Bytes 4 - 7: Flash player version: 11.2.202.233
+
+    // Create random bytes for the part after the digest
+    byte[] partAfterDigest = new byte[HANDSHAKE_SIZE - absoluteDigestOffset - SHA256_DIGEST_SIZE]; // subtract 8 because of initial 8 bytes already written
+    Log.d(TAG, "partAfterDigest(): size: " + partAfterDigest.length);
+    random.nextBytes(partAfterDigest);
+
+
+    // Set the offset byte
+//        if (digestOffset > 772) {                      
+    Log.d(TAG, "copying digest offset bytes in partBeforeDigest");
+    System.arraycopy(digestOffsetBytes, 0, partBeforeDigest, 772, 4);
+//        } else {
+    // Implied offset of partAfterDigest is digestOffset + 32
+///        Log.d(TAG, "copying digest offset bytes in partAfterDigest");
+///        Log.d(TAG, " writing to location: " + (DIGEST_OFFSET_INDICATOR_POS - digestOffset - SHA256_DIGEST_SIZE - 8));
+//        System.arraycopy(digestOffsetBytes, 0, partAfterDigest, (DIGEST_OFFSET_INDICATOR_POS - digestOffset - SHA256_DIGEST_SIZE - 8), 4);
+//        }
+
+    Log.d(TAG, "writeC1(): Calculating digest");
+    byte[] tempBuffer = new byte[HANDSHAKE_SIZE - SHA256_DIGEST_SIZE];
+    System.arraycopy(partBeforeDigest, 0, tempBuffer, 0, partBeforeDigest.length);
+    System.arraycopy(partAfterDigest, 0, tempBuffer, partBeforeDigest.length, partAfterDigest.length);
+
+    Crypto crypto = new Crypto();
+    byte[] digest = crypto.calculateHmacSHA256(tempBuffer, GENUINE_FP_KEY, 30);
+
+    // Now write the packet
+    Log.d(TAG, "writeC1(): writing C1 packet");
+    out.write(partBeforeDigest);
+    out.write(digest);
+    out.write(partAfterDigest);
+  }
+
+  public final void readS1(InputStream in) throws IOException {
+    // S1 == 1536 bytes. We do not bother with checking the content of it
+    Log.d(TAG, "readS1");
+    s1 = new byte[HANDSHAKE_SIZE];
+
+    // Read server time (4 bytes)
+    int totalBytesRead = 0;
+    int read;
+    do {
+      read = in.read(s1, totalBytesRead, (HANDSHAKE_SIZE - totalBytesRead));
+      if (read != -1) {
+        totalBytesRead += read;
+      }
+    } while (totalBytesRead < HANDSHAKE_SIZE);
+
+    if (totalBytesRead != HANDSHAKE_SIZE) {
+      throw new IOException("Unexpected EOF while reading S1, expected " + HANDSHAKE_SIZE + " bytes, but only read " + totalBytesRead + " bytes");
+    } else {
+      Log.d(TAG, "readS1(): S1 total bytes read OK");
+    }
+  }
+
+  /**
+   * Generates and writes the third handshake packet (C2)
+   */
+  public final void writeC2(OutputStream out) throws IOException {
+    Log.d(TAG, "readC2");
+    // C2 is an echo of S1
+    if (s1 == null) {
+      throw new IllegalStateException("C2 cannot be written without S1 being read first");
+    }
+    out.write(s1);
+  }
+
+  public final void readS2(InputStream in) throws IOException {
+    // S2 should be an echo of C1, but we are not too strict
+    Log.d(TAG, "readS2");
+    byte[] sr_serverTime = new byte[4];
+    byte[] s2_serverVersion = new byte[4];
+    byte[] s2_rest = new byte[HANDSHAKE_SIZE - 8]; // subtract 4+4 bytes for time and version
+
+    // Read server time (4 bytes)
+    int totalBytesRead = 0;
+    int read;
+    do {
+      read = in.read(sr_serverTime, totalBytesRead, (4 - totalBytesRead));
+      if (read == -1) {
+        // End of stream reached - should not have happened at this point
+        throw new IOException("Unexpected EOF while reading S2 bytes 0-3");
+      } else {
+        totalBytesRead += read;
+      }
+    } while (totalBytesRead < 4);
+
+    // Read server version (4 bytes)
+    totalBytesRead = 0;
+    do {
+      read = in.read(s2_serverVersion, totalBytesRead, (4 - totalBytesRead));
+      if (read == -1) {
+        // End of stream reached - should not have happened at this point
+        throw new IOException("Unexpected EOF while reading S2 bytes 4-7");
+      } else {
+        totalBytesRead += read;
+      }
+    } while (totalBytesRead < 4);
+
+    // Read 1528 bytes (to make up S1 total size of 1536 bytes)
+    final int remainingBytes = HANDSHAKE_SIZE - 8;
+    totalBytesRead = 0;
+    do {
+      read = in.read(s2_rest, totalBytesRead, (remainingBytes - totalBytesRead));
+      if (read != -1) {
+        totalBytesRead += read;
+      }
+    } while (totalBytesRead < remainingBytes && read != -1);
+
+    if (totalBytesRead != remainingBytes) {
+      throw new IOException("Unexpected EOF while reading remainder of S2, expected " + remainingBytes + " bytes, but only read " + totalBytesRead + " bytes");
+    } else {
+      Log.d(TAG, "readS2(): S2 total bytes read OK");
+    }
+
+    // Technically we should check that S2 == C1, but for now this is ignored
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/RtmpHeader.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/RtmpHeader.java
@@ -1,0 +1,446 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+import com.google.android.exoplayer2.upstream.rtmp.io.RtmpSessionInfo;
+
+/**
+ * @author francois, leoma
+ */
+public class RtmpHeader {
+
+  private static final String TAG = "RtmpHeader";
+
+  /**
+   * RTMP packet/message type definitions.
+   * Note: docstrings are adapted from the official Adobe RTMP spec:
+   * http://www.adobe.com/devnet/rtmp/
+   */
+  public enum MessageType {
+
+    /**
+     * Protocol control message 1
+     * Set Chunk Size, is used to notify the peer a new maximum chunk size to use.
+     */
+    SET_CHUNK_SIZE(0x01),
+    /**
+     * Protocol control message 2
+     * Abort Message, is used to notify the peer if it is waiting for chunks
+     * to complete a message, then to discard the partially received message
+     * over a chunk stream and abort processing of that message.
+     */
+    ABORT(0x02),
+    /**
+     * Protocol control message 3
+     * The client or the server sends the acknowledgment to the peer after
+     * receiving bytes equal to the window size. The window size is the
+     * maximum number of bytes that the sender sends without receiving
+     * acknowledgment from the receiver.
+     */
+    ACKNOWLEDGEMENT(0x03),
+    /**
+     * Protocol control message 4
+     * The client or the server sends this message to notify the peer about
+     * the user control events. This message carries Event type and Event
+     * data.
+     * Also known as a PING message in some RTMP implementations.
+     */
+    USER_CONTROL_MESSAGE(0x04),
+    /**
+     * Protocol control message 5
+     * The client or the server sends this message to inform the peer which
+     * window size to use when sending acknowledgment.
+     * Also known as ServerBW ("server bandwidth") in some RTMP implementations.
+     */
+    WINDOW_ACKNOWLEDGEMENT_SIZE(0x05),
+    /**
+     * Protocol control message 6
+     * The client or the server sends this message to update the output
+     * bandwidth of the peer. The output bandwidth value is the same as the
+     * window size for the peer.
+     * Also known as ClientBW ("client bandwidth") in some RTMP implementations.
+     */
+    SET_PEER_BANDWIDTH(0x06),
+    /**
+     * RTMP audio packet (0x08)
+     * The client or the server sends this message to send audio data to the peer.
+     */
+    AUDIO(0x08),
+    /**
+     * RTMP video packet (0x09)
+     * The client or the server sends this message to send video data to the peer.
+     */
+    VIDEO(0x09),
+    /**
+     * RTMP message type 0x0F
+     * The client or the server sends this message to send Metadata or any
+     * user data to the peer. Metadata includes details about the data (audio, video etc.)
+     * like creation time, duration, theme and so on.
+     * This is the AMF3-encoded version.
+     */
+    DATA_AMF3(0x0F),
+    /**
+     * RTMP message type 0x10
+     * A shared object is a Flash object (a collection of name value pairs)
+     * that are in synchronization across multiple clients, instances, and
+     * so on.
+     * This is the AMF3 version: kMsgContainerEx=16 for AMF3.
+     */
+    SHARED_OBJECT_AMF3(0x10),
+    /**
+     * RTMP message type 0x11
+     * Command messages carry the AMF-encoded commands between the client
+     * and the server.
+     * A command message consists of command name, transaction ID, and command object that
+     * contains related parameters.
+     * This is the AMF3-encoded version.
+     */
+    COMMAND_AMF3(0x11),
+    /**
+     * RTMP message type 0x12
+     * The client or the server sends this message to send Metadata or any
+     * user data to the peer. Metadata includes details about the data (audio, video etc.)
+     * like creation time, duration, theme and so on.
+     * This is the AMF0-encoded version.
+     */
+    DATA_AMF0(0x12),
+    /**
+     * RTMP message type 0x14
+     * Command messages carry the AMF-encoded commands between the client
+     * and the server.
+     * A command message consists of command name, transaction ID, and command object that
+     * contains related parameters.
+     * This is the common AMF0 version, also known as INVOKE in some RTMP implementations.
+     */
+    COMMAND_AMF0(0x14),
+    /**
+     * RTMP message type 0x13
+     * A shared object is a Flash object (a collection of name value pairs)
+     * that are in synchronization across multiple clients, instances, and
+     * so on.
+     * This is the AMF0 version: kMsgContainer=19 for AMF0.
+     */
+    SHARED_OBJECT_AMF0(0x13),
+    /**
+     * RTMP message type 0x16
+     * An aggregate message is a single message that contains a list of sub-messages.
+     */
+    AGGREGATE_MESSAGE(0x16);
+    private byte value;
+    private static final Map<Byte, MessageType> quickLookupMap = new HashMap<Byte, MessageType>();
+
+    static {
+      for (MessageType messageTypId : MessageType.values()) {
+        quickLookupMap.put(messageTypId.getValue(), messageTypId);
+      }
+    }
+
+    MessageType(int value) {
+      this.value = (byte) value;
+    }
+
+    /**
+     * Returns the value of this chunk type
+     */
+    public byte getValue() {
+      return value;
+    }
+
+    public static MessageType valueOf(byte messageTypeId) {
+      if (quickLookupMap.containsKey(messageTypeId)) {
+        return quickLookupMap.get(messageTypeId);
+      } else {
+        throw new IllegalArgumentException("Unknown message type byte: " + Util.toHexString(messageTypeId));
+      }
+    }
+  }
+
+  public enum ChunkType {
+
+    /**
+     * Full 12-byte RTMP chunk header
+     */
+    TYPE_0_FULL(0x00),
+    /**
+     * Relative 8-byte RTMP chunk header (message stream ID is not included)
+     */
+    TYPE_1_RELATIVE_LARGE(0x01),
+    /**
+     * Relative 4-byte RTMP chunk header (only timestamp delta)
+     */
+    TYPE_2_RELATIVE_TIMESTAMP_ONLY(0x02),
+    /**
+     * Relative 1-byte RTMP chunk header (no "real" header, just the 1-byte indicating chunk header type & chunk stream ID)
+     */
+    TYPE_3_RELATIVE_SINGLE_BYTE(0x03);
+    /**
+     * The byte value of this chunk header type
+     */
+    private byte value;
+    /**
+     * The full size (in bytes) of this RTMP header (including the basic header byte)
+     */
+    private static final Map<Byte, ChunkType> quickLookupMap = new HashMap<Byte, ChunkType>();
+
+    static {
+      for (ChunkType messageTypId : ChunkType.values()) {
+        quickLookupMap.put(messageTypId.getValue(), messageTypId);
+      }
+    }
+
+    ChunkType(int byteValue) {
+      this.value = (byte) byteValue;
+    }
+
+    /**
+     * Returns the byte value of this chunk header type
+     */
+    public byte getValue() {
+      return value;
+    }
+
+    public static ChunkType valueOf(byte chunkHeaderType) {
+      if (quickLookupMap.containsKey(chunkHeaderType)) {
+        return quickLookupMap.get(chunkHeaderType);
+      } else {
+        throw new IllegalArgumentException("Unknown chunk header type byte: " + Util.toHexString(chunkHeaderType));
+      }
+    }
+  }
+
+  private ChunkType chunkType;
+  private int chunkStreamId;
+  private int absoluteTimestamp;
+  private int timestampDelta = -1;
+  private int packetLength;
+  private MessageType messageType;
+  private int messageStreamId;
+  private int extendedTimestamp;
+
+  public RtmpHeader() {
+  }
+
+  public RtmpHeader(ChunkType chunkType, int chunkStreamId, MessageType messageType) {
+    this.chunkType = chunkType;
+    this.chunkStreamId = chunkStreamId;
+    this.messageType = messageType;
+  }
+
+  public static RtmpHeader readHeader(InputStream in, RtmpSessionInfo rtmpSessionInfo) throws IOException {
+    RtmpHeader rtmpHeader = new RtmpHeader();
+    rtmpHeader.readHeaderImpl(in, rtmpSessionInfo);
+    return rtmpHeader;
+  }
+
+  private void readHeaderImpl(InputStream in, RtmpSessionInfo rtmpSessionInfo) throws IOException {
+
+    int basicHeaderByte = in.read();
+    if (basicHeaderByte == -1) {
+      throw new EOFException("Unexpected EOF while reading RTMP packet basic header");
+    }
+    // Read byte 0: chunk type and chunk stream ID
+    parseBasicHeader((byte) basicHeaderByte);
+
+    switch (chunkType) {
+      case TYPE_0_FULL: { //  b00 = 12 byte header (full header)
+        // Read bytes 1-3: Absolute timestamp
+        absoluteTimestamp = Util.readUnsignedInt24(in);
+        timestampDelta = 0;
+        // Read bytes 4-6: Packet length
+        packetLength = Util.readUnsignedInt24(in);
+        // Read byte 7: Message type ID
+        messageType = MessageType.valueOf((byte) in.read());
+        // Read bytes 8-11: Message stream ID (apparently little-endian order)
+        byte[] messageStreamIdBytes = new byte[4];
+        Util.readBytesUntilFull(in, messageStreamIdBytes);
+        messageStreamId = Util.toUnsignedInt32LittleEndian(messageStreamIdBytes);
+        // Read bytes 1-4: Extended timestamp
+        extendedTimestamp = absoluteTimestamp >= 0xffffff ? Util.readUnsignedInt32(in) : 0;
+        if (extendedTimestamp != 0) {
+          absoluteTimestamp = extendedTimestamp;
+        }
+        break;
+      }
+      case TYPE_1_RELATIVE_LARGE: { // b01 = 8 bytes - like type 0. not including message stream ID (4 last bytes)
+        // Read bytes 1-3: Timestamp delta
+        timestampDelta = Util.readUnsignedInt24(in);
+        // Read bytes 4-6: Packet length
+        packetLength = Util.readUnsignedInt24(in);
+        // Read byte 7: Message type ID
+        messageType = MessageType.valueOf((byte) in.read());
+        // Read bytes 1-4: Extended timestamp delta
+        extendedTimestamp = timestampDelta >= 0xffffff ? Util.readUnsignedInt32(in) : 0;
+        RtmpHeader prevHeader = rtmpSessionInfo.getChunkStreamInfo(chunkStreamId).prevHeaderRx();
+        if (prevHeader != null) {
+          messageStreamId = prevHeader.messageStreamId;
+          absoluteTimestamp = extendedTimestamp != 0 ? extendedTimestamp : prevHeader.absoluteTimestamp + timestampDelta;
+        } else {
+          messageStreamId = 0;
+          absoluteTimestamp = extendedTimestamp != 0 ? extendedTimestamp : timestampDelta;
+        }
+        break;
+      }
+      case TYPE_2_RELATIVE_TIMESTAMP_ONLY: { // b10 = 4 bytes - Basic Header and timestamp (3 bytes) are included
+        // Read bytes 1-3: Timestamp delta
+        timestampDelta = Util.readUnsignedInt24(in);
+        // Read bytes 1-4: Extended timestamp delta
+        extendedTimestamp = timestampDelta >= 0xffffff ? Util.readUnsignedInt32(in) : 0;
+        RtmpHeader prevHeader = rtmpSessionInfo.getChunkStreamInfo(chunkStreamId).prevHeaderRx();
+        if (prevHeader == null) {
+          throw new IllegalArgumentException("Unknown chunk stream id " + chunkStreamId);
+        }
+        packetLength = prevHeader.packetLength;
+        messageType = prevHeader.messageType;
+        messageStreamId = prevHeader.messageStreamId;
+        absoluteTimestamp = extendedTimestamp != 0 ? extendedTimestamp : prevHeader.absoluteTimestamp + timestampDelta;
+        break;
+      }
+      case TYPE_3_RELATIVE_SINGLE_BYTE: { // b11 = 1 byte: basic header only
+        RtmpHeader prevHeader = rtmpSessionInfo.getChunkStreamInfo(chunkStreamId).prevHeaderRx();
+        if (prevHeader == null) {
+          throw new IllegalArgumentException("Unknown chunk stream id " + chunkStreamId);
+        }
+        // Read bytes 1-4: Extended timestamp
+        extendedTimestamp = prevHeader.timestampDelta >= 0xffffff ? Util.readUnsignedInt32(in) : 0;
+        timestampDelta = extendedTimestamp != 0 ? 0xffffff : prevHeader.timestampDelta;
+        packetLength = prevHeader.packetLength;
+        messageType = prevHeader.messageType;
+        messageStreamId = prevHeader.messageStreamId;
+        absoluteTimestamp = extendedTimestamp != 0 ? extendedTimestamp : prevHeader.absoluteTimestamp + timestampDelta;
+        break;
+      }
+      default:
+        throw new IOException("Invalid chunk type; basic header byte was: " + Util.toHexString((byte) basicHeaderByte));
+    }
+  }
+
+  public void writeTo(OutputStream out, ChunkType chunkType, final ChunkStreamInfo chunkStreamInfo) throws IOException {
+    // Write basic header byte
+    out.write(((byte) (chunkType.getValue() << 6) | chunkStreamId));
+    switch (chunkType) {
+      case TYPE_0_FULL: { //  b00 = 12 byte header (full header)
+        chunkStreamInfo.markDeltaTimestamp();
+        Util.writeUnsignedInt24(out, absoluteTimestamp >= 0xffffff ? 0xffffff : absoluteTimestamp);
+        Util.writeUnsignedInt24(out, packetLength);
+        out.write(messageType.getValue());
+        Util.writeUnsignedInt32LittleEndian(out, messageStreamId);
+        if (absoluteTimestamp >= 0xffffff) {
+          extendedTimestamp = absoluteTimestamp;
+          Util.writeUnsignedInt32(out, extendedTimestamp);
+        }
+        break;
+      }
+      case TYPE_1_RELATIVE_LARGE: { // b01 = 8 bytes - like type 0. not including message ID (4 last bytes)
+        timestampDelta = (int) chunkStreamInfo.markDeltaTimestamp();
+        absoluteTimestamp = chunkStreamInfo.getPrevHeaderTx().getAbsoluteTimestamp() + timestampDelta;
+        Util.writeUnsignedInt24(out, absoluteTimestamp >= 0xffffff ? 0xffffff : timestampDelta);
+        Util.writeUnsignedInt24(out, packetLength);
+        out.write(messageType.getValue());
+        if (absoluteTimestamp >= 0xffffff) {
+          extendedTimestamp = absoluteTimestamp;
+          Util.writeUnsignedInt32(out, absoluteTimestamp);
+        }
+        break;
+      }
+      case TYPE_2_RELATIVE_TIMESTAMP_ONLY: { // b10 = 4 bytes - Basic Header and timestamp (3 bytes) are included
+        timestampDelta = (int) chunkStreamInfo.markDeltaTimestamp();
+        absoluteTimestamp = chunkStreamInfo.getPrevHeaderTx().getAbsoluteTimestamp() + timestampDelta;
+        Util.writeUnsignedInt24(out, (absoluteTimestamp >= 0xffffff) ? 0xffffff : timestampDelta);
+        if (absoluteTimestamp >= 0xffffff) {
+          extendedTimestamp = absoluteTimestamp;
+          Util.writeUnsignedInt32(out, extendedTimestamp);
+        }
+        break;
+      }
+      case TYPE_3_RELATIVE_SINGLE_BYTE: { // b11 = 1 byte: basic header only
+        timestampDelta = (int) chunkStreamInfo.markDeltaTimestamp();
+        absoluteTimestamp = chunkStreamInfo.getPrevHeaderTx().getAbsoluteTimestamp() + timestampDelta;
+        if (absoluteTimestamp >= 0xffffff) {
+          extendedTimestamp = absoluteTimestamp;
+          Util.writeUnsignedInt32(out, extendedTimestamp);
+        }
+        break;
+      }
+      default:
+        throw new IOException("Invalid chunk type: " + chunkType);
+    }
+  }
+
+  private void parseBasicHeader(byte basicHeaderByte) {
+    chunkType = ChunkType.valueOf((byte) ((0xff & basicHeaderByte) >>> 6)); // 2 most significant bits define the chunk type
+    chunkStreamId = basicHeaderByte & 0x3F; // 6 least significant bits define chunk stream ID
+  }
+
+  /**
+   * @return the RTMP chunk stream ID (channel ID) for this chunk
+   */
+  public int getChunkStreamId() {
+    return chunkStreamId;
+  }
+
+  public ChunkType getChunkType() {
+    return chunkType;
+  }
+
+  public int getPacketLength() {
+    return packetLength;
+  }
+
+  public int getMessageStreamId() {
+    return messageStreamId;
+  }
+
+  public MessageType getMessageType() {
+    return messageType;
+  }
+
+  public int getAbsoluteTimestamp() {
+    return absoluteTimestamp;
+  }
+
+  public void setAbsoluteTimestamp(int absoluteTimestamp) {
+    this.absoluteTimestamp = absoluteTimestamp;
+  }
+
+  public int getTimestampDelta() {
+    return timestampDelta;
+  }
+
+  public void setTimestampDelta(int timestampDelta) {
+    this.timestampDelta = timestampDelta;
+  }
+
+  /**
+   * Sets the RTMP chunk stream ID (channel ID) for this chunk
+   */
+  public void setChunkStreamId(int channelId) {
+    this.chunkStreamId = channelId;
+  }
+
+  public void setChunkType(ChunkType chunkType) {
+    this.chunkType = chunkType;
+  }
+
+  public void setMessageStreamId(int messageStreamId) {
+    this.messageStreamId = messageStreamId;
+  }
+
+  public void setMessageType(MessageType messageType) {
+    this.messageType = messageType;
+  }
+
+  public void setPacketLength(int packetLength) {
+    this.packetLength = packetLength;
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/RtmpPacket.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/RtmpPacket.java
@@ -1,0 +1,48 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * @author francois, leo
+ */
+public abstract class RtmpPacket {
+
+  protected RtmpHeader header;
+
+  public RtmpPacket(RtmpHeader header) {
+    this.header = header;
+  }
+
+  public RtmpHeader getHeader() {
+    return header;
+  }
+
+  public abstract void readBody(InputStream in) throws IOException;
+
+  protected abstract void writeBody(OutputStream out) throws IOException;
+
+  public void writeTo(OutputStream out, final int chunkSize, final ChunkStreamInfo chunkStreamInfo) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    writeBody(baos);
+    byte[] body = baos.toByteArray();
+    header.setPacketLength(body.length);
+    // Write header for first chunk
+    header.writeTo(out, RtmpHeader.ChunkType.TYPE_0_FULL, chunkStreamInfo);
+    int remainingBytes = body.length;
+    int pos = 0;
+    while (remainingBytes > chunkSize) {
+      // Write packet for chunk
+      out.write(body, pos, chunkSize);
+      remainingBytes -= chunkSize;
+      pos += chunkSize;
+      // Write header for remain chunk
+      header.writeTo(out, RtmpHeader.ChunkType.TYPE_3_RELATIVE_SINGLE_BYTE, chunkStreamInfo);
+    }
+    out.write(body, pos, remainingBytes);
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/SetChunkSize.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/SetChunkSize.java
@@ -1,0 +1,46 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * A "Set chunk size" RTMP message, received on chunk stream ID 2 (control channel)
+ *
+ * @author francois
+ */
+public class SetChunkSize extends RtmpPacket {
+
+  private int chunkSize;
+
+  public SetChunkSize(RtmpHeader header) {
+    super(header);
+  }
+
+  public SetChunkSize(int chunkSize) {
+    super(new RtmpHeader(RtmpHeader.ChunkType.TYPE_1_RELATIVE_LARGE, ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL, RtmpHeader.MessageType.SET_CHUNK_SIZE));
+    this.chunkSize = chunkSize;
+  }
+
+  public int getChunkSize() {
+    return chunkSize;
+  }
+
+  public void setChunkSize(int chunkSize) {
+    this.chunkSize = chunkSize;
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    // Value is received in the 4 bytes of the body
+    chunkSize = Util.readUnsignedInt32(in);
+  }
+
+  @Override
+  protected void writeBody(OutputStream out) throws IOException {
+    Util.writeUnsignedInt32(out, chunkSize);
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/SetPeerBandwidth.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/SetPeerBandwidth.java
@@ -1,0 +1,106 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * Set Peer Bandwidth
+ * <p>
+ * Also known as ClientrBW ("client bandwidth") in some RTMP implementations.
+ *
+ * @author francois
+ */
+public class SetPeerBandwidth extends RtmpPacket {
+
+  /**
+   * Bandwidth limiting type
+   */
+  public static enum LimitType {
+
+    /**
+     * In a hard (0) request, the peer must send the data in the provided bandwidth.
+     */
+    HARD(0),
+    /**
+     * In a soft (1) request, the bandwidth is at the discretion of the peer
+     * and the sender can limit the bandwidth.
+     */
+    SOFT(1),
+    /**
+     * In a dynamic (2) request, the bandwidth can be hard or soft.
+     */
+    DYNAMIC(2);
+    private int intValue;
+    private static final Map<Integer, LimitType> quickLookupMap = new HashMap<Integer, LimitType>();
+
+    static {
+      for (LimitType type : LimitType.values()) {
+        quickLookupMap.put(type.getIntValue(), type);
+      }
+    }
+
+    LimitType(int intValue) {
+      this.intValue = intValue;
+    }
+
+    public int getIntValue() {
+      return intValue;
+    }
+
+    public static LimitType valueOf(int intValue) {
+      return quickLookupMap.get(intValue);
+    }
+  }
+
+  private int acknowledgementWindowSize;
+  private LimitType limitType;
+
+  public SetPeerBandwidth(RtmpHeader header) {
+    super(header);
+  }
+
+  public SetPeerBandwidth(int acknowledgementWindowSize, LimitType limitType, ChunkStreamInfo channelInfo) {
+    super(new RtmpHeader(channelInfo.canReusePrevHeaderTx(RtmpHeader.MessageType.SET_PEER_BANDWIDTH) ? RtmpHeader.ChunkType.TYPE_2_RELATIVE_TIMESTAMP_ONLY : RtmpHeader.ChunkType.TYPE_0_FULL, ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL, RtmpHeader.MessageType.WINDOW_ACKNOWLEDGEMENT_SIZE));
+    this.acknowledgementWindowSize = acknowledgementWindowSize;
+    this.limitType = limitType;
+  }
+
+  public int getAcknowledgementWindowSize() {
+    return acknowledgementWindowSize;
+  }
+
+  public void setAcknowledgementWindowSize(int acknowledgementWindowSize) {
+    this.acknowledgementWindowSize = acknowledgementWindowSize;
+  }
+
+  public LimitType getLimitType() {
+    return limitType;
+  }
+
+  public void setLimitType(LimitType limitType) {
+    this.limitType = limitType;
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    acknowledgementWindowSize = Util.readUnsignedInt32(in);
+    limitType = LimitType.valueOf(in.read());
+  }
+
+  @Override
+  protected void writeBody(OutputStream out) throws IOException {
+    Util.writeUnsignedInt32(out, acknowledgementWindowSize);
+    out.write(limitType.getIntValue());
+  }
+
+  @Override
+  public String toString() {
+    return "RTMP Set Peer Bandwidth";
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/UserControl.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/UserControl.java
@@ -1,0 +1,251 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * User Control message, such as ping
+ *
+ * @author francois
+ */
+public class UserControl extends RtmpPacket {
+
+  /**
+   * Control message type
+   * Docstring adapted from the official Adobe RTMP spec, section 3.7
+   */
+  public static enum Type {
+
+    /**
+     * Type: 0
+     * The server sends this event to notify the client that a stream has become
+     * functional and can be used for communication. By default, this event
+     * is sent on ID 0 after the application connect command is successfully
+     * received from the client.
+     * <p>
+     * Event Data:
+     * eventData[0] (int) the stream ID of the stream that became functional
+     */
+    STREAM_BEGIN(0),
+    /**
+     * Type: 1
+     * The server sends this event to notify the client that the playback of
+     * data is over as requested on this stream. No more data is sent without
+     * issuing additional commands. The client discards the messages received
+     * for the stream.
+     * <p>
+     * Event Data:
+     * eventData[0]: the ID of the stream on which playback has ended.
+     */
+    STREAM_EOF(1),
+    /**
+     * Type: 2
+     * The server sends this event to notify the client that there is no
+     * more data on the stream. If the server does not detect any message for
+     * a time period, it can notify the subscribed clients that the stream is
+     * dry.
+     * <p>
+     * Event Data:
+     * eventData[0]: the stream ID of the dry stream.
+     */
+    STREAM_DRY(2),
+    /**
+     * Type: 3
+     * The client sends this event to inform the server of the buffer size
+     * (in milliseconds) that is used to buffer any data coming over a stream.
+     * This event is sent before the server starts processing the stream.
+     * <p>
+     * Event Data:
+     * eventData[0]: the stream ID and
+     * eventData[1]: the buffer length, in milliseconds.
+     */
+    SET_BUFFER_LENGTH(3),
+    /**
+     * Type: 4
+     * The server sends this event to notify the client that the stream is a
+     * recorded stream.
+     * <p>
+     * Event Data:
+     * eventData[0]: the stream ID of the recorded stream.
+     */
+    STREAM_IS_RECORDED(4),
+    /**
+     * Type: 6
+     * The server sends this event to test whether the client is reachable.
+     * <p>
+     * Event Data:
+     * eventData[0]: a timestamp representing the local server time when the server dispatched the command.
+     * <p>
+     * The client responds with PING_RESPONSE on receiving PING_REQUEST.
+     */
+    PING_REQUEST(6),
+    /**
+     * Type: 7
+     * The client sends this event to the server in response to the ping request.
+     * <p>
+     * Event Data:
+     * eventData[0]: the 4-byte timestamp which was received with the PING_REQUEST.
+     */
+    PONG_REPLY(7),
+    /**
+     * Type: 31 (0x1F)
+     * <p>
+     * This user control type is not specified in any official documentation, but
+     * is sent by Flash Media Server 3.5. Thanks to the rtmpdump devs for their
+     * explanation:
+     * <p>
+     * Buffer Empty (unofficial name): After the server has sent a complete buffer, and
+     * sends this Buffer Empty message, it will wait until the play
+     * duration of that buffer has passed before sending a new buffer.
+     * The Buffer Ready message will be sent when the new buffer starts.
+     * <p>
+     * (see also: http://repo.or.cz/w/rtmpdump.git/blob/8880d1456b282ee79979adbe7b6a6eb8ad371081:/librtmp/rtmp.c#l2787)
+     */
+    BUFFER_EMPTY(31),
+    /**
+     * Type: 32 (0x20)
+     * <p>
+     * This user control type is not specified in any official documentation, but
+     * is sent by Flash Media Server 3.5. Thanks to the rtmpdump devs for their
+     * explanation:
+     * <p>
+     * Buffer Ready (unofficial name): After the server has sent a complete buffer, and
+     * sends a Buffer Empty message, it will wait until the play
+     * duration of that buffer has passed before sending a new buffer.
+     * The Buffer Ready message will be sent when the new buffer starts.
+     * (There is no BufferReady message for the very first buffer;
+     * presumably the Stream Begin message is sufficient for that
+     * purpose.)
+     * <p>
+     * (see also: http://repo.or.cz/w/rtmpdump.git/blob/8880d1456b282ee79979adbe7b6a6eb8ad371081:/librtmp/rtmp.c#l2787)
+     */
+    BUFFER_READY(32);
+
+    private int intValue;
+    private static final Map<Integer, Type> quickLookupMap = new HashMap<Integer, Type>();
+
+    static {
+      for (Type type : Type.values()) {
+        quickLookupMap.put(type.getIntValue(), type);
+      }
+    }
+
+    Type(int intValue) {
+      this.intValue = intValue;
+    }
+
+    public int getIntValue() {
+      return intValue;
+    }
+
+    public static Type valueOf(int intValue) {
+      return quickLookupMap.get(intValue);
+    }
+  }
+
+  private Type type;
+  private int[] eventData;
+
+  public UserControl(RtmpHeader header) {
+    super(header);
+  }
+
+  public UserControl(ChunkStreamInfo channelInfo) {
+    super(new RtmpHeader(channelInfo.canReusePrevHeaderTx(RtmpHeader.MessageType.USER_CONTROL_MESSAGE) ?
+        RtmpHeader.ChunkType.TYPE_2_RELATIVE_TIMESTAMP_ONLY : RtmpHeader.ChunkType.TYPE_0_FULL,
+        ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL, RtmpHeader.MessageType.USER_CONTROL_MESSAGE));
+  }
+
+  /**
+   * Convenience construtor that creates a "pong" message for the specified ping
+   */
+  public UserControl(UserControl replyToPing, ChunkStreamInfo channelInfo) {
+    this(Type.PONG_REPLY, channelInfo);
+    this.eventData = replyToPing.eventData;
+  }
+
+  public UserControl(Type type, ChunkStreamInfo channelInfo) {
+    this(channelInfo);
+    this.type = type;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public void setType(Type type) {
+    this.type = type;
+  }
+
+  /**
+   * Convenience method for getting the first event data item, as most user control
+   * message types only have one event data item anyway
+   * This is equivalent to calling <code>getEventData()[0]</code>
+   */
+  public int getFirstEventData() {
+    return eventData[0];
+  }
+
+  public int[] getEventData() {
+    return eventData;
+  }
+
+  /**
+   * Used to set (a single) event data for most user control message types
+   */
+  public void setEventData(int eventData) {
+    if (type == Type.SET_BUFFER_LENGTH) {
+      throw new IllegalStateException("SET_BUFFER_LENGTH requires two event data values; use setEventData(int, int) instead");
+    }
+    this.eventData = new int[]{eventData};
+  }
+
+  /**
+   * Used to set event data for the SET_BUFFER_LENGTH user control message types
+   */
+  public void setEventData(int streamId, int bufferLength) {
+    if (type != Type.SET_BUFFER_LENGTH) {
+      throw new IllegalStateException("User control type " + type + " requires only one event data value; use setEventData(int) instead");
+    }
+    this.eventData = new int[]{streamId, bufferLength};
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    // Bytes 0-1: first parameter: ping type (mandatory)
+    type = Type.valueOf(Util.readUnsignedInt16(in));
+    int bytesRead = 2;
+    // Event data (1 for most types, 2 for SET_BUFFER_LENGTH)
+    if (type == Type.SET_BUFFER_LENGTH) {
+      setEventData(Util.readUnsignedInt32(in), Util.readUnsignedInt32(in));
+      bytesRead += 8;
+    } else {
+      setEventData(Util.readUnsignedInt32(in));
+      bytesRead += 4;
+    }
+    // To ensure some strange non-specified UserControl/ping message does not slip through
+    assert header.getPacketLength() == bytesRead;
+  }
+
+  @Override
+  protected void writeBody(OutputStream out) throws IOException {
+    // Write the user control message type
+    Util.writeUnsignedInt16(out, type.getIntValue());
+    // Now write the event data
+    Util.writeUnsignedInt32(out, eventData[0]);
+    if (type == Type.SET_BUFFER_LENGTH) {
+      Util.writeUnsignedInt32(out, eventData[1]);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "RTMP User Control (type: " + type + ", event data: " + eventData + ")";
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/VariableBodyRtmpPacket.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/VariableBodyRtmpPacket.java
@@ -1,0 +1,78 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfBoolean;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfData;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfDecoder;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfNull;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfNumber;
+import com.google.android.exoplayer2.upstream.rtmp.amf.AmfString;
+
+/**
+ * RTMP packet with a "variable" body structure (i.e. the structure of the
+ * body depends on some other state/parameter in the packet.
+ * <p>
+ * Examples of this type of packet are Command and Data; this abstract class
+ * exists mostly for code re-use.
+ *
+ * @author francois
+ */
+public abstract class VariableBodyRtmpPacket extends RtmpPacket {
+
+  protected List<AmfData> data;
+
+  public VariableBodyRtmpPacket(RtmpHeader header) {
+    super(header);
+  }
+
+  public List<AmfData> getData() {
+    return data;
+  }
+
+  public void addData(String string) {
+    addData(new AmfString(string));
+  }
+
+  public void addData(double number) {
+    addData(new AmfNumber(number));
+  }
+
+  public void addData(boolean bool) {
+    addData(new AmfBoolean(bool));
+  }
+
+  public void addData(AmfData dataItem) {
+    if (data == null) {
+      this.data = new ArrayList<AmfData>();
+    }
+    if (dataItem == null) {
+      dataItem = new AmfNull();
+    }
+    this.data.add(dataItem);
+  }
+
+  protected void readVariableData(final InputStream in, int bytesAlreadyRead) throws IOException {
+    // ...now read in arguments (if any)
+    do {
+      AmfData dataItem = AmfDecoder.readFrom(in);
+      addData(dataItem);
+      bytesAlreadyRead += dataItem.getSize();
+    } while (bytesAlreadyRead < header.getPacketLength());
+  }
+
+  protected void writeVariableData(final OutputStream out) throws IOException {
+    if (data != null) {
+      for (AmfData dataItem : data) {
+        dataItem.writeTo(out);
+      }
+    } else {
+      // Write a null
+      AmfNull.writeNullTo(out);
+    }
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Video.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/Video.java
@@ -1,0 +1,24 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * Video data packet
+ *
+ * @author francois
+ */
+public class Video extends ContentData {
+
+  public Video(RtmpHeader header) {
+    super(header);
+  }
+
+  public Video() {
+    super(new RtmpHeader(RtmpHeader.ChunkType.TYPE_0_FULL, ChunkStreamInfo.RTMP_CID_VIDEO, RtmpHeader.MessageType.VIDEO));
+  }
+
+  @Override
+  public String toString() {
+    return "RTMP Video";
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/WindowAckSize.java
+++ b/library/src/main/java/com/google/android/exoplayer2/upstream/rtmp/packets/WindowAckSize.java
@@ -1,0 +1,55 @@
+package com.google.android.exoplayer2.upstream.rtmp.packets;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.android.exoplayer2.upstream.rtmp.Util;
+import com.google.android.exoplayer2.upstream.rtmp.io.ChunkStreamInfo;
+
+/**
+ * Window Acknowledgement Size
+ * <p>
+ * Also known as ServerBW ("Server bandwidth") in some RTMP implementations.
+ *
+ * @author francois
+ */
+public class WindowAckSize extends RtmpPacket {
+
+  private int acknowledgementWindowSize;
+
+  public WindowAckSize(RtmpHeader header) {
+    super(header);
+  }
+
+  public WindowAckSize(int acknowledgementWindowSize, ChunkStreamInfo channelInfo) {
+    super(new RtmpHeader(channelInfo.canReusePrevHeaderTx(RtmpHeader.MessageType.WINDOW_ACKNOWLEDGEMENT_SIZE) ?
+        RtmpHeader.ChunkType.TYPE_2_RELATIVE_TIMESTAMP_ONLY : RtmpHeader.ChunkType.TYPE_0_FULL,
+        ChunkStreamInfo.RTMP_CID_PROTOCOL_CONTROL, RtmpHeader.MessageType.WINDOW_ACKNOWLEDGEMENT_SIZE));
+    this.acknowledgementWindowSize = acknowledgementWindowSize;
+  }
+
+
+  public int getAcknowledgementWindowSize() {
+    return acknowledgementWindowSize;
+  }
+
+  public void setAcknowledgementWindowSize(int acknowledgementWindowSize) {
+    this.acknowledgementWindowSize = acknowledgementWindowSize;
+  }
+
+  @Override
+  public void readBody(InputStream in) throws IOException {
+    acknowledgementWindowSize = Util.readUnsignedInt32(in);
+  }
+
+  @Override
+  protected void writeBody(OutputStream out) throws IOException {
+    Util.writeUnsignedInt32(out, acknowledgementWindowSize);
+  }
+
+  @Override
+  public String toString() {
+    return "RTMP Window Acknowledgment Size";
+  }
+}

--- a/library/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -818,6 +818,8 @@ public final class Util {
     } else if (fileName.endsWith(".ism") || fileName.endsWith(".isml")
         || fileName.endsWith(".ism/manifest") || fileName.endsWith(".isml/manifest")) {
       return C.TYPE_SS;
+    } else if (fileName.startsWith("rtmp")) {
+      return C.TYPE_RTMP;
     } else {
       return C.TYPE_OTHER;
     }


### PR DESCRIPTION
I have implemented RTMP in pure Java for ExoPlayer with the HKS-TV RTMP live stream link added into `media.exolist.json` as a demo for watching.

The commits include:

- RTMP implementation modified from [SimpleRTMP](https://github.com/faucamp/SimpleRtmp).
  - Amf0 data format;
  - RTMP packet header format;
  - RTMP chunk stream format;
  - RTMP packet decoder;
  - RTMP connection and session.
- RTMP data source porting which is consistent with other upstream protocol such as HTTP.
- FLV stream extractor adaptation for RTMP to parse FLV stream within RTMP packets.
- RTMP uri parser.

My PR works well under HKS-TV RTMP live stream link.