### PR TITLE
Fix primary hls playlist update

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
@@ -351,7 +351,7 @@ public final class HlsPlaylistTracker implements Loader.Callback<ParsingLoadable
     }
     MediaPlaylistBundle currentPrimaryBundle = playlistBundles.get(primaryHlsUrl);
     long primarySnapshotAccessAgeMs =
-        currentPrimaryBundle.lastSnapshotAccessTimeMs - SystemClock.elapsedRealtime();
+        SystemClock.elapsedRealtime() - currentPrimaryBundle.lastSnapshotAccessTimeMs;
     if (primarySnapshotAccessAgeMs > PRIMARY_URL_KEEPALIVE_MS) {
       primaryHlsUrl = url;
       playlistBundles.get(primaryHlsUrl).loadPlaylist();

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
@@ -200,7 +200,7 @@ public final class HlsPlaylistTracker implements Loader.Callback<ParsingLoadable
    */
   public HlsMediaPlaylist getPlaylistSnapshot(HlsUrl url) {
     HlsMediaPlaylist snapshot = playlistBundles.get(url).getPlaylistSnapshot();
-    if (url != primaryHlsUrl && snapshot != null ) {
+    if (url != primaryHlsUrl && snapshot != null) {
       maybeSetPrimaryUrl(url);
     }
     return snapshot;

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
@@ -112,11 +112,6 @@ public final class HlsPlaylistTracker implements Loader.Callback<ParsingLoadable
    * which an unchanging playlist is considered stuck.
    */
   private static final double PLAYLIST_STUCK_TARGET_DURATION_COEFFICIENT = 3.5;
-  /**
-   * The minimum number of milliseconds that a url is kept as primary url, if no
-   * {@link #getPlaylistSnapshot} call is made for that url.
-   */
-  private static final long PRIMARY_URL_KEEPALIVE_MS = 15000;
 
   private final Uri initialPlaylistUri;
   private final HlsDataSourceFactory dataSourceFactory;
@@ -205,7 +200,7 @@ public final class HlsPlaylistTracker implements Loader.Callback<ParsingLoadable
    */
   public HlsMediaPlaylist getPlaylistSnapshot(HlsUrl url) {
     HlsMediaPlaylist snapshot = playlistBundles.get(url).getPlaylistSnapshot();
-    if (snapshot != null) {
+    if (url != primaryHlsUrl && snapshot != null ) {
       maybeSetPrimaryUrl(url);
     }
     return snapshot;
@@ -349,13 +344,9 @@ public final class HlsPlaylistTracker implements Loader.Callback<ParsingLoadable
       // the last primary snapshot contains an end tag.
       return;
     }
-    MediaPlaylistBundle currentPrimaryBundle = playlistBundles.get(primaryHlsUrl);
-    long primarySnapshotAccessAgeMs =
-        SystemClock.elapsedRealtime() - currentPrimaryBundle.lastSnapshotAccessTimeMs;
-    if (primarySnapshotAccessAgeMs > PRIMARY_URL_KEEPALIVE_MS) {
-      primaryHlsUrl = url;
-      playlistBundles.get(primaryHlsUrl).loadPlaylist();
-    }
+
+    primaryHlsUrl = url;
+    playlistBundles.get(primaryHlsUrl).loadPlaylist();
   }
 
   private void createBundles(List<HlsUrl> urls) {


### PR DESCRIPTION
The current implementation does not update the `primaryHlsUrl` in `HlsPlaylistTracker` class. 
Please review the followings:

ff2ece5
- fixed `primarySnapshotAccessAgeMs` to update `primaryHlsUrl`. Due to this bug, `primaryHlsUrl` does not change and keep loading its url while loading higher variant url. 
Based on the media I used, the accesses to playlist is decreased from 40times/minute to 22times/minute.

cac16f1
- removed keepalive check for updating primary url. Because of this, `primaryHlsUrl` does not change 15 seconds and keep loading its url even though the player starts loading higher variant url within 15 second.
I couldn't think of any good reason to wait updating the primary url, so please tell me the case we need this check if there is any. 
Based on the media I used, the accesses to playlist is decreased to 15times/minute.   

thanks.