### PR TITLE
It’s possible that url has query parameters after .m3u8, for example …

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -837,6 +837,10 @@ public final class Util {
   @C.ContentType
   public static int inferContentType(String fileName) {
     fileName = fileName.toLowerCase();
+    int q = fileName.lastIndexOf("?");
+    if (q > -1) {
+       fileName = fileName.substring(0, q);
+    }
     if (fileName.endsWith(".mpd")) {
       return C.TYPE_DASH;
     } else if (fileName.endsWith(".m3u8")) {


### PR DESCRIPTION
…Wowza HLS DVR urls end with .m3u8?DVR.

This fix will strip any query parameters before trying to guess the content type.