### PR TITLE
Ignore unused comments when match the master playlist

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -121,8 +121,18 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
         if (line.isEmpty()) {
           // Do nothing.
         } else if (line.startsWith(TAG_STREAM_INF)) {
-          extraLines.add(line);
-          return parseMasterPlaylist(new LineIterator(extraLines, reader), uri.toString());
+          String nextLine ;
+          while((nextLine = reader.readLine()) != null){
+            nextLine = nextLine.trim();
+            if(!nextLine.startsWith("#")){
+              extraLines.add(line);
+              extraLines.add(nextLine);
+              return parseMasterPlaylist(new LineIterator(extraLines, reader), uri.toString());
+            }
+            if(nextLine.startsWith(TAG_STREAM_INF)){
+              line = nextLine;
+            }
+          }
         } else if (line.startsWith(TAG_TARGET_DURATION)
             || line.startsWith(TAG_MEDIA_SEQUENCE)
             || line.startsWith(TAG_MEDIA_DURATION)


### PR DESCRIPTION
I meet a m3u8 file. It looks like:
```
#EXTM3U
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1200000
#YSGD_YSGD2016010106675391_1200.m3u8?shifttime=1497316740&shiftend=1497319140
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=800000
YSGD_YSGD2016010106675391_800.m3u8?shifttime=1497316740&shiftend=1497319140
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=400000
#YSGD_YSGD2016010106675391_400.m3u8?shifttime=1497316740&shiftend=1497319140
```
When the program matchs `#EXT-X-STREAM-INF` , it will store the next line as the url without any checking.  While the next line is a comment.

VLC can play it correctly. It's a legal m3u8 file.

I fix it by filtering the comment, and match the real url with the closest  `#EXT-X-STREAM-INF`.

I'm sorry that I cannot provide the test url here for some personal reasons. 
