### PR TITLE
Fix possible subrip timing line NPE

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/subrip/SubripDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/subrip/SubripDecoder.java
@@ -69,8 +69,8 @@ public final class SubripDecoder extends SimpleSubtitleDecoder {
       // Read and parse the timing line.
       boolean haveEndTimecode = false;
       currentLine = subripData.readLine();
-      Matcher matcher = SUBRIP_TIMING_LINE.matcher(currentLine);
-      if (matcher.matches()) {
+      Matcher matcher = currentLine == null ? null : SUBRIP_TIMING_LINE.matcher(currentLine);
+      if (matcher != null && matcher.matches()) {
         cueTimesUs.add(parseTimecode(matcher, 1));
         if (!TextUtils.isEmpty(matcher.group(6))) {
           haveEndTimecode = true;


### PR DESCRIPTION
Fixes a possible NPE when reading the subrips timing line. We've had this occur for multiple users. Most likely due to corrupt srts, but would prefer the subs to just not appear in this scenario.

Not sure of your style guide (re: ternary operators), but figured it was tidier to reuse the "matches" check as in both scenarios the timing line is "invalid".

Error seen in the wild (trimmed) is:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke interface method 'int java.lang.CharSequence.length()' on a null object reference  
       at java.util.regex.Matcher.reset(Matcher.java:995)  
       at java.util.regex.Matcher.<init>(Matcher.java:174)  
       at java.util.regex.Pattern.matcher(Pattern.java:1006)  
       at com.google.android.exoplayer2.text.subrip.SubripDecoder.decode(SubripDecoder.java:72)
```