### PR TITLE
Fix AdaptiveTrackSelection failed to switch up

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
@@ -88,7 +88,7 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
   }
 
   public static final int DEFAULT_MAX_INITIAL_BITRATE = 800000;
-  public static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 10000;
+  public static final int DEFAULT_MIN_DURATION_FOR_QUALITY_INCREASE_MS = 4000;
   public static final int DEFAULT_MAX_DURATION_FOR_QUALITY_DECREASE_MS = 25000;
   public static final int DEFAULT_MIN_DURATION_TO_RETAIN_AFTER_DISCARD_MS = 25000;
   public static final float DEFAULT_BANDWIDTH_FRACTION = 0.75f;

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -206,10 +206,9 @@ import java.util.List;
     int oldVariantIndex = previous == null ? C.INDEX_UNSET
         : trackGroup.indexOf(previous.trackFormat);
     expectedPlaylistUrl = null;
-    // Use start time of the previous chunk rather than its end time because switching format will
-    // require downloading overlapping segments.
+    // Use end time instead because bufferedDurationUs will always be zero for 30s segment
     long bufferedDurationUs = previous == null ? 0
-        : Math.max(0, previous.startTimeUs - playbackPositionUs);
+        : Math.max(0, previous.endTimeUs - playbackPositionUs);
 
     // Select the variant.
     trackSelection.updateSelectedTrack(bufferedDurationUs);


### PR DESCRIPTION
Proposed workaround for: #3224

Update bufferedDurationUs and parameter minDurationForQualityIncreaseUs in AdaptiveTrackSelection and verified this fix for 3s, 10s and 30s HLS segment respectively.