### PR TITLE
Add onPreAacquireSession event.

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer2/demo/EventLogger.java
+++ b/demo/src/main/java/com/google/android/exoplayer2/demo/EventLogger.java
@@ -28,6 +28,7 @@ import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.audio.AudioRendererEventListener;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.metadata.MetadataRenderer;
 import com.google.android.exoplayer2.metadata.emsg.EventMessage;
@@ -203,6 +204,11 @@ import java.util.Locale;
       Log.d(TAG, "  ]");
     }
     Log.d(TAG, "]");
+  }
+
+  @Override
+  public void onPreAcquireSession(DrmInitData drmInitData) {
+    Log.d(TAG, "preAcquireSession [" + getSessionTimeString() + "]");
   }
 
   // MetadataRenderer.Output

--- a/demo/src/main/java/com/google/android/exoplayer2/demo/PlayerActivity.java
+++ b/demo/src/main/java/com/google/android/exoplayer2/demo/PlayerActivity.java
@@ -42,6 +42,7 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.drm.DefaultDrmSessionManager;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.drm.FrameworkMediaDrm;
@@ -471,6 +472,11 @@ public class PlayerActivity extends Activity implements OnClickListener, ExoPlay
 
   @Override
   public void onTimelineChanged(Timeline timeline, Object manifest) {
+    // Do nothing.
+  }
+
+  @Override
+  public void onPreAcquireSession(DrmInitData drmInitData) {
     // Do nothing.
   }
 

--- a/library/core/src/androidTest/java/com/google/android/exoplayer2/ExoPlayerTest.java
+++ b/library/core/src/androidTest/java/com/google/android/exoplayer2/ExoPlayerTest.java
@@ -19,6 +19,7 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.util.Pair;
 import com.google.android.exoplayer2.decoder.DecoderInputBuffer;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.SampleStream;
@@ -418,6 +419,11 @@ public final class ExoPlayerTest extends TestCase {
     @Override
     public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
       this.trackGroups = trackGroups;
+    }
+
+    @Override
+    public void onPreAcquireSession(DrmInitData drmInitData) {
+      // Do nothing.
     }
 
     @Override

--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayer.java
@@ -19,6 +19,8 @@ import android.os.Looper;
 import android.support.annotation.IntDef;
 import android.support.annotation.Nullable;
 import com.google.android.exoplayer2.audio.MediaCodecAudioRenderer;
+import com.google.android.exoplayer2.drm.DrmInitData;
+import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.metadata.MetadataRenderer;
 import com.google.android.exoplayer2.source.ConcatenatingMediaSource;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
@@ -136,6 +138,13 @@ public interface ExoPlayer {
      *     of length {@link #getRendererCount()}, but may contain null elements.
      */
     void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections);
+
+    /**
+     * Called before acquires a {@link DrmSession}.
+     *
+     * @param drmInitData DRM initialization data.
+     */
+    void onPreAcquireSession(DrmInitData drmInitData);
 
     /**
      * Called when the player starts or stops loading the source.
@@ -305,6 +314,13 @@ public interface ExoPlayer {
    * @return One of the {@code STATE} constants defined in this interface.
    */
   int getPlaybackState();
+
+  /**
+   * Called before acquires a {@link DrmSession}.
+   *
+   * @param drmInitData DRM initialization data.
+   */
+  void preAcquireSession(DrmInitData drmInitData);
 
   /**
    * Prepares the player to play the provided {@link MediaSource}. Equivalent to

--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImpl.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImpl.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 import com.google.android.exoplayer2.ExoPlayerImplInternal.PlaybackInfo;
 import com.google.android.exoplayer2.ExoPlayerImplInternal.SourceInfo;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
@@ -119,6 +120,12 @@ import java.util.concurrent.CopyOnWriteArraySet;
   @Override
   public int getPlaybackState() {
     return playbackState;
+  }
+
+  @Override public void preAcquireSession(DrmInitData drmInitData) {
+    for (EventListener listener : listeners) {
+      listener.onPreAcquireSession(drmInitData);
+    }
   }
 
   @Override

--- a/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
@@ -29,6 +29,7 @@ import android.view.SurfaceView;
 import android.view.TextureView;
 import com.google.android.exoplayer2.audio.AudioRendererEventListener;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.metadata.MetadataRenderer;
 import com.google.android.exoplayer2.source.MediaSource;
@@ -494,6 +495,10 @@ public class SimpleExoPlayer implements ExoPlayer {
     return player.getPlaybackState();
   }
 
+  @Override public void preAcquireSession(DrmInitData drmInitData) {
+    // Do nothing.
+  }
+
   @Override
   public void prepare(MediaSource mediaSource) {
     player.prepare(mediaSource);
@@ -725,6 +730,14 @@ public class SimpleExoPlayer implements ExoPlayer {
       videoFormat = format;
       if (videoDebugListener != null) {
         videoDebugListener.onVideoInputFormatChanged(format);
+      }
+    }
+
+    @Override
+    public void onPreAcquireSession(DrmInitData drmInitData) {
+      player.preAcquireSession(drmInitData);
+      if (videoDebugListener != null) {
+        videoDebugListener.onPreAcquireSession(drmInitData);
       }
     }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -31,6 +31,7 @@ import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.FormatHolder;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
 import com.google.android.exoplayer2.decoder.DecoderInputBuffer;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
@@ -771,6 +772,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
           throw ExoPlaybackException.createForRenderer(
               new IllegalStateException("Media requires a DrmSessionManager"), getIndex());
         }
+        onPreAcquireSession(format.drmInitData);
         pendingDrmSession = drmSessionManager.acquireSession(Looper.myLooper(), format.drmInitData);
         if (pendingDrmSession == drmSession) {
           drmSessionManager.releaseSession(pendingDrmSession);
@@ -820,6 +822,17 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
    * @param buffer The buffer to be queued.
    */
   protected void onQueueInputBuffer(DecoderInputBuffer buffer) {
+    // Do nothing.
+  }
+
+  /**
+   * Called before acquires a {@link DrmSession}.
+   * <p>
+   * The default implementation is a no-op.
+   *
+   * @param drmInitData DRM initialization data.
+   */
+  protected void onPreAcquireSession(DrmInitData drmInitData) {
     // Do nothing.
   }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -369,6 +369,11 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
   }
 
   @Override
+  protected void onPreAcquireSession(DrmInitData drmInitData) {
+    eventDispatcher.preAcquireSession(drmInitData);
+  }
+
+  @Override
   protected void onQueueInputBuffer(DecoderInputBuffer buffer) {
     if (Util.SDK_INT < 23 && tunneling) {
       maybeNotifyRenderedFirstFrame();

--- a/library/core/src/main/java/com/google/android/exoplayer2/video/VideoRendererEventListener.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/VideoRendererEventListener.java
@@ -22,6 +22,8 @@ import android.view.TextureView;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.Renderer;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
+import com.google.android.exoplayer2.drm.DrmInitData;
+import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.util.Assertions;
 
 /**
@@ -54,6 +56,13 @@ public interface VideoRendererEventListener {
    * @param format The new format.
    */
   void onVideoInputFormatChanged(Format format);
+
+  /**
+   * Called before acquires a {@link DrmSession}.
+   *
+   * @param drmInitData DRM initialization data.
+   */
+  void onPreAcquireSession(DrmInitData drmInitData);
 
   /**
    * Called to report the number of frames dropped by the renderer. Dropped frames are reported
@@ -161,6 +170,20 @@ public interface VideoRendererEventListener {
           @Override
           public void run() {
             listener.onVideoInputFormatChanged(format);
+          }
+        });
+      }
+    }
+
+    /**
+     * Invokes {@link VideoRendererEventListener#onPreAcquireSession(DrmInitData)}.
+     */
+    public void preAcquireSession(final DrmInitData drmInitData) {
+      if (listener != null) {
+        handler.post(new Runnable() {
+          @Override
+          public void run() {
+            listener.onPreAcquireSession(drmInitData);
           }
         });
       }

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/DebugTextViewHelper.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/DebugTextViewHelper.java
@@ -23,6 +23,7 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 
@@ -113,6 +114,11 @@ public final class DebugTextViewHelper implements Runnable, ExoPlayer.EventListe
 
   @Override
   public void onTracksChanged(TrackGroupArray tracks, TrackSelectionArray selections) {
+    // Do nothing.
+  }
+
+  @Override
+  public void onPreAcquireSession(DrmInitData drmInitData) {
     // Do nothing.
   }
 

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlaybackControlView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlaybackControlView.java
@@ -35,6 +35,7 @@ import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.util.Assertions;
@@ -1103,6 +1104,11 @@ public class PlaybackControlView extends FrameLayout {
 
     @Override
     public void onTracksChanged(TrackGroupArray tracks, TrackSelectionArray selections) {
+      // Do nothing.
+    }
+
+    @Override
+    public void onPreAcquireSession(DrmInitData drmInitData) {
       // Do nothing.
     }
 

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/SimpleExoPlayerView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/SimpleExoPlayerView.java
@@ -39,6 +39,7 @@ import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.metadata.id3.ApicFrame;
 import com.google.android.exoplayer2.source.TrackGroupArray;
@@ -802,6 +803,11 @@ public final class SimpleExoPlayerView extends FrameLayout {
     @Override
     public void onTracksChanged(TrackGroupArray tracks, TrackSelectionArray selections) {
       updateForCurrentTrackSelections();
+    }
+
+    @Override
+    public void onPreAcquireSession(DrmInitData drmInitData) {
+      // Do nothing.
     }
 
     // ExoPlayer.EventListener implementation

--- a/playbacktests/src/main/java/com/google/android/exoplayer2/playbacktests/util/ExoHostedTest.java
+++ b/playbacktests/src/main/java/com/google/android/exoplayer2/playbacktests/util/ExoHostedTest.java
@@ -31,6 +31,7 @@ import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.audio.AudioRendererEventListener;
 import com.google.android.exoplayer2.audio.AudioTrack;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
+import com.google.android.exoplayer2.drm.DrmInitData;
 import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.drm.FrameworkMediaCrypto;
 import com.google.android.exoplayer2.playbacktests.util.HostActivity.HostedTest;
@@ -227,6 +228,10 @@ public abstract class ExoHostedTest implements HostedTest, ExoPlayer.EventListen
 
   @Override
   public final void onPositionDiscontinuity() {
+    // Do nothing.
+  }
+
+  @Override public void onPreAcquireSession(DrmInitData drmInitData) {
     // Do nothing.
   }
 


### PR DESCRIPTION
We created an event to handle the timing just before the DRM is switched.
I need to play videos that always switch to widevine and other DRM.
Widevine needs to update SurfaceView every time it plays. Therefore, we decided to detect changes in DRM in advance at this event.