### PR TITLE
Add support for new codecs parameter string

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
@@ -184,9 +184,9 @@ public final class MimeTypes {
       return MimeTypes.VIDEO_H264;
     } else if (codec.startsWith("hev1") || codec.startsWith("hvc1")) {
       return MimeTypes.VIDEO_H265;
-    } else if (codec.startsWith("vp9")) {
+    } else if (codec.startsWith("vp9") || codec.startsWith("vp09")) {
       return MimeTypes.VIDEO_VP9;
-    } else if (codec.startsWith("vp8")) {
+    } else if (codec.startsWith("vp8") || codec.startsWith("vp08")) {
       return MimeTypes.VIDEO_VP8;
     } else if (codec.startsWith("mp4a")) {
       return MimeTypes.AUDIO_AAC;


### PR DESCRIPTION
Hi,
I was doing tests for VP9 in ISOBMFF container and I realized my tests assets were not working. I was wondering why Exoplayer test videos did work and I found the difference codecs string format. Exoplayer demos have 'codecs="vp9"' while mine has the new codecs parameter string 'codecs="vp09"' as specified here: https://www.webmproject.org/vp9/mp4/

Same think happened in shaka-player (https://github.com/google/shaka-player/issues/944)

With this change it started working again. It's simple change but it does the trick.