### PR TITLE
Fixes OOM that can occur from improperly formatted flv data

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/flv/FlvExtractor.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/flv/FlvExtractor.java
@@ -110,6 +110,7 @@ public final class FlvExtractor implements Extractor, SeekMap {
     input.peekFully(scratch.data, 0, 4);
     scratch.setPosition(0);
     int dataOffset = scratch.readInt();
+    if (dataOffset > 9) dataOffset = 9;
 
     input.resetPeekPosition();
     input.advancePeekPosition(dataOffset);


### PR DESCRIPTION
This prevents an OOM error that can occur. We have seen situations where dataOffset isn't stopped at 9. The offset should be 9 according to flv specifications. This can cause the offset to grow too large and cause OOM errors. My co-worker @rkrishnan2012 can clarify the issue further.