### PR TITLE
Fix FLV AVCVIDEOPACKET  CTS Type Issue

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/flv/VideoTagPayloadReader.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/flv/VideoTagPayloadReader.java
@@ -80,6 +80,9 @@ import com.google.android.exoplayer2.video.AvcConfig;
   protected void parsePayload(ParsableByteArray data, long timeUs) throws ParserException {
     int packetType = data.readUnsignedByte();
     int compositionTimeMs = data.readUnsignedInt24();
+    // compositionTimeMs is signed int 24, change unsigned int 24 to signed int 24
+    compositionTimeMs = (compositionTimeMs & 0x800000) >> 23 == 1 ? (compositionTimeMs & 0xff000000) : compositionTimeMs;
+
     timeUs += compositionTimeMs * 1000L;
     // Parse avc sequence header in case this was not done before.
     if (packetType == AVC_PACKET_TYPE_SEQUENCE_HEADER && !hasOutputFormat) {

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/flv/VideoTagPayloadReader.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/flv/VideoTagPayloadReader.java
@@ -81,7 +81,7 @@ import com.google.android.exoplayer2.video.AvcConfig;
     int packetType = data.readUnsignedByte();
     int compositionTimeMs = data.readUnsignedInt24();
     // compositionTimeMs is signed int 24, change unsigned int 24 to signed int 24
-    compositionTimeMs = (compositionTimeMs & 0x800000) >> 23 == 1 ? (compositionTimeMs & 0xff000000) : compositionTimeMs;
+    compositionTimeMs = (compositionTimeMs & 0x800000L) >>> 23 == 1 ? (compositionTimeMs | 0xff000000) : compositionTimeMs;
 
     timeUs += compositionTimeMs * 1000L;
     // Parse avc sequence header in case this was not done before.

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/flv/VideoTagPayloadReader.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/flv/VideoTagPayloadReader.java
@@ -79,9 +79,7 @@ import com.google.android.exoplayer2.video.AvcConfig;
   @Override
   protected void parsePayload(ParsableByteArray data, long timeUs) throws ParserException {
     int packetType = data.readUnsignedByte();
-    int compositionTimeMs = data.readUnsignedInt24();
-    // compositionTimeMs is signed int 24, change unsigned int 24 to signed int 24
-    compositionTimeMs = (compositionTimeMs & 0x800000L) >>> 23 == 1 ? (compositionTimeMs | 0xff000000) : compositionTimeMs;
+    int compositionTimeMs = data.readSignedInt24();
 
     timeUs += compositionTimeMs * 1000L;
     // Parse avc sequence header in case this was not done before.

--- a/library/core/src/main/java/com/google/android/exoplayer2/util/ParsableByteArray.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/ParsableByteArray.java
@@ -257,6 +257,14 @@ public final class ParsableByteArray {
   }
 
   /**
+   * Reads the next three bytes as an signed value.
+   */
+  public int readSignedInt24() {
+    int ui24 = readUnsignedInt24();
+    return (ui24 & 0x800000L) >>> 23 == 1 ? (ui24 | 0xff000000) : ui24;
+  }
+
+  /**
    * Reads the next three bytes as a signed value in little endian order.
    */
   public int readLittleEndianInt24() {

--- a/library/core/src/test/java/com/google/android/exoplayer2/util/ParsableByteArrayTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/util/ParsableByteArrayTest.java
@@ -335,6 +335,22 @@ public final class ParsableByteArrayTest {
   }
 
   @Test
+  public void testReadPositiveSignedInt24() {
+    byte[] data = { 0x01, 0x02, (byte) 0xFF };
+    ParsableByteArray byteArray = new ParsableByteArray(data);
+    assertThat(byteArray.readSignedInt24()).isEqualTo(0x0102FF);
+    assertThat(byteArray.getPosition()).isEqualTo(3);
+  }
+
+  @Test
+  public void testReadNegativeSignedInt24() {
+    byte[] data = { (byte)0xFF, 0x02, (byte) 0x01 };
+    ParsableByteArray byteArray = new ParsableByteArray(data);
+    assertThat(byteArray.readSignedInt24()).isEqualTo(0xFFFF0201);
+    assertThat(byteArray.getPosition()).isEqualTo(3);
+  }
+
+  @Test
   public void testReadLittleEndianUnsignedShort() {
     ParsableByteArray byteArray = new ParsableByteArray(new byte[] {
         0x01, (byte) 0xFF, 0x02, (byte) 0xFF


### PR DESCRIPTION
AVCVIDEOPACKET --> compositionTimeMs should be SI 24, not UI24.
refer to FLV 1.0 Format Document
http://wwwimages.adobe.com/content/dam/acom/en/devnet/flv/video_file_format_spec_v10.pdf
Page 10

As is
If compositionTimeMs is negative, when call data.readUnsignedInt24() will get a much larger number

Tobe
Support negative compositionTimeMs, that is to say support non sequential timestamp. 
compositionTimeMs can be both positive and negtive