### PR TITLE
Support H262 video in MP4

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -1027,6 +1027,10 @@ import java.util.List;
       case 0xAB:
         mimeType = MimeTypes.AUDIO_DTS_HD;
         return Pair.create(mimeType, null);
+      case 0x60: /* Visual 13818-2 Simple Profile */
+      case 0x61: /* Visual 13818-2 Main Profile */
+        mimeType = MimeTypes.VIDEO_MPEG2;
+        break;
       default:
         mimeType = null;
         break;


### PR DESCRIPTION
### Issue description
https://github.com/google/ExoPlayer/issues/3181

### Solution

According to ISO/IEC 14496-1 Table 8-5: objectProfileIndication Values,  objectProfileIndication Value = 0x60 & 0x61 means Visual 13818-2 Simple Profile & Visual 13818-2 Main Profile respectively.

### Verification
1: before fix: black screen.
![image](https://user-images.githubusercontent.com/14846473/29398210-edd6c964-8355-11e7-976a-6dbe6ff9245b.png)


2. After fix: Both A\V are fine.
https://youtu.be/DrOa4vcltqA

### Test file
https://drive.google.com/open?id=0B7H5vJR3qWj0NjJEb0JLb3pvc28