### PR TITLE
Add support for AVC Level 5.2

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecUtil.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecUtil.java
@@ -429,6 +429,7 @@ public final class MediaCodecUtil {
       case CodecProfileLevel.AVCLevel42: return 8704 * 16 * 16;
       case CodecProfileLevel.AVCLevel5: return 22080 * 16 * 16;
       case CodecProfileLevel.AVCLevel51: return 36864 * 16 * 16;
+      case CodecProfileLevel.AVCLevel52: return 36864 * 16 * 16;
       default: return -1;
     }
   }


### PR DESCRIPTION
Samsung S7 and Sony XZs with 7.1.1 updates are advertising the capability to support AVC Level 5.2 frame sizes. Without this proposed update these devices' videos will play at only 480p. 
See https://github.com/google/ExoPlayer/commit/83b43a6fe620f9ce74066f6b06c35e134b07d094

Level 5.1 and 5.2 support same frame size according to https://en.wikipedia.org/wiki/H.264/MPEG-4_AVC.

The constant was set in _MediaCodecInfo.java_
```        public static final int AVCLevel52      = 0x10000;```

but never checks against:
```     
...
      case CodecProfileLevel.AVCLevel5: return 22080 * 16 * 16;
      case CodecProfileLevel.AVCLevel51: return 36864 * 16 * 16;  <-- only 5.1
      default: return -1;
    }
  }
```
