### PR TITLE
Allow PlaybackControlView to be overridden in SimpleExoPlayerView

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/SimpleExoPlayerView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/SimpleExoPlayerView.java
@@ -168,6 +168,15 @@ import java.util.List;
  *        <li>Type: {@link View}</li>
  *       </ul>
  *   </li>
+ *   <li><b>{@code exo_controller}</b> - An already inflated instance of
+ *       {@link PlaybackControlView}. Allows you to use your own {@link PlaybackControlView} instead
+ *       of default. Note: attrs such as rewind_increment will not be passed through to this
+ *       instance and should be set at creation. {@code exo_controller_placeholder} will be ignored
+ *       if this is set.
+ *       <ul>
+ *        <li>Type: {@link View}</li>
+ *       </ul>
+ *   </li>
  *   <li><b>{@code exo_overlay}</b> - A {@link FrameLayout} positioned on top of the player which
  *       the app can access via {@link #getOverlayFrameLayout()}, provided for convenience.
  *       <ul>
@@ -315,8 +324,11 @@ public final class SimpleExoPlayerView extends FrameLayout {
     }
 
     // Playback control view.
+    PlaybackControlView customController = (PlaybackControlView) findViewById(R.id.exo_controller);
     View controllerPlaceholder = findViewById(R.id.exo_controller_placeholder);
-    if (controllerPlaceholder != null) {
+    if (customController != null) {
+      this.controller = customController;
+    } else if (controllerPlaceholder != null) {
       // Note: rewindMs and fastForwardMs are passed via attrs, so we don't need to make explicit
       // calls to set them.
       this.controller = new PlaybackControlView(context, attrs);

--- a/library/ui/src/main/res/values/ids.xml
+++ b/library/ui/src/main/res/values/ids.xml
@@ -20,6 +20,7 @@
   <item name="exo_subtitles" type="id"/>
   <item name="exo_artwork" type="id"/>
   <item name="exo_controller_placeholder" type="id"/>
+  <item name="exo_controller" type="id"/>
   <item name="exo_overlay" type="id"/>
   <item name="exo_play" type="id"/>
   <item name="exo_pause" type="id"/>


### PR DESCRIPTION
Allow users to override the `PlaybackControlView` in `SimpleExoPlayerView` instead of forcing the default implementation. This will allow for things such as overriding `hide()` and `show()` to animate the controls in and out of view.

See issue: https://github.com/google/ExoPlayer/issues/2277

I ensured the demo application still functioned correctly without any changes, and also functioned correctly when I overrode the `PlaybackControlView` with my own with a white background so I knew it had applied. Let me know if there's any further testing/automated testing this project requires.