### PR TITLE
Support zoom mode for AspectRatioFrameLayout

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/AspectRatioFrameLayout.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/AspectRatioFrameLayout.java
@@ -32,7 +32,7 @@ public final class AspectRatioFrameLayout extends FrameLayout {
    * Resize modes for {@link AspectRatioFrameLayout}.
    */
   @Retention(RetentionPolicy.SOURCE)
-  @IntDef({RESIZE_MODE_FIT, RESIZE_MODE_FIXED_WIDTH, RESIZE_MODE_FIXED_HEIGHT, RESIZE_MODE_FILL})
+  @IntDef({RESIZE_MODE_FIT, RESIZE_MODE_FIXED_WIDTH, RESIZE_MODE_FIXED_HEIGHT, RESIZE_MODE_FILL, RESIZE_MODE_CROP})
   public @interface ResizeMode {}
 
   /**
@@ -51,6 +51,10 @@ public final class AspectRatioFrameLayout extends FrameLayout {
    * The specified aspect ratio is ignored.
    */
   public static final int RESIZE_MODE_FILL = 3;
+  /**
+   * The height or width is increased or decreased to crop and to obtain the desired aspect ratio.
+   */
+  public static final int RESIZE_MODE_CROP = 4;
 
   /**
    * The {@link FrameLayout} will not resize itself if the fractional difference between its natural
@@ -97,6 +101,15 @@ public final class AspectRatioFrameLayout extends FrameLayout {
   }
 
   /**
+   * Gets the resize mode.
+   *
+   * @return The resize mode.
+   */
+  public int getResizeMode() {
+    return this.resizeMode;
+  }
+
+  /**
    * Sets the resize mode.
    *
    * @param resizeMode The resize mode.
@@ -131,6 +144,13 @@ public final class AspectRatioFrameLayout extends FrameLayout {
         break;
       case RESIZE_MODE_FIXED_HEIGHT:
         width = (int) (height * videoAspectRatio);
+        break;
+      case RESIZE_MODE_CROP:
+        if (videoAspectRatio > viewAspectRatio) {
+          width = (int) (height * videoAspectRatio);
+        } else {
+          height = (int) (width / videoAspectRatio);
+        }
         break;
       default:
         if (aspectDeformation > 0) {

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/AspectRatioFrameLayout.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/AspectRatioFrameLayout.java
@@ -32,7 +32,7 @@ public final class AspectRatioFrameLayout extends FrameLayout {
    * Resize modes for {@link AspectRatioFrameLayout}.
    */
   @Retention(RetentionPolicy.SOURCE)
-  @IntDef({RESIZE_MODE_FIT, RESIZE_MODE_FIXED_WIDTH, RESIZE_MODE_FIXED_HEIGHT, RESIZE_MODE_FILL, RESIZE_MODE_CROP})
+  @IntDef({RESIZE_MODE_FIT, RESIZE_MODE_FIXED_WIDTH, RESIZE_MODE_FIXED_HEIGHT, RESIZE_MODE_FILL, RESIZE_MODE_ASPECT_FILL})
   public @interface ResizeMode {}
 
   /**
@@ -52,9 +52,9 @@ public final class AspectRatioFrameLayout extends FrameLayout {
    */
   public static final int RESIZE_MODE_FILL = 3;
   /**
-   * The height or width is increased or decreased to crop and to obtain the desired aspect ratio.
+   * Either height or width is increased to obtain the desired aspect ratio.
    */
-  public static final int RESIZE_MODE_CROP = 4;
+  public static final int RESIZE_MODE_ASPECT_FILL = 4;
 
   /**
    * The {@link FrameLayout} will not resize itself if the fractional difference between its natural
@@ -145,7 +145,7 @@ public final class AspectRatioFrameLayout extends FrameLayout {
       case RESIZE_MODE_FIXED_HEIGHT:
         width = (int) (height * videoAspectRatio);
         break;
-      case RESIZE_MODE_CROP:
+      case RESIZE_MODE_ASPECT_FILL:
         if (videoAspectRatio > viewAspectRatio) {
           width = (int) (height * videoAspectRatio);
         } else {

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/AspectRatioFrameLayout.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/AspectRatioFrameLayout.java
@@ -32,7 +32,7 @@ public final class AspectRatioFrameLayout extends FrameLayout {
    * Resize modes for {@link AspectRatioFrameLayout}.
    */
   @Retention(RetentionPolicy.SOURCE)
-  @IntDef({RESIZE_MODE_FIT, RESIZE_MODE_FIXED_WIDTH, RESIZE_MODE_FIXED_HEIGHT, RESIZE_MODE_FILL, RESIZE_MODE_ASPECT_FILL})
+  @IntDef({RESIZE_MODE_FIT, RESIZE_MODE_FIXED_WIDTH, RESIZE_MODE_FIXED_HEIGHT, RESIZE_MODE_FILL, RESIZE_MODE_ZOOM})
   public @interface ResizeMode {}
 
   /**
@@ -54,7 +54,7 @@ public final class AspectRatioFrameLayout extends FrameLayout {
   /**
    * Either height or width is increased to obtain the desired aspect ratio.
    */
-  public static final int RESIZE_MODE_ASPECT_FILL = 4;
+  public static final int RESIZE_MODE_ZOOM = 4;
 
   /**
    * The {@link FrameLayout} will not resize itself if the fractional difference between its natural
@@ -145,7 +145,7 @@ public final class AspectRatioFrameLayout extends FrameLayout {
       case RESIZE_MODE_FIXED_HEIGHT:
         width = (int) (height * videoAspectRatio);
         break;
-      case RESIZE_MODE_ASPECT_FILL:
+      case RESIZE_MODE_ZOOM:
         if (videoAspectRatio > viewAspectRatio) {
           width = (int) (height * videoAspectRatio);
         } else {


### PR DESCRIPTION
The AspectRatioFrameLayout does not provide resize mode that offer full screen mode respecting the aspect ratio. It is specially useful for mobile screens like Samsung S8 or LG G6 (aspect ratio 18.5:9).

  