### PR TITLE
#3215 Additional secure DummySurface device exclusions

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/video/DummySurface.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/DummySurface.java
@@ -43,6 +43,7 @@ import static android.opengl.GLES20.glGenTextures;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.graphics.SurfaceTexture;
 import android.graphics.SurfaceTexture.OnFrameAvailableListener;
 import android.opengl.EGL14;
@@ -152,9 +153,16 @@ public final class DummySurface extends Surface {
    *
    * @param context Any {@link Context}.
    */
-  @SuppressWarnings("unused") // Context may be needed in the future for better targeting.
+  @SuppressWarnings("unused")
   private static boolean deviceNeedsSecureDummySurfaceWorkaround(Context context) {
-    return Util.SDK_INT == 24 && "samsung".equals(Util.MANUFACTURER);
+    return (Util.SDK_INT == 24 && "samsung".equals(Util.MANUFACTURER))
+            || (Util.SDK_INT >= 24 && Util.SDK_INT < 26
+              && !hasVrModeHighPerformanceSystemFeatureV24(context.getPackageManager()));
+  }
+
+  @TargetApi(24)
+  private static boolean hasVrModeHighPerformanceSystemFeatureV24(PackageManager packageManager) {
+    return packageManager.hasSystemFeature(PackageManager.FEATURE_VR_MODE_HIGH_PERFORMANCE);
   }
 
   private static class DummySurfaceThread extends HandlerThread implements OnFrameAvailableListener,


### PR DESCRIPTION
Proposed workaround for: https://github.com/google/ExoPlayer/issues/3215

Excludes all API 24/25 devices that do not have the `FEATURE_VR_MODE_HIGH_PERFORMANCE` system feature from having a secure `DummySurface`. This seems to be the cause of a `libstagefright.so` SIGSEGV in ExoPlayer 2.5.1 on certain 24/25 devices when releasing the player.

Verified this fixes the issue on one of the affected devices (Moto G5 Plus), but do not have access to the other 19+. My other (API: 26, 18, 19) devices lying around are also working as expected.