### PR TITLE
Add label attribute support for DASH audio/text

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer2/demo/DemoUtil.java
+++ b/demo/src/main/java/com/google/android/exoplayer2/demo/DemoUtil.java
@@ -38,14 +38,14 @@ import java.util.Locale;
           buildResolutionString(format), buildBitrateString(format)), buildTrackIdString(format)),
           buildSampleMimeTypeString(format));
     } else if (MimeTypes.isAudio(format.sampleMimeType)) {
-      trackName = joinWithSeparator(joinWithSeparator(joinWithSeparator(joinWithSeparator(
+      trackName = joinWithSeparator(joinWithSeparator(joinWithSeparator(joinWithSeparator(joinWithSeparator(
           buildLanguageString(format), buildAudioPropertyString(format)),
           buildBitrateString(format)), buildTrackIdString(format)),
-          buildSampleMimeTypeString(format));
+          buildSampleMimeTypeString(format)), buildLabelString(format));
     } else {
-      trackName = joinWithSeparator(joinWithSeparator(joinWithSeparator(buildLanguageString(format),
+      trackName = joinWithSeparator(joinWithSeparator(joinWithSeparator(joinWithSeparator(buildLanguageString(format),
           buildBitrateString(format)), buildTrackIdString(format)),
-          buildSampleMimeTypeString(format));
+          buildSampleMimeTypeString(format)), buildLabelString(format));
     }
     return trackName.length() == 0 ? "unknown" : trackName;
   }
@@ -63,6 +63,11 @@ import java.util.Locale;
   private static String buildLanguageString(Format format) {
     return TextUtils.isEmpty(format.language) || "und".equals(format.language) ? ""
         : format.language;
+  }
+
+  private static String buildLabelString(Format format) {
+    return TextUtils.isEmpty(format.label) || "und".equals(format.label) ? ""
+        : format.label;
   }
 
   private static String buildBitrateString(Format format) {

--- a/library/core/src/main/java/com/google/android/exoplayer2/Format.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/Format.java
@@ -184,6 +184,11 @@ public final class Format implements Parcelable {
   public final String language;
 
   /**
+   * The label, or null if unknown or not applicable.
+   */
+  public final String label;
+
+  /**
    * The Accessibility channel, or {@link #NO_VALUE} if not known or applicable.
    */
   public final int accessibilityChannel;
@@ -199,7 +204,7 @@ public final class Format implements Parcelable {
     return new Format(id, containerMimeType, sampleMimeType, codecs, bitrate, NO_VALUE, width,
         height, frameRate, NO_VALUE, NO_VALUE, null, NO_VALUE, null, NO_VALUE, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, selectionFlags, null, NO_VALUE, OFFSET_SAMPLE_RELATIVE,
-        initializationData, null, null);
+        initializationData, null, null, null);
   }
 
   public static Format createVideoSampleFormat(String id, String sampleMimeType, String codecs,
@@ -226,18 +231,18 @@ public final class Format implements Parcelable {
     return new Format(id, null, sampleMimeType, codecs, bitrate, maxInputSize, width, height,
         frameRate, rotationDegrees, pixelWidthHeightRatio, projectionData, stereoMode,
         colorInfo, NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE, 0, null, NO_VALUE,
-        OFFSET_SAMPLE_RELATIVE, initializationData, drmInitData, null);
+        OFFSET_SAMPLE_RELATIVE, initializationData, drmInitData, null, null);
   }
 
   // Audio.
 
   public static Format createAudioContainerFormat(String id, String containerMimeType,
       String sampleMimeType, String codecs, int bitrate, int channelCount, int sampleRate,
-      List<byte[]> initializationData, @C.SelectionFlags int selectionFlags, String language) {
+      List<byte[]> initializationData, @C.SelectionFlags int selectionFlags, String language, String label) {
     return new Format(id, containerMimeType, sampleMimeType, codecs, bitrate, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE, null, NO_VALUE, null, channelCount, sampleRate,
         NO_VALUE, NO_VALUE, NO_VALUE, selectionFlags, language, NO_VALUE, OFFSET_SAMPLE_RELATIVE,
-        initializationData, null, null);
+        initializationData, null, null, label);
   }
 
   public static Format createAudioSampleFormat(String id, String sampleMimeType, String codecs,
@@ -265,25 +270,25 @@ public final class Format implements Parcelable {
     return new Format(id, null, sampleMimeType, codecs, bitrate, maxInputSize, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, null, NO_VALUE, null, channelCount, sampleRate, pcmEncoding,
         encoderDelay, encoderPadding, selectionFlags, language, NO_VALUE, OFFSET_SAMPLE_RELATIVE,
-        initializationData, drmInitData, metadata);
+        initializationData, drmInitData, metadata, null);
   }
 
   // Text.
 
   public static Format createTextContainerFormat(String id, String containerMimeType,
       String sampleMimeType, String codecs, int bitrate, @C.SelectionFlags int selectionFlags,
-      String language) {
+      String language, String label) {
     return createTextContainerFormat(id, containerMimeType, sampleMimeType, codecs, bitrate,
-        selectionFlags, language, NO_VALUE);
+        selectionFlags, language, NO_VALUE, label);
   }
 
   public static Format createTextContainerFormat(String id, String containerMimeType,
       String sampleMimeType, String codecs, int bitrate, @C.SelectionFlags int selectionFlags,
-      String language, int accessibilityChannel) {
+      String language, int accessibilityChannel, String label) {
     return new Format(id, containerMimeType, sampleMimeType, codecs, bitrate, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE, null, NO_VALUE, null, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, selectionFlags, language, accessibilityChannel,
-        OFFSET_SAMPLE_RELATIVE, null, null, null);
+        OFFSET_SAMPLE_RELATIVE, null, null, null, label);
   }
 
   public static Format createTextSampleFormat(String id, String sampleMimeType, String codecs,
@@ -313,7 +318,7 @@ public final class Format implements Parcelable {
     return new Format(id, null, sampleMimeType, codecs, bitrate, NO_VALUE, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, null, NO_VALUE, null, NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE,
         NO_VALUE, selectionFlags, language, accessibilityChannel, subsampleOffsetUs,
-        initializationData, drmInitData, null);
+        initializationData, drmInitData, null, null);
   }
 
   // Image.
@@ -323,7 +328,7 @@ public final class Format implements Parcelable {
     return new Format(id, null, sampleMimeType, codecs, bitrate, NO_VALUE, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, null, NO_VALUE, null, NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE,
         NO_VALUE, 0, language, NO_VALUE, OFFSET_SAMPLE_RELATIVE, initializationData, drmInitData,
-        null);
+        null, null);
   }
 
   // Generic.
@@ -334,21 +339,21 @@ public final class Format implements Parcelable {
     return new Format(id, containerMimeType, sampleMimeType, codecs, bitrate, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE, null, NO_VALUE, null, NO_VALUE, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, selectionFlags, language, NO_VALUE, OFFSET_SAMPLE_RELATIVE, null, null,
-        null);
+        null, null);
   }
 
   public static Format createSampleFormat(String id, String sampleMimeType,
       long subsampleOffsetUs) {
     return new Format(id, null, sampleMimeType, null, NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, null, NO_VALUE, null, NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE,
-        NO_VALUE, 0, null, NO_VALUE, subsampleOffsetUs, null, null, null);
+        NO_VALUE, 0, null, NO_VALUE, subsampleOffsetUs, null, null, null, null);
   }
 
   public static Format createSampleFormat(String id, String sampleMimeType, String codecs,
       int bitrate, DrmInitData drmInitData) {
     return new Format(id, null, sampleMimeType, codecs, bitrate, NO_VALUE, NO_VALUE, NO_VALUE,
         NO_VALUE, NO_VALUE, NO_VALUE, null, NO_VALUE, null, NO_VALUE, NO_VALUE, NO_VALUE, NO_VALUE,
-        NO_VALUE, 0, null, NO_VALUE, OFFSET_SAMPLE_RELATIVE, null, drmInitData, null);
+        NO_VALUE, 0, null, NO_VALUE, OFFSET_SAMPLE_RELATIVE, null, drmInitData, null, null);
   }
 
   /* package */ Format(String id, String containerMimeType, String sampleMimeType, String codecs,
@@ -357,7 +362,7 @@ public final class Format implements Parcelable {
       ColorInfo colorInfo, int channelCount, int sampleRate, @C.PcmEncoding int pcmEncoding,
       int encoderDelay, int encoderPadding, @C.SelectionFlags int selectionFlags, String language,
       int accessibilityChannel, long subsampleOffsetUs, List<byte[]> initializationData,
-      DrmInitData drmInitData, Metadata metadata) {
+      DrmInitData drmInitData, Metadata metadata, String label) {
     this.id = id;
     this.containerMimeType = containerMimeType;
     this.sampleMimeType = sampleMimeType;
@@ -379,6 +384,7 @@ public final class Format implements Parcelable {
     this.encoderPadding = encoderPadding;
     this.selectionFlags = selectionFlags;
     this.language = language;
+    this.label = label;
     this.accessibilityChannel = accessibilityChannel;
     this.subsampleOffsetUs = subsampleOffsetUs;
     this.initializationData = initializationData == null ? Collections.<byte[]>emptyList()
@@ -411,6 +417,7 @@ public final class Format implements Parcelable {
     encoderPadding = in.readInt();
     selectionFlags = in.readInt();
     language = in.readString();
+    label = in.readString();
     accessibilityChannel = in.readInt();
     subsampleOffsetUs = in.readLong();
     int initializationDataSize = in.readInt();
@@ -427,7 +434,7 @@ public final class Format implements Parcelable {
         width, height, frameRate, rotationDegrees, pixelWidthHeightRatio, projectionData,
         stereoMode, colorInfo, channelCount, sampleRate, pcmEncoding, encoderDelay,
         encoderPadding, selectionFlags, language, accessibilityChannel, subsampleOffsetUs,
-        initializationData, drmInitData, metadata);
+        initializationData, drmInitData, metadata, label);
   }
 
   public Format copyWithSubsampleOffsetUs(long subsampleOffsetUs) {
@@ -435,7 +442,7 @@ public final class Format implements Parcelable {
         width, height, frameRate, rotationDegrees, pixelWidthHeightRatio, projectionData,
         stereoMode, colorInfo, channelCount, sampleRate, pcmEncoding, encoderDelay,
         encoderPadding, selectionFlags, language, accessibilityChannel, subsampleOffsetUs,
-        initializationData, drmInitData, metadata);
+        initializationData, drmInitData, metadata, label);
   }
 
   public Format copyWithContainerInfo(String id, String codecs, int bitrate, int width, int height,
@@ -444,7 +451,7 @@ public final class Format implements Parcelable {
         width, height, frameRate, rotationDegrees, pixelWidthHeightRatio, projectionData,
         stereoMode, colorInfo, channelCount, sampleRate, pcmEncoding, encoderDelay,
         encoderPadding, selectionFlags, language, accessibilityChannel, subsampleOffsetUs,
-        initializationData, drmInitData, metadata);
+        initializationData, drmInitData, metadata, label);
   }
 
   @SuppressWarnings("ReferenceEquality")
@@ -459,13 +466,14 @@ public final class Format implements Parcelable {
     float frameRate = this.frameRate == NO_VALUE ? manifestFormat.frameRate : this.frameRate;
     @C.SelectionFlags int selectionFlags = this.selectionFlags |  manifestFormat.selectionFlags;
     String language = this.language == null ? manifestFormat.language : this.language;
+    String label = this.label == null ? manifestFormat.label : this.label;
     DrmInitData drmInitData = manifestFormat.drmInitData != null ? manifestFormat.drmInitData
         : this.drmInitData;
     return new Format(id, containerMimeType, sampleMimeType, codecs, bitrate, maxInputSize, width,
         height, frameRate, rotationDegrees, pixelWidthHeightRatio, projectionData, stereoMode,
         colorInfo, channelCount, sampleRate, pcmEncoding, encoderDelay, encoderPadding,
         selectionFlags, language, accessibilityChannel, subsampleOffsetUs, initializationData,
-        drmInitData, metadata);
+        drmInitData, metadata, label);
   }
 
   public Format copyWithGaplessInfo(int encoderDelay, int encoderPadding) {
@@ -473,7 +481,7 @@ public final class Format implements Parcelable {
         width, height, frameRate, rotationDegrees, pixelWidthHeightRatio, projectionData,
         stereoMode, colorInfo, channelCount, sampleRate, pcmEncoding, encoderDelay,
         encoderPadding, selectionFlags, language, accessibilityChannel, subsampleOffsetUs,
-        initializationData, drmInitData, metadata);
+        initializationData, drmInitData, metadata, label);
   }
 
   public Format copyWithDrmInitData(DrmInitData drmInitData) {
@@ -481,7 +489,7 @@ public final class Format implements Parcelable {
         width, height, frameRate, rotationDegrees, pixelWidthHeightRatio, projectionData,
         stereoMode, colorInfo, channelCount, sampleRate, pcmEncoding, encoderDelay,
         encoderPadding, selectionFlags, language, accessibilityChannel, subsampleOffsetUs,
-        initializationData, drmInitData, metadata);
+        initializationData, drmInitData, metadata, label);
   }
 
   public Format copyWithMetadata(Metadata metadata) {
@@ -489,7 +497,7 @@ public final class Format implements Parcelable {
         width, height, frameRate, rotationDegrees, pixelWidthHeightRatio, projectionData,
         stereoMode, colorInfo, channelCount, sampleRate, pcmEncoding, encoderDelay,
         encoderPadding, selectionFlags, language, accessibilityChannel, subsampleOffsetUs,
-        initializationData, drmInitData, metadata);
+        initializationData, drmInitData, metadata, label);
   }
 
   /**
@@ -658,6 +666,9 @@ public final class Format implements Parcelable {
     }
     if (format.language != null) {
       builder.append(", language=").append(format.language);
+    }
+    if (format.label != null) {
+      builder.append(", label=").append(format.label);
     }
     return builder.toString();
   }

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestParser.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestParser.java
@@ -238,6 +238,7 @@ public class DashManifestParser extends DefaultHandler
     int audioChannels = Format.NO_VALUE;
     int audioSamplingRate = parseInt(xpp, "audioSamplingRate", Format.NO_VALUE);
     String language = xpp.getAttributeValue(null, "lang");
+    String label = xpp.getAttributeValue(null, "label");
     ArrayList<SchemeData> drmSchemeDatas = new ArrayList<>();
     ArrayList<SchemeValuePair> inbandEventStreams = new ArrayList<>();
     ArrayList<SchemeValuePair> accessibilityDescriptors = new ArrayList<>();
@@ -269,7 +270,7 @@ public class DashManifestParser extends DefaultHandler
       } else if (XmlPullParserUtil.isStartTag(xpp, "Representation")) {
         RepresentationInfo representationInfo = parseRepresentation(xpp, baseUrl, mimeType, codecs,
             width, height, frameRate, audioChannels, audioSamplingRate, language,
-            selectionFlags, accessibilityDescriptors, segmentBase);
+            selectionFlags, accessibilityDescriptors, segmentBase, label);
         contentType = checkContentTypeConsistency(contentType,
             getContentType(representationInfo.format));
         representationInfos.add(representationInfo);
@@ -429,7 +430,7 @@ public class DashManifestParser extends DefaultHandler
       int adaptationSetHeight, float adaptationSetFrameRate, int adaptationSetAudioChannels,
       int adaptationSetAudioSamplingRate, String adaptationSetLanguage,
       @C.SelectionFlags int adaptationSetSelectionFlags,
-      List<SchemeValuePair> adaptationSetAccessibilityDescriptors, SegmentBase segmentBase)
+      List<SchemeValuePair> adaptationSetAccessibilityDescriptors, SegmentBase segmentBase, String label)
       throws XmlPullParserException, IOException {
     String id = xpp.getAttributeValue(null, "id");
     int bandwidth = parseInt(xpp, "bandwidth", Format.NO_VALUE);
@@ -472,7 +473,7 @@ public class DashManifestParser extends DefaultHandler
 
     Format format = buildFormat(id, mimeType, width, height, frameRate, audioChannels,
         audioSamplingRate, bandwidth, adaptationSetLanguage, adaptationSetSelectionFlags,
-        adaptationSetAccessibilityDescriptors, codecs);
+        adaptationSetAccessibilityDescriptors, codecs, label);
     segmentBase = segmentBase != null ? segmentBase : new SingleSegmentBase();
 
     return new RepresentationInfo(format, baseUrl, segmentBase, drmSchemeDatas, inbandEventStreams);
@@ -481,7 +482,7 @@ public class DashManifestParser extends DefaultHandler
   protected Format buildFormat(String id, String containerMimeType, int width, int height,
       float frameRate, int audioChannels, int audioSamplingRate, int bitrate, String language,
       @C.SelectionFlags int selectionFlags, List<SchemeValuePair> accessibilityDescriptors,
-      String codecs) {
+      String codecs, String label) {
     String sampleMimeType = getSampleMimeType(containerMimeType, codecs);
     if (sampleMimeType != null) {
       if (MimeTypes.isVideo(sampleMimeType)) {
@@ -489,7 +490,7 @@ public class DashManifestParser extends DefaultHandler
             bitrate, width, height, frameRate, null, selectionFlags);
       } else if (MimeTypes.isAudio(sampleMimeType)) {
         return Format.createAudioContainerFormat(id, containerMimeType, sampleMimeType, codecs,
-            bitrate, audioChannels, audioSamplingRate, null, selectionFlags, language);
+            bitrate, audioChannels, audioSamplingRate, null, selectionFlags, language, label);
       } else if (mimeTypeIsRawText(sampleMimeType)) {
         int accessibilityChannel;
         if (MimeTypes.APPLICATION_CEA608.equals(sampleMimeType)) {
@@ -500,7 +501,7 @@ public class DashManifestParser extends DefaultHandler
           accessibilityChannel = Format.NO_VALUE;
         }
         return Format.createTextContainerFormat(id, containerMimeType, sampleMimeType, codecs,
-            bitrate, selectionFlags, language, accessibilityChannel);
+            bitrate, selectionFlags, language, accessibilityChannel, label);
       }
     }
     return Format.createContainerFormat(id, containerMimeType, sampleMimeType, codecs, bitrate,

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -191,7 +191,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
         switch (parseStringAttr(line, REGEX_TYPE)) {
           case TYPE_AUDIO:
             format = Format.createAudioContainerFormat(id, MimeTypes.APPLICATION_M3U8, null, null,
-                Format.NO_VALUE, Format.NO_VALUE, Format.NO_VALUE, null, selectionFlags, language);
+                Format.NO_VALUE, Format.NO_VALUE, Format.NO_VALUE, null, selectionFlags, language, id);
             if (uri == null) {
               muxedAudioFormat = format;
             } else {
@@ -200,7 +200,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
             break;
           case TYPE_SUBTITLES:
             format = Format.createTextContainerFormat(id, MimeTypes.APPLICATION_M3U8,
-                MimeTypes.TEXT_VTT, null, Format.NO_VALUE, selectionFlags, language);
+                MimeTypes.TEXT_VTT, null, Format.NO_VALUE, selectionFlags, language, id);
             subtitles.add(new HlsMasterPlaylist.HlsUrl(uri, format));
             break;
           case TYPE_CLOSED_CAPTIONS:
@@ -218,7 +218,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
               muxedCaptionFormats = new ArrayList<>();
             }
             muxedCaptionFormats.add(Format.createTextContainerFormat(id, null, mimeType, null,
-                Format.NO_VALUE, selectionFlags, language, accessibilityChannel));
+                Format.NO_VALUE, selectionFlags, language, accessibilityChannel,id));
             break;
           default:
             // Do nothing.

--- a/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/manifest/SsManifestParser.java
+++ b/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/manifest/SsManifestParser.java
@@ -603,6 +603,7 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
     private static final String KEY_FOUR_CC = "FourCC";
     private static final String KEY_TYPE = "Type";
     private static final String KEY_LANGUAGE = "Language";
+    private static final String KEY_NAME = "Name";
     private static final String KEY_MAX_WIDTH = "MaxWidth";
     private static final String KEY_MAX_HEIGHT = "MaxHeight";
 
@@ -637,12 +638,14 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
               CodecSpecificDataUtil.buildAacLcAudioSpecificConfig(samplingRate, channels));
         }
         String language = (String) getNormalizedAttribute(KEY_LANGUAGE);
+        String label = (String) getNormalizedAttribute(KEY_NAME);
         format = Format.createAudioContainerFormat(id, MimeTypes.AUDIO_MP4, sampleMimeType, null,
-            bitrate, channels, samplingRate, codecSpecificData, 0, language);
+            bitrate, channels, samplingRate, codecSpecificData, 0, language, label);
       } else if (type == C.TRACK_TYPE_TEXT) {
         String language = (String) getNormalizedAttribute(KEY_LANGUAGE);
+        String label = (String) getNormalizedAttribute(KEY_NAME);
         format = Format.createTextContainerFormat(id, MimeTypes.APPLICATION_MP4, sampleMimeType,
-            null, bitrate, 0, language);
+            null, bitrate, 0, language, label);
       } else {
         format = Format.createContainerFormat(id, MimeTypes.APPLICATION_MP4, sampleMimeType, null,
             bitrate, 0, null);


### PR DESCRIPTION
When playing a stream with multiple audio tracks, currently the only way to identify the different tracks is using the lang attribute of AdaptationSet. We have customers who would like to customize the label that is displayed to the end user for selecting the audio track. Also, multiple audio tracks are sometimes used for uses cases which are not multiple languages, for example - one audio track with background music and one without it.
While it is possible to pass this info out-of-band, we feel it makes most sense to pass it in-band in the MPD. Other protocols have support for this - in HLS you can set the NAME attribute of EXT-X-MEDIA, and in MSS there's a Name attribute on StreamIndex