### PR TITLE
Fix OMX crash for Odroid Android builds . Ignore buffer release error

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -879,8 +879,15 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
           return false;
         }
       } else {
-        outputIndex = codec.dequeueOutputBuffer(outputBufferInfo,
-            getDequeueOutputBufferTimeoutUs());
+          try{
+            outputIndex = codec.dequeueOutputBuffer(outputBufferInfo,
+              getDequeueOutputBufferTimeoutUs());
+          }catch (Exception e) {
+              //e.printStackTrace();
+              releaseCodec();
+              // Release the codec, as it's in an error state.
+              return false;
+            }
       }
       if (outputIndex >= 0) {
         // We've dequeued a buffer.

--- a/library/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -502,7 +502,12 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
   private void renderOutputBuffer(MediaCodec codec, int bufferIndex) {
     maybeNotifyVideoSizeChanged();
     TraceUtil.beginSection("releaseOutputBuffer");
-    codec.releaseOutputBuffer(bufferIndex, true);
+    try {
+      codec.releaseOutputBuffer(bufferIndex, true);
+    } catch (Exception e) {
+      // ignore release error
+      e.printStackTrace();
+    }
     TraceUtil.endSection();
     decoderCounters.renderedOutputBufferCount++;
     consecutiveDroppedFrameCount = 0;


### PR DESCRIPTION
Exynos OMX decoder for ODROID XU4 returns errors on buffer release when HLS bitrate switch happens.
This will release codec instance and continue without error