### PR TITLE
Add possibility of forcing a specific license URL in HttpMediaDrmCallback

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/HttpMediaDrmCallback.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/HttpMediaDrmCallback.java
@@ -47,29 +47,29 @@ public final class HttpMediaDrmCallback implements MediaDrmCallback {
   }
 
   private final HttpDataSource.Factory dataSourceFactory;
-  private final String defaultUrl;
+  private final String defaultLicenseUrl;
+  private final boolean forceDefaultLicenseUrl;
   private final Map<String, String> keyRequestProperties;
 
   /**
-   * @param defaultUrl The default license URL.
+   * @param defaultLicenseUrl The default license URL.
    * @param dataSourceFactory A factory from which to obtain {@link HttpDataSource} instances.
    */
-  public HttpMediaDrmCallback(String defaultUrl, HttpDataSource.Factory dataSourceFactory) {
-    this(defaultUrl, dataSourceFactory, null);
+  public HttpMediaDrmCallback(String defaultLicenseUrl, HttpDataSource.Factory dataSourceFactory) {
+    this(defaultLicenseUrl, false, dataSourceFactory, null);
   }
 
   /**
-   * @deprecated Use {@link HttpMediaDrmCallback#HttpMediaDrmCallback(String, Factory)}. Request
-   *     properties can be set by calling {@link #setKeyRequestProperty(String, String)}.
-   * @param defaultUrl The default license URL.
+   * @param defaultLicenseUrl The default license URL.
+   * @param forceDefaultLicenseUrl Whether to force use of {@code defaultLicenseUrl} even for key
+   *     requests that include their own license URL.
    * @param dataSourceFactory A factory from which to obtain {@link HttpDataSource} instances.
-   * @param keyRequestProperties Request properties to set when making key requests, or null.
    */
-  @Deprecated
-  public HttpMediaDrmCallback(String defaultUrl, HttpDataSource.Factory dataSourceFactory,
-      Map<String, String> keyRequestProperties) {
+  public HttpMediaDrmCallback(String defaultLicenseUrl, boolean forceDefaultLicenseUrl,
+      HttpDataSource.Factory dataSourceFactory, Map<String, String> keyRequestProperties) {
     this.dataSourceFactory = dataSourceFactory;
-    this.defaultUrl = defaultUrl;
+    this.defaultLicenseUrl = defaultLicenseUrl;
+    this.forceDefaultLicenseUrl = forceDefaultLicenseUrl;
     this.keyRequestProperties = new HashMap<>();
     if (keyRequestProperties != null) {
       this.keyRequestProperties.putAll(keyRequestProperties);
@@ -120,8 +120,8 @@ public final class HttpMediaDrmCallback implements MediaDrmCallback {
   @Override
   public byte[] executeKeyRequest(UUID uuid, KeyRequest request) throws Exception {
     String url = request.getDefaultUrl();
-    if (TextUtils.isEmpty(url)) {
-      url = defaultUrl;
+    if (forceDefaultLicenseUrl || TextUtils.isEmpty(url)) {
+      url = defaultLicenseUrl;
     }
     Map<String, String> requestProperties = new HashMap<>();
     requestProperties.put("Content-Type", "application/octet-stream");

--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/OfflineLicenseHelper.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/OfflineLicenseHelper.java
@@ -43,23 +43,44 @@ public final class OfflineLicenseHelper<T extends ExoMediaCrypto> {
    * Instantiates a new instance which uses Widevine CDM. Call {@link #release()} when the instance
    * is no longer required.
    *
-   * @param licenseUrl The default license URL.
+   * @param defaultLicenseUrl The default license URL.
    * @param httpDataSourceFactory A factory from which to obtain {@link HttpDataSource} instances.
    * @return A new instance which uses Widevine CDM.
    * @throws UnsupportedDrmException If the Widevine DRM scheme is unsupported or cannot be
    *     instantiated.
    */
   public static OfflineLicenseHelper<FrameworkMediaCrypto> newWidevineInstance(
-      String licenseUrl, Factory httpDataSourceFactory) throws UnsupportedDrmException {
-    return newWidevineInstance(
-        new HttpMediaDrmCallback(licenseUrl, httpDataSourceFactory), null);
+      String defaultLicenseUrl, Factory httpDataSourceFactory)
+      throws UnsupportedDrmException {
+    return newWidevineInstance(defaultLicenseUrl, false, httpDataSourceFactory, null);
   }
 
   /**
    * Instantiates a new instance which uses Widevine CDM. Call {@link #release()} when the instance
    * is no longer required.
    *
-   * @param callback Performs key and provisioning requests.
+   * @param defaultLicenseUrl The default license URL.
+   * @param forceDefaultLicenseUrl Whether to force use of {@code defaultLicenseUrl} even for key
+   *     requests that include their own license URL.
+   * @param httpDataSourceFactory A factory from which to obtain {@link HttpDataSource} instances.
+   * @return A new instance which uses Widevine CDM.
+   * @throws UnsupportedDrmException If the Widevine DRM scheme is unsupported or cannot be
+   *     instantiated.
+   */
+  public static OfflineLicenseHelper<FrameworkMediaCrypto> newWidevineInstance(
+      String defaultLicenseUrl, boolean forceDefaultLicenseUrl, Factory httpDataSourceFactory)
+      throws UnsupportedDrmException {
+    return newWidevineInstance(defaultLicenseUrl, forceDefaultLicenseUrl, httpDataSourceFactory,
+        null);
+  }
+
+  /**
+   * Instantiates a new instance which uses Widevine CDM. Call {@link #release()} when the instance
+   * is no longer required.
+   *
+   * @param defaultLicenseUrl The default license URL.
+   * @param forceDefaultLicenseUrl Whether to force use of {@code defaultLicenseUrl} even for key
+   *     requests that include their own license URL.
    * @param optionalKeyRequestParameters An optional map of parameters to pass as the last argument
    *     to {@link MediaDrm#getKeyRequest(byte[], byte[], String, int, HashMap)}. May be null.
    * @return A new instance which uses Widevine CDM.
@@ -69,10 +90,12 @@ public final class OfflineLicenseHelper<T extends ExoMediaCrypto> {
    *     MediaDrmCallback, HashMap, Handler, EventListener)
    */
   public static OfflineLicenseHelper<FrameworkMediaCrypto> newWidevineInstance(
-      MediaDrmCallback callback, HashMap<String, String> optionalKeyRequestParameters)
+      String defaultLicenseUrl, boolean forceDefaultLicenseUrl, Factory httpDataSourceFactory,
+      HashMap<String, String> optionalKeyRequestParameters)
       throws UnsupportedDrmException {
-    return new OfflineLicenseHelper<>(FrameworkMediaDrm.newInstance(C.WIDEVINE_UUID), callback,
-        optionalKeyRequestParameters);
+    return new OfflineLicenseHelper<>(FrameworkMediaDrm.newInstance(C.WIDEVINE_UUID),
+        new HttpMediaDrmCallback(defaultLicenseUrl, forceDefaultLicenseUrl, httpDataSourceFactory,
+        null), optionalKeyRequestParameters);
   }
 
   /**


### PR DESCRIPTION
- Renamed some license URL related variables to keep consistency across the code.
- Added a new parameter to HttpMediaDrmCallback that enables forcing defaultLicenseURL as the license acquisition URL.