### PR TITLE
added Google maven repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ the `build.gradle` file in the root of your project:
 ```gradle
 repositories {
     jcenter()
+    maven { url 'https://maven.google.com' }
 }
 ```
 


### PR DESCRIPTION
Fixes the "Failed to resolve: annotationProcessor" error when attempting to compile ExoPlayer.

Addresses #3168 