### PR TITLE
Include timestamp of frame onRenderedFirstFrame

### DIFF
--- a/demo/src/main/java/com/google/android/exoplayer2/demo/EventLogger.java
+++ b/demo/src/main/java/com/google/android/exoplayer2/demo/EventLogger.java
@@ -285,8 +285,8 @@ import java.util.Locale;
   }
 
   @Override
-  public void onRenderedFirstFrame(Surface surface) {
-    Log.d(TAG, "renderedFirstFrame [" + surface + "]");
+  public void onRenderedFirstFrame(Surface surface, long framePosition) {
+    Log.d(TAG, "renderedFirstFrame [" + surface + ", " + framePosition + "]");
   }
 
   // DefaultDrmSessionManager.EventListener

--- a/extensions/vp9/src/main/java/com/google/android/exoplayer2/ext/vp9/LibvpxVideoRenderer.java
+++ b/extensions/vp9/src/main/java/com/google/android/exoplayer2/ext/vp9/LibvpxVideoRenderer.java
@@ -314,7 +314,7 @@ public final class LibvpxVideoRenderer extends BaseRenderer {
       outputBuffer = null;
       consecutiveDroppedFrameCount = 0;
       decoderCounters.renderedOutputBufferCount++;
-      maybeNotifyRenderedFirstFrame();
+      maybeNotifyRenderedFirstFrame(0);
     }
   }
 
@@ -597,7 +597,7 @@ public final class LibvpxVideoRenderer extends BaseRenderer {
       // The output is unchanged and non-null. If we know the video size and/or have already
       // rendered to the output, report these again immediately.
       maybeRenotifyVideoSizeChanged();
-      maybeRenotifyRenderedFirstFrame();
+      maybeRenotifyRenderedFirstFrame(0);
     }
   }
 
@@ -610,16 +610,16 @@ public final class LibvpxVideoRenderer extends BaseRenderer {
     renderedFirstFrame = false;
   }
 
-  private void maybeNotifyRenderedFirstFrame() {
+  private void maybeNotifyRenderedFirstFrame(long framePosition) {
     if (!renderedFirstFrame) {
       renderedFirstFrame = true;
-      eventDispatcher.renderedFirstFrame(surface);
+      eventDispatcher.renderedFirstFrame(surface, framePosition);
     }
   }
 
-  private void maybeRenotifyRenderedFirstFrame() {
+  private void maybeRenotifyRenderedFirstFrame(long framePosition) {
     if (renderedFirstFrame) {
-      eventDispatcher.renderedFirstFrame(surface);
+      eventDispatcher.renderedFirstFrame(surface, framePosition);
     }
   }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
@@ -750,12 +750,12 @@ public class SimpleExoPlayer implements ExoPlayer {
     }
 
     @Override
-    public void onRenderedFirstFrame(Surface surface) {
+    public void onRenderedFirstFrame(Surface surface, long framePosition) {
       if (videoListener != null && SimpleExoPlayer.this.surface == surface) {
         videoListener.onRenderedFirstFrame();
       }
       if (videoDebugListener != null) {
-        videoDebugListener.onRenderedFirstFrame(surface);
+        videoDebugListener.onRenderedFirstFrame(surface, framePosition);
       }
     }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -378,7 +378,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
       // The surface is set and unchanged. If we know the video size and/or have already rendered to
       // the surface, report these again immediately.
       maybeRenotifyVideoSizeChanged();
-      maybeRenotifyRenderedFirstFrame();
+      maybeRenotifyRenderedFirstFrame(0);
     }
   }
 
@@ -438,7 +438,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
   @Override
   protected void onQueueInputBuffer(DecoderInputBuffer buffer) {
     if (Util.SDK_INT < 23 && tunneling) {
-      maybeNotifyRenderedFirstFrame();
+      maybeNotifyRenderedFirstFrame(0);
     }
   }
 
@@ -630,7 +630,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
     TraceUtil.endSection();
     decoderCounters.renderedOutputBufferCount++;
     consecutiveDroppedFrameCount = 0;
-    maybeNotifyRenderedFirstFrame();
+    maybeNotifyRenderedFirstFrame(presentationTimeUs / 1000);
   }
 
   /**
@@ -651,7 +651,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
     TraceUtil.endSection();
     decoderCounters.renderedOutputBufferCount++;
     consecutiveDroppedFrameCount = 0;
-    maybeNotifyRenderedFirstFrame();
+    maybeNotifyRenderedFirstFrame(presentationTimeUs / 1000);
   }
 
   private boolean shouldUseDummySurface(boolean codecIsSecure) {
@@ -679,16 +679,16 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
     }
   }
 
-  /* package */ void maybeNotifyRenderedFirstFrame() {
+  /* package */ void maybeNotifyRenderedFirstFrame(long framePosition) {
     if (!renderedFirstFrame) {
       renderedFirstFrame = true;
-      eventDispatcher.renderedFirstFrame(surface);
+      eventDispatcher.renderedFirstFrame(surface, framePosition);
     }
   }
 
-  private void maybeRenotifyRenderedFirstFrame() {
+  private void maybeRenotifyRenderedFirstFrame(long framePosition) {
     if (renderedFirstFrame) {
-      eventDispatcher.renderedFirstFrame(surface);
+      eventDispatcher.renderedFirstFrame(surface, framePosition);
     }
   }
 
@@ -992,7 +992,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
         // Stale event.
         return;
       }
-      maybeNotifyRenderedFirstFrame();
+      maybeNotifyRenderedFirstFrame(presentationTimeUs / 1000);
     }
 
   }

--- a/library/core/src/main/java/com/google/android/exoplayer2/video/VideoRendererEventListener.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/VideoRendererEventListener.java
@@ -94,8 +94,9 @@ public interface VideoRendererEventListener {
    *
    * @param surface The {@link Surface} to which a first frame has been rendered, or {@code null} if
    *     the renderer renders to something that isn't a {@link Surface}.
+   * @param framePosition The position of the rendered first frame in milliseconds.
    */
-  void onRenderedFirstFrame(Surface surface);
+  void onRenderedFirstFrame(Surface surface, long framePosition);
 
   /**
    * Called when the renderer is disabled.
@@ -197,14 +198,14 @@ public interface VideoRendererEventListener {
     }
 
     /**
-     * Invokes {@link VideoRendererEventListener#onRenderedFirstFrame(Surface)}.
+     * Invokes {@link VideoRendererEventListener#onRenderedFirstFrame(Surface, long)}.
      */
-    public void renderedFirstFrame(final Surface surface) {
+    public void renderedFirstFrame(final Surface surface, final long framePosition) {
       if (listener != null) {
         handler.post(new Runnable()  {
           @Override
           public void run() {
-            listener.onRenderedFirstFrame(surface);
+            listener.onRenderedFirstFrame(surface, framePosition);
           }
         });
       }

--- a/testutils/src/main/java/com/google/android/exoplayer2/testutil/ExoHostedTest.java
+++ b/testutils/src/main/java/com/google/android/exoplayer2/testutil/ExoHostedTest.java
@@ -313,7 +313,7 @@ public abstract class ExoHostedTest implements HostedTest, ExoPlayer.EventListen
   }
 
   @Override
-  public void onRenderedFirstFrame(Surface surface) {
+  public void onRenderedFirstFrame(Surface surface, long framePosition) {
     // Do nothing.
   }
 


### PR DESCRIPTION
As per #2533, the presentation timestamp of the first frame is passed on to onRenderedFirstFrame. This is helpful because the first available keyframe is rendered instantly, and is then followed by a visible delay before playback catches up with rendered frame.