### PR TITLE
Upgrade to Android Plugin for Gradle 3.0.0-rc2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
+        classpath 'com.android.tools.build:gradle:3.0.0-rc2'
         classpath 'com.novoda:bintray-release:0.5.0'
     }
     // Workaround for the following test coverage issue. Remove when fixed:


### PR DESCRIPTION
Upgrade to Android Plugin for Gradle 3.0.0-rc2. Required by Android Studio 3.0 RC 2.