### PR TITLE
make defaultloadcontrol extensible

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/DefaultLoadControl.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/DefaultLoadControl.java
@@ -25,7 +25,7 @@ import com.google.android.exoplayer2.util.Util;
 /**
  * The default {@link LoadControl} implementation.
  */
-public final class DefaultLoadControl implements LoadControl {
+public class DefaultLoadControl implements LoadControl {
 
   /**
    * The default minimum duration of media that the player will attempt to ensure is buffered at all


### PR DESCRIPTION
`DefaultLoadControl` is nice for most usages. It’s better to make it extensible so users can add more features to it. eg. load dynamic configs over network. It can be done by using a wrapper over it but it’s easier by inheriting