### PR TITLE
issue #2975 - fix for flac extension build 

### DIFF
--- a/extensions/flac/src/main/jni/flac_parser.cc
+++ b/extensions/flac/src/main/jni/flac_parser.cc
@@ -23,6 +23,8 @@
 #include <cassert>
 #include <cstdlib>
 
+#include <string.h> /* for memset() */
+
 #define LOG_TAG "FLACParser"
 #define ALOGE(...) \
   ((void)__android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__))


### PR DESCRIPTION
failing with "use of undeclared identifier - memset"

- include strings.h for memeset.
- tested with flac-1.3.1