### PR TITLE
Remove user agent override from OkHttpDataSourceFactory

### DIFF
--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
@@ -46,7 +46,6 @@ public class OkHttpDataSource implements HttpDataSource {
   private static final AtomicReference<byte[]> skipBufferReference = new AtomicReference<>();
 
   private final Call.Factory callFactory;
-  private final String userAgent;
   private final Predicate<String> contentTypePredicate;
   private final TransferListener<? super OkHttpDataSource> listener;
   private final CacheControl cacheControl;
@@ -67,33 +66,31 @@ public class OkHttpDataSource implements HttpDataSource {
   /**
    * @param callFactory A {@link Call.Factory} (typically an {@link okhttp3.OkHttpClient}) for use
    *     by the source.
-   * @param userAgent The User-Agent string that should be used.
    * @param contentTypePredicate An optional {@link Predicate}. If a content type is rejected by the
    *     predicate then a InvalidContentTypeException} is thrown from {@link #open(DataSpec)}.
    */
-  public OkHttpDataSource(Call.Factory callFactory, String userAgent,
-      Predicate<String> contentTypePredicate) {
-    this(callFactory, userAgent, contentTypePredicate, null);
+  public OkHttpDataSource(Call.Factory callFactory,
+                          Predicate<String> contentTypePredicate) {
+    this(callFactory, contentTypePredicate, null);
   }
 
   /**
    * @param callFactory A {@link Call.Factory} (typically an {@link okhttp3.OkHttpClient}) for use
    *     by the source.
-   * @param userAgent The User-Agent string that should be used.
    * @param contentTypePredicate An optional {@link Predicate}. If a content type is rejected by the
    *     predicate then a {@link InvalidContentTypeException} is thrown from
    *     {@link #open(DataSpec)}.
    * @param listener An optional listener.
    */
-  public OkHttpDataSource(Call.Factory callFactory, String userAgent,
-      Predicate<String> contentTypePredicate, TransferListener<? super OkHttpDataSource> listener) {
-    this(callFactory, userAgent, contentTypePredicate, listener, null, null);
+  public OkHttpDataSource(Call.Factory callFactory,
+                          Predicate<String> contentTypePredicate,
+                          TransferListener<? super OkHttpDataSource> listener) {
+    this(callFactory, contentTypePredicate, listener, null, null);
   }
 
   /**
    * @param callFactory A {@link Call.Factory} (typically an {@link okhttp3.OkHttpClient}) for use
    *     by the source.
-   * @param userAgent The User-Agent string that should be used.
    * @param contentTypePredicate An optional {@link Predicate}. If a content type is rejected by the
    *     predicate then a {@link InvalidContentTypeException} is thrown from
    *     {@link #open(DataSpec)}.
@@ -102,11 +99,10 @@ public class OkHttpDataSource implements HttpDataSource {
    * @param defaultRequestProperties The optional default {@link RequestProperties} to be sent to
    *    the server as HTTP headers on every request.
    */
-  public OkHttpDataSource(Call.Factory callFactory, String userAgent,
+  public OkHttpDataSource(Call.Factory callFactory,
       Predicate<String> contentTypePredicate, TransferListener<? super OkHttpDataSource> listener,
       CacheControl cacheControl, RequestProperties defaultRequestProperties) {
     this.callFactory = Assertions.checkNotNull(callFactory);
-    this.userAgent = Assertions.checkNotEmpty(userAgent);
     this.contentTypePredicate = contentTypePredicate;
     this.listener = listener;
     this.cacheControl = cacheControl;
@@ -280,7 +276,6 @@ public class OkHttpDataSource implements HttpDataSource {
       }
       builder.addHeader("Range", rangeRequest);
     }
-    builder.addHeader("User-Agent", userAgent);
     if (!allowGzip) {
       builder.addHeader("Accept-Encoding", "identity");
     }

--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSourceFactory.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSourceFactory.java
@@ -29,32 +29,28 @@ import okhttp3.Call;
 public final class OkHttpDataSourceFactory extends BaseFactory {
 
   private final Call.Factory callFactory;
-  private final String userAgent;
   private final TransferListener<? super DataSource> listener;
   private final CacheControl cacheControl;
 
   /**
    * @param callFactory A {@link Call.Factory} (typically an {@link okhttp3.OkHttpClient}) for use
    *     by the sources created by the factory.
-   * @param userAgent The User-Agent string that should be used.
    * @param listener An optional listener.
    */
-  public OkHttpDataSourceFactory(Call.Factory callFactory, String userAgent,
+  public OkHttpDataSourceFactory(Call.Factory callFactory,
       TransferListener<? super DataSource> listener) {
-    this(callFactory, userAgent, listener, null);
+    this(callFactory, listener, null);
   }
 
   /**
    * @param callFactory A {@link Call.Factory} (typically an {@link okhttp3.OkHttpClient}) for use
    *     by the sources created by the factory.
-   * @param userAgent The User-Agent string that should be used.
    * @param listener An optional listener.
    * @param cacheControl An optional {@link CacheControl} for setting the Cache-Control header.
    */
-  public OkHttpDataSourceFactory(Call.Factory callFactory, String userAgent,
+  public OkHttpDataSourceFactory(Call.Factory callFactory,
       TransferListener<? super DataSource> listener, CacheControl cacheControl) {
     this.callFactory = callFactory;
-    this.userAgent = userAgent;
     this.listener = listener;
     this.cacheControl = cacheControl;
   }
@@ -62,7 +58,7 @@ public final class OkHttpDataSourceFactory extends BaseFactory {
   @Override
   protected OkHttpDataSource createDataSourceInternal(
       HttpDataSource.RequestProperties defaultRequestProperties) {
-    return new OkHttpDataSource(callFactory, userAgent, null, listener, cacheControl,
+    return new OkHttpDataSource(callFactory, null, listener, cacheControl,
         defaultRequestProperties);
   }
 


### PR DESCRIPTION
Like any other header, the `User-Agent` can be configured on an `OkHttpClient`
instance e.g.:

```kotlin
val okHttpClient = OkHttpClient.Builder()
        .addInterceptor { chain ->
            val request = chain.request().newBuilder().addHeader(USER_AGENT, userAgent).build()
            chain.proceed(request)
        }
        .addInterceptor(httpLoggingInterceptor)
        .build()
```

The `OkHttpDataSource` required that a `User-Agent` was passed in as a parameter
overriding any `User-Agent` already configured on the `OkHttpClient`. This made
it impossible to configure the `User-Agent` in once place if the `OkHttpClient`
is also used elsewhere in the app.

The OkHttpClient is the appropriate place to configure headers that are not
specific to a particular request.