### PR TITLE
Allow out of tree builds.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ allprojects {
         releaseVersion = 'r2.3.1'
         releaseWebsite = 'https://github.com/google/ExoPlayer'
     }
+    if (it.hasProperty('externalBuildDir')) {
+        if (!new File(externalBuildDir).isAbsolute())
+            externalBuildDir = new File(rootDir, externalBuildDir)
+        buildDir = "${externalBuildDir}/${project.name}"
+    }
 }
 
 def getBintrayRepo() {


### PR DESCRIPTION
Before modularisation of the code, it was possible to do an out of tree build
giving an -PbuildDir=someDir argument to gradle. With the modularisation, it's
broken as using -PbuildDir=someDir will force the same directory for each
sub-projects, which breaks the gradle build system.

This commit adds a new externalBuildDir project property to allow out of tree
builds again. When set, it updates the buildDir property for each project to
point to ${externalBuildDir}/${project.name}. That way, the build artefacts are
written in the out of tree directory in a project specific folder.

To do an out of tree build, use

    gradle -PexternalBuildDir=someDir ...

It supports absolute and relative path. Relative path are interpreted against
the ExoPlayer root directory.

The patch has been tested with absolute and relative path. 

The call to hasProperty needs to explicit the "it" message receiver due to gradle issue 1826.