### PR TITLE
Include Pixel Aspect Ratio in DebugTextViewHelper

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/DebugTextViewHelper.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/DebugTextViewHelper.java
@@ -163,9 +163,15 @@ public final class DebugTextViewHelper implements Runnable, ExoPlayer.EventListe
     if (format == null) {
       return "";
     }
+    float par = format.pixelWidthHeightRatio;
+    String parInfo = "";
+    if (par != Format.NO_VALUE && (int) par != 1) {
+      // Add pixel aspect ratio only when it's useful
+      parInfo = " par:" + format.pixelWidthHeightRatio;
+    }
     return "\n" + format.sampleMimeType + "(id:" + format.id + " r:" + format.width + "x"
-        + format.height + getDecoderCountersBufferCountString(player.getVideoDecoderCounters())
-        + ")";
+        + format.height + parInfo
+        + getDecoderCountersBufferCountString(player.getVideoDecoderCounters()) + ")";
   }
 
   private String getAudioString() {


### PR DESCRIPTION
Add the video Pixel Aspect Ratio to the DebugTextViewHelper in order to help debug issues related to PAR changes mid-stream.

This info is useful to know and have available, so that my apps users (when they have debugging enabled) can see both the resolution and stretch applied.