### PR TITLE
Allow multiple PSSH boxes for same system

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/DrmInitData.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/DrmInitData.java
@@ -22,6 +22,8 @@ import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.drm.DrmInitData.SchemeData;
 import com.google.android.exoplayer2.util.Assertions;
 import com.google.android.exoplayer2.util.Util;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -78,12 +80,7 @@ public final class DrmInitData implements Comparator<SchemeData>, Parcelable {
     // Sorting ensures that universal scheme data (i.e. data that applies to all schemes) is matched
     // last. It's also required by the equals and hashcode implementations.
     Arrays.sort(schemeDatas, this);
-    // Check for no duplicates.
-    for (int i = 1; i < schemeDatas.length; i++) {
-      if (schemeDatas[i - 1].uuid.equals(schemeDatas[i].uuid)) {
-        throw new IllegalArgumentException("Duplicate data for uuid: " + schemeDatas[i].uuid);
-      }
-    }
+
     this.schemeDatas = schemeDatas;
     schemeDataCount = schemeDatas.length;
   }
@@ -97,9 +94,11 @@ public final class DrmInitData implements Comparator<SchemeData>, Parcelable {
   /**
    * Retrieves data for a given DRM scheme, specified by its UUID.
    *
+   * @deprecated This will only get the first data found for the scheme.
    * @param uuid The DRM scheme's UUID.
    * @return The initialization data for the scheme, or null if the scheme is not supported.
    */
+  @Deprecated
   public SchemeData get(UUID uuid) {
     for (SchemeData schemeData : schemeDatas) {
       if (schemeData.matches(uuid)) {
@@ -112,7 +111,7 @@ public final class DrmInitData implements Comparator<SchemeData>, Parcelable {
   /**
    * Retrieves the {@link SchemeData} at a given index.
    *
-   * @param index index of the scheme to return.
+   * @param index index of the scheme to return. Must not exceed {@link #schemeDataCount}.
    * @return The {@link SchemeData} at the index.
    */
   public SchemeData get(int index) {

--- a/library/core/src/test/java/com/google/android/exoplayer2/drm/DrmInitDataTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/drm/DrmInitDataTest.java
@@ -31,6 +31,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Unit test for {@link DrmInitData}.
  */
@@ -97,6 +100,7 @@ public class DrmInitDataTest {
   }
 
   @Test
+  @Deprecated
   public void testGet() {
     // Basic matching.
     DrmInitData testInitData = new DrmInitData(DATA_1, DATA_2);
@@ -124,27 +128,22 @@ public class DrmInitDataTest {
   }
 
   @Test
-  public void testDuplicateSchemeDataRejected() {
-    try {
-      new DrmInitData(DATA_1, DATA_1);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // Expected.
-    }
+  public void testGetByIndex() {
+    DrmInitData testInitData = new DrmInitData(DATA_1, DATA_2);
+    assertThat(getAllSchemeData(testInitData)).containsAllOf(DATA_1, DATA_2);
+  }
 
-    try {
-      new DrmInitData(DATA_1, DATA_1B);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // Expected.
-    }
+  @Test
+  public void testDuplicateSchemeData() {
+    DrmInitData testInitData = new DrmInitData(DATA_1, DATA_1);
+    assertThat(testInitData.schemeDataCount).isEqualTo(2);
 
-    try {
-      new DrmInitData(DATA_1, DATA_2, DATA_1B);
-      fail();
-    } catch (IllegalArgumentException e) {
-      // Expected.
-    }
+    testInitData = new DrmInitData(DATA_1, DATA_2, DATA_1B);
+    assertThat(testInitData.schemeDataCount).isEqualTo(3);
+    assertThat(getAllSchemeData(testInitData)).containsAllOf(DATA_1, DATA_1B, DATA_2);
+    // Deprecated get method should return first entry
+    assertThat(testInitData.get(WIDEVINE_UUID)).isEqualTo(DATA_1);
+    assertThat(testInitData.get(PLAYREADY_UUID)).isEqualTo(DATA_2);
   }
 
   @Test
@@ -160,6 +159,14 @@ public class DrmInitDataTest {
     assertThat(DATA_UNIVERSAL.matches(WIDEVINE_UUID)).isTrue();
     assertThat(DATA_UNIVERSAL.matches(PLAYREADY_UUID)).isTrue();
     assertThat(DATA_UNIVERSAL.matches(UUID_NIL)).isTrue();
+  }
+
+  private List<SchemeData> getAllSchemeData(DrmInitData drmInitData) {
+    ArrayList<SchemeData> schemeDatas = new ArrayList<>();
+    for (int i = 0; i < drmInitData.schemeDataCount; i++) {
+      schemeDatas.add(drmInitData.get(i));
+    }
+    return schemeDatas;
   }
 
 }


### PR DESCRIPTION
Updates DefaultDrmSessionManager to use the prefered Widevine version (v1 on >= 23 and v0 for < 23).
For other DRM schemes, uses the first scheme found.

This lets the player successfully play content with both headers.

This is the implementation discussed in the comments of https://github.com/google/ExoPlayer/pull/3217 - see that PR for more information.
