### PR TITLE
H264 sei msg recovery point flow

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/ts/H264Reader.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/ts/H264Reader.java
@@ -227,7 +227,8 @@ public final class H264Reader implements ElementaryStreamReader {
       ffByte = bitArray.readBits(8);
       type += ffByte;
     } while (ffByte == 255 /* equal to 0xFF */);
-	if (type != SEI_TYPE_RECOVERY_POINT)
+
+    if (type != SEI_TYPE_RECOVERY_POINT)
       return;
 
     do {


### PR DESCRIPTION
It proposes a possible solution to #2841;

By identifying key frame according to H264 SEI message recovery point, it succeeds finding key frame & could playback the issued files.  