### PR TITLE
#3230: SmoothStreaming URLs that uses parenthesis '(...)' as part of …

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -901,7 +901,8 @@ public final class Util {
     } else if (fileName.endsWith(".m3u8")) {
       return C.TYPE_HLS;
     } else if (fileName.endsWith(".ism") || fileName.endsWith(".isml")
-        || fileName.endsWith(".ism/manifest") || fileName.endsWith(".isml/manifest")) {
+        || fileName.endsWith(".ism/manifest") || fileName.endsWith(".isml/manifest")
+            || Uri.parse(fileName).getLastPathSegment().matches("manifest\\(.*\\)")) {
       return C.TYPE_SS;
     } else {
       return C.TYPE_OTHER;

--- a/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaSource.java
+++ b/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaSource.java
@@ -192,7 +192,9 @@ public final class SsMediaSource implements MediaSource,
       AdaptiveMediaSourceEventListener eventListener) {
     Assertions.checkState(manifest == null || !manifest.isLive);
     this.manifest = manifest;
-    this.manifestUri = manifestUri == null ? null : lastPathSegment.contains("manifest") && lastPathSegment.contains("(") && lastPathSegment.contains(")")) ? manifestUri : lastPathSegment.equals("manifest") ? manifestUri : Uri.withAppendedPath(manifestUri, "Manifest");
+    String lastPathSegment = Util.toLowerInvariant(manifestUri.getLastPathSegment());
+    // Using a regexp here to allow for URLs which contain (..) as their last part, e.g. http://host/content.ism/manifest(filter=0) - see #3230
+    this.manifestUri = manifestUri == null ? null : lastPathSegment.equals("manifest") ? manifestUri : lastPathSegment.matches("manifest\\(.*\\)") ? manifestUri : Uri.withAppendedPath(manifestUri, "Manifest");
     this.manifestDataSourceFactory = manifestDataSourceFactory;
     this.manifestParser = manifestParser;
     this.chunkSourceFactory = chunkSourceFactory;

--- a/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaSource.java
+++ b/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaSource.java
@@ -192,9 +192,7 @@ public final class SsMediaSource implements MediaSource,
       AdaptiveMediaSourceEventListener eventListener) {
     Assertions.checkState(manifest == null || !manifest.isLive);
     this.manifest = manifest;
-    this.manifestUri = manifestUri == null ? null
-        : Util.toLowerInvariant(manifestUri.getLastPathSegment()).equals("manifest") ? manifestUri
-            : Uri.withAppendedPath(manifestUri, "Manifest");
+    this.manifestUri = manifestUri == null ? null : lastPathSegment.contains("manifest") && lastPathSegment.contains("(") && lastPathSegment.contains(")")) ? manifestUri : lastPathSegment.equals("manifest") ? manifestUri : Uri.withAppendedPath(manifestUri, "Manifest");
     this.manifestDataSourceFactory = manifestDataSourceFactory;
     this.manifestParser = manifestParser;
     this.chunkSourceFactory = chunkSourceFactory;


### PR DESCRIPTION
…the URL causes server side errors

Here is the suggested fix for #3230 in a pull request.