### PR TITLE
Allow passing of initialtrackselection for HLS.

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -118,7 +118,7 @@ import java.util.List;
    */
   public HlsChunkSource(HlsPlaylistTracker playlistTracker, HlsUrl[] variants,
       HlsDataSourceFactory dataSourceFactory, TimestampAdjusterProvider timestampAdjusterProvider,
-      List<Format> muxedCaptionFormats) {
+      List<Format> muxedCaptionFormats, TrackSelection.Factory initialTrackSelectionFactory) {
     this.playlistTracker = playlistTracker;
     this.variants = variants;
     this.timestampAdjusterProvider = timestampAdjusterProvider;
@@ -133,7 +133,9 @@ import java.util.List;
     mediaDataSource = dataSourceFactory.createDataSource(C.DATA_TYPE_MEDIA);
     encryptionDataSource = dataSourceFactory.createDataSource(C.DATA_TYPE_DRM);
     trackGroup = new TrackGroup(variantFormats);
-    trackSelection = new InitializationTrackSelection(trackGroup, initialTrackSelection);
+    trackSelection = initialTrackSelectionFactory != null ?
+            initialTrackSelectionFactory.createTrackSelection(trackGroup, initialTrackSelection) :
+            new InitializationTrackSelection(trackGroup, initialTrackSelection);
   }
 
   /**

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java
@@ -52,6 +52,7 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsSampleStreamWrapper
   private final IdentityHashMap<SampleStream, Integer> streamWrapperIndices;
   private final TimestampAdjusterProvider timestampAdjusterProvider;
   private final Handler continueLoadingHandler;
+  private final TrackSelection.Factory initialTrackSelectionFactory;
 
   private Callback callback;
   private int pendingPrepareCount;
@@ -61,12 +62,14 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsSampleStreamWrapper
   private CompositeSequenceableLoader sequenceableLoader;
 
   public HlsMediaPeriod(HlsPlaylistTracker playlistTracker, HlsDataSourceFactory dataSourceFactory,
-      int minLoadableRetryCount, EventDispatcher eventDispatcher, Allocator allocator) {
+      int minLoadableRetryCount, EventDispatcher eventDispatcher, Allocator allocator,
+      TrackSelection.Factory initialTrackSelectionFactory) {
     this.playlistTracker = playlistTracker;
     this.dataSourceFactory = dataSourceFactory;
     this.minLoadableRetryCount = minLoadableRetryCount;
     this.eventDispatcher = eventDispatcher;
     this.allocator = allocator;
+    this.initialTrackSelectionFactory = initialTrackSelectionFactory;
     streamWrapperIndices = new IdentityHashMap<>();
     timestampAdjusterProvider = new TimestampAdjusterProvider();
     continueLoadingHandler = new Handler();
@@ -345,7 +348,7 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsSampleStreamWrapper
   private HlsSampleStreamWrapper buildSampleStreamWrapper(int trackType, HlsUrl[] variants,
       Format muxedAudioFormat, List<Format> muxedCaptionFormats, long positionUs) {
     HlsChunkSource defaultChunkSource = new HlsChunkSource(playlistTracker, variants,
-        dataSourceFactory, timestampAdjusterProvider, muxedCaptionFormats);
+        dataSourceFactory, timestampAdjusterProvider, muxedCaptionFormats, initialTrackSelectionFactory);
     return new HlsSampleStreamWrapper(trackType, this, defaultChunkSource, allocator, positionUs,
         muxedAudioFormat, minLoadableRetryCount, eventDispatcher);
   }

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaSource.java
@@ -17,6 +17,7 @@ package com.google.android.exoplayer2.source.hls;
 
 import android.net.Uri;
 import android.os.Handler;
+
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
@@ -27,9 +28,11 @@ import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.SinglePeriodTimeline;
 import com.google.android.exoplayer2.source.hls.playlist.HlsMediaPlaylist;
 import com.google.android.exoplayer2.source.hls.playlist.HlsPlaylistTracker;
+import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.upstream.Allocator;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.util.Assertions;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -52,6 +55,7 @@ public final class HlsMediaSource implements MediaSource,
   private final HlsDataSourceFactory dataSourceFactory;
   private final int minLoadableRetryCount;
   private final EventDispatcher eventDispatcher;
+  private final TrackSelection.Factory initialTrackSelectionFactory;
 
   private HlsPlaylistTracker playlistTracker;
   private Listener sourceListener;
@@ -66,16 +70,17 @@ public final class HlsMediaSource implements MediaSource,
       int minLoadableRetryCount, Handler eventHandler,
       AdaptiveMediaSourceEventListener eventListener) {
     this(manifestUri, new DefaultHlsDataSourceFactory(dataSourceFactory), minLoadableRetryCount,
-        eventHandler, eventListener);
+        eventHandler, eventListener, null);
   }
 
   public HlsMediaSource(Uri manifestUri, HlsDataSourceFactory dataSourceFactory,
       int minLoadableRetryCount, Handler eventHandler,
-      AdaptiveMediaSourceEventListener eventListener) {
+      AdaptiveMediaSourceEventListener eventListener, TrackSelection.Factory initialTrackSelectionFactory) {
     this.manifestUri = manifestUri;
     this.dataSourceFactory = dataSourceFactory;
     this.minLoadableRetryCount = minLoadableRetryCount;
     eventDispatcher = new EventDispatcher(eventHandler, eventListener);
+    this.initialTrackSelectionFactory = initialTrackSelectionFactory;
   }
 
   @Override
@@ -96,7 +101,7 @@ public final class HlsMediaSource implements MediaSource,
   public MediaPeriod createPeriod(MediaPeriodId id, Allocator allocator) {
     Assertions.checkArgument(id.periodIndex == 0);
     return new HlsMediaPeriod(playlistTracker, dataSourceFactory, minLoadableRetryCount,
-        eventDispatcher, allocator);
+        eventDispatcher, allocator, initialTrackSelectionFactory);
   }
 
   @Override


### PR DESCRIPTION
To avoid situations where we download .ts files that we never intend to
play. #3293 