### PR TITLE
Disables codecIsAdaptive for Odroid-XU4

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -1171,14 +1171,14 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         && "OMX.MTK.AUDIO.DECODER.MP3".equals(name);
   }
   /**
-   * Returns whether the decoder is known to be non adaptive.
+   * Returns whether the decoder is known to be non Adaptive.
    * <p>
    * If false is returned then we explicitly override codecIsAdaptive,
    * setting it to false.
    *
    * @param name The decoder name.
    * @param format The input format.
-   * @return True if the device is known  to be non adaptiv .
+   * @return False if the device is known  to be non adaptive .
    */
   private static boolean codecSupportsAdaptive(String name, Format format) {
     return !(

--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -337,7 +337,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     }
 
     String codecName = decoderInfo.name;
-    codecIsAdaptive = decoderInfo.adaptive && codecSupportsAdaptive(codecName, format);
+    codecIsAdaptive = decoderInfo.adaptive && (codecNeedsDisableAdaptationWorkaround(codecName)==false);
     codecNeedsDiscardToSpsWorkaround = codecNeedsDiscardToSpsWorkaround(codecName, format);
     codecNeedsFlushWorkaround = codecNeedsFlushWorkaround(codecName);
     codecNeedsAdaptationWorkaround = codecNeedsAdaptationWorkaround(codecName);
@@ -1171,18 +1171,16 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
         && "OMX.MTK.AUDIO.DECODER.MP3".equals(name);
   }
   /**
-   * Returns whether the decoder is known to be non Adaptive.
+   * Returns whether the decoder is needs Apaptive workaround disabled
    * <p>
    * If false is returned then we explicitly override codecIsAdaptive,
    * setting it to false.
    *
-   * @param name The decoder name.
-   * @param format The input format.
-   * @return False if the device is known  to be non adaptive .
+   * @return TRUE if the device needs Adaptive workaround disabled
    */
-  private static boolean codecSupportsAdaptive(String name, Format format) {
-    return !(
-        (Util.SDK_INT == 19 && Util.MODEL.equals("ODROID-XU3")
+  private static boolean codecNeedsDisableAdaptationWorkaround(String name) {
+    return (
+        (Util.SDK_INT <= 19 && Util.MODEL.equals("ODROID-XU3")
         && ("OMX.Exynos.AVC.Decoder".equals(name) || "OMX.Exynos.AVC.Decoder.secure".equals(name))));
   }
 }

--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -1173,7 +1173,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   /**
    * Returns whether the decoder is needs Apaptive workaround disabled
    * <p>
-   * If false is returned then we explicitly override codecIsAdaptive,
+   * If TRUE is returned then we explicitly override codecIsAdaptive,
    * setting it to false.
    * @param name The decoder name.
    * @return TRUE if the device needs Adaptive workaround disabled

--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -337,7 +337,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     }
 
     String codecName = decoderInfo.name;
-    codecIsAdaptive = decoderInfo.adaptive;
+    codecIsAdaptive = decoderInfo.adaptive && codecSupportsAdaptive(codecName, format);
     codecNeedsDiscardToSpsWorkaround = codecNeedsDiscardToSpsWorkaround(codecName, format);
     codecNeedsFlushWorkaround = codecNeedsFlushWorkaround(codecName);
     codecNeedsAdaptationWorkaround = codecNeedsAdaptationWorkaround(codecName);
@@ -1170,5 +1170,19 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     return Util.SDK_INT <= 18 && format.channelCount == 1
         && "OMX.MTK.AUDIO.DECODER.MP3".equals(name);
   }
-
+  /**
+   * Returns whether the decoder is known to be non adaptive.
+   * <p>
+   * If false is returned then we explicitly override codecIsAdaptive,
+   * setting it to false.
+   *
+   * @param name The decoder name.
+   * @param format The input format.
+   * @return True if the device is known  to be non adaptiv .
+   */
+  private static boolean codecSupportsAdaptive(String name, Format format) {
+    return !(
+        (Util.SDK_INT == 19 && Util.MODEL.equals("ODROID-XU3")
+        && ("OMX.Exynos.AVC.Decoder".equals(name) || "OMX.Exynos.AVC.Decoder.secure".equals(name))));
+  }
 }

--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -1175,7 +1175,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    * <p>
    * If false is returned then we explicitly override codecIsAdaptive,
    * setting it to false.
-   *
+   * @param name The decoder name.
    * @return TRUE if the device needs Adaptive workaround disabled
    */
   private static boolean codecNeedsDisableAdaptationWorkaround(String name) {


### PR DESCRIPTION
Disables codecIsAdaptive for Odroid-XU3/4.

Crash log on bitrate change in HLS is attached.
[ordoid-xu4-crash.zip](https://github.com/google/ExoPlayer/files/872251/ordoid-xu4-crash.zip)
