### PR TITLE
Use modulePrefix for the library-core dependency

### DIFF
--- a/extensions/mediasession/build.gradle
+++ b/extensions/mediasession/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    compile project(':library-core')
+    compile project(modulePrefix + 'library-core')
     compile 'com.android.support:support-media-compat:' + supportLibraryVersion
     compile 'com.android.support:appcompat-v7:' + supportLibraryVersion
 }


### PR DESCRIPTION
When working with the local ExoPlayer repository and using extensions, I had to add the `modulePrefix` to the `library-core` dependency so my app project could recognize it.

I saw that all other modules use `modulePrefix` and mediasession is the one missing it.