### PR TITLE
Dev v2 ffmpegfloat

### DIFF
--- a/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegAudioRenderer.java
+++ b/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegAudioRenderer.java
@@ -67,7 +67,7 @@ public final class FfmpegAudioRenderer extends SimpleDecoderAudioRenderer {
     String sampleMimeType = format.sampleMimeType;
     if (!FfmpegLibrary.isAvailable() || !MimeTypes.isAudio(sampleMimeType)) {
       return FORMAT_UNSUPPORTED_TYPE;
-    } else if (!FfmpegLibrary.supportsFormat(sampleMimeType)) {
+    } else if (!FfmpegLibrary.supportsFormat(sampleMimeType, format.pcmEncoding)) {
       return FORMAT_UNSUPPORTED_SUBTYPE;
     } else if (!supportsFormatDrm(drmSessionManager, format.drmInitData)) {
       return FORMAT_UNSUPPORTED_DRM;
@@ -85,8 +85,7 @@ public final class FfmpegAudioRenderer extends SimpleDecoderAudioRenderer {
   protected FfmpegDecoder createDecoder(Format format, ExoMediaCrypto mediaCrypto)
       throws FfmpegDecoderException {
     decoder = new FfmpegDecoder(NUM_BUFFERS, NUM_BUFFERS, INITIAL_INPUT_BUFFER_SIZE,
-        format.sampleMimeType, format.initializationData,
-        Util.canHandleFloatAudio(audioCapabilities, format.channelCount));
+        format, Util.canHandleFloatAudio(audioCapabilities, format.channelCount));
     return decoder;
   }
 

--- a/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegDecoder.java
+++ b/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegDecoder.java
@@ -16,6 +16,7 @@
 package com.google.android.exoplayer2.ext.ffmpeg;
 
 import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.decoder.DecoderInputBuffer;
 import com.google.android.exoplayer2.decoder.SimpleDecoder;
 import com.google.android.exoplayer2.decoder.SimpleOutputBuffer;
@@ -45,7 +46,7 @@ import java.util.List;
   private final int outputBufferSize;
 
   public FfmpegDecoder(int numInputBuffers, int numOutputBuffers, int initialInputBufferSize,
-      String mimeType, List<byte[]> initializationData, boolean useFloatOutput)
+      Format format, boolean useFloatOutput)
    throws FfmpegDecoderException {
     super(new DecoderInputBuffer[numInputBuffers], new SimpleOutputBuffer[numOutputBuffers]);
     if (!FfmpegLibrary.isAvailable()) {
@@ -53,8 +54,8 @@ import java.util.List;
     }
     this.useFloatOutput = useFloatOutput;
     outputBufferSize = useFloatOutput ? OUTPUT_BUFFER_SIZE_32BIT : OUTPUT_BUFFER_SIZE;
-    codecName = FfmpegLibrary.getCodecName(mimeType);
-    extraData = getExtraData(mimeType, initializationData);
+    codecName = FfmpegLibrary.getCodecName(format.sampleMimeType, format.pcmEncoding);
+    extraData = getExtraData(format.sampleMimeType, format.initializationData);
     nativeContext = ffmpegInitialize(codecName, extraData, useFloatOutput);
     if (nativeContext == 0) {
       throw new FfmpegDecoderException("Initialization failed.");
@@ -138,6 +139,7 @@ import java.util.List;
    */
   private static byte[] getExtraData(String mimeType, List<byte[]> initializationData) {
     switch (mimeType) {
+      case MimeTypes.AUDIO_RAW:
       case MimeTypes.AUDIO_AAC:
       case MimeTypes.AUDIO_ALAC:
       case MimeTypes.AUDIO_OPUS:

--- a/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegDecoder.java
+++ b/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegDecoder.java
@@ -56,7 +56,8 @@ import java.util.List;
     outputBufferSize = useFloatOutput ? OUTPUT_BUFFER_SIZE_32BIT : OUTPUT_BUFFER_SIZE;
     codecName = FfmpegLibrary.getCodecName(format.sampleMimeType, format.pcmEncoding);
     extraData = getExtraData(format.sampleMimeType, format.initializationData);
-    nativeContext = ffmpegInitialize(codecName, extraData, useFloatOutput);
+    nativeContext = ffmpegInitialize(codecName, extraData, useFloatOutput,
+        format.channelCount, format.sampleRate);
     if (nativeContext == 0) {
       throw new FfmpegDecoderException("Initialization failed.");
     }
@@ -143,7 +144,9 @@ import java.util.List;
       case MimeTypes.AUDIO_AAC:
       case MimeTypes.AUDIO_ALAC:
       case MimeTypes.AUDIO_OPUS:
-        return initializationData.get(0);
+        if (!initializationData.isEmpty())
+          return initializationData.get(0);
+        return null;
       case MimeTypes.AUDIO_VORBIS:
         byte[] header0 = initializationData.get(0);
         byte[] header1 = initializationData.get(1);
@@ -169,7 +172,8 @@ import java.util.List;
     return useFloatOutput ? C.ENCODING_PCM_FLOAT : C.ENCODING_PCM_16BIT;
   }
 
-  private native long ffmpegInitialize(String codecName, byte[] extraData, boolean useFloatOutput);
+  private native long ffmpegInitialize(String codecName, byte[] extraData,
+      boolean useFloatOutput, int inputChannelCount, int inputSampleRate);
   private native int ffmpegDecode(long context, ByteBuffer inputData, int inputSize,
       ByteBuffer outputData, int outputSize);
   private native int ffmpegGetChannelCount(long context);

--- a/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegDecoder.java
+++ b/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegDecoder.java
@@ -15,6 +15,7 @@
  */
 package com.google.android.exoplayer2.ext.ffmpeg;
 
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.decoder.DecoderInputBuffer;
 import com.google.android.exoplayer2.decoder.SimpleDecoder;
 import com.google.android.exoplayer2.decoder.SimpleOutputBuffer;
@@ -31,7 +32,8 @@ import java.util.List;
 
   // Space for 64 ms of 6 channel 48 kHz 16-bit PCM audio.
   private static final int OUTPUT_BUFFER_SIZE = 1536 * 6 * 2 * 2;
-
+  // Space for 64 ms of 8 channel 48 kHz 32-bit PCM audio.
+  private static final int OUTPUT_BUFFER_SIZE_32BIT = OUTPUT_BUFFER_SIZE * 2;
   private final String codecName;
   private final byte[] extraData;
 
@@ -39,16 +41,21 @@ import java.util.List;
   private boolean hasOutputFormat;
   private volatile int channelCount;
   private volatile int sampleRate;
+  private final boolean useFloatOutput;
+  private final int outputBufferSize;
 
   public FfmpegDecoder(int numInputBuffers, int numOutputBuffers, int initialInputBufferSize,
-      String mimeType, List<byte[]> initializationData) throws FfmpegDecoderException {
+      String mimeType, List<byte[]> initializationData, boolean useFloatOutput)
+   throws FfmpegDecoderException {
     super(new DecoderInputBuffer[numInputBuffers], new SimpleOutputBuffer[numOutputBuffers]);
     if (!FfmpegLibrary.isAvailable()) {
       throw new FfmpegDecoderException("Failed to load decoder native libraries.");
     }
+    this.useFloatOutput = useFloatOutput;
+    outputBufferSize = useFloatOutput ? OUTPUT_BUFFER_SIZE_32BIT : OUTPUT_BUFFER_SIZE;
     codecName = FfmpegLibrary.getCodecName(mimeType);
     extraData = getExtraData(mimeType, initializationData);
-    nativeContext = ffmpegInitialize(codecName, extraData);
+    nativeContext = ffmpegInitialize(codecName, extraData, useFloatOutput);
     if (nativeContext == 0) {
       throw new FfmpegDecoderException("Initialization failed.");
     }
@@ -81,8 +88,9 @@ import java.util.List;
     }
     ByteBuffer inputData = inputBuffer.data;
     int inputSize = inputData.limit();
-    ByteBuffer outputData = outputBuffer.init(inputBuffer.timeUs, OUTPUT_BUFFER_SIZE);
-    int result = ffmpegDecode(nativeContext, inputData, inputSize, outputData, OUTPUT_BUFFER_SIZE);
+
+    ByteBuffer outputData = outputBuffer.init(inputBuffer.timeUs, outputBufferSize);
+    int result = ffmpegDecode(nativeContext, inputData, inputSize, outputData, outputBufferSize);
     if (result < 0) {
       return new FfmpegDecoderException("Error decoding (see logcat). Code: " + result);
     }
@@ -153,7 +161,13 @@ import java.util.List;
     }
   }
 
-  private native long ffmpegInitialize(String codecName, byte[] extraData);
+
+  public @C.PcmEncoding int getOutputEncoding() {
+
+    return useFloatOutput ? C.ENCODING_PCM_FLOAT : C.ENCODING_PCM_16BIT;
+  }
+
+  private native long ffmpegInitialize(String codecName, byte[] extraData, boolean useFloatOutput);
   private native int ffmpegDecode(long context, ByteBuffer inputData, int inputSize,
       ByteBuffer outputData, int outputSize);
   private native int ffmpegGetChannelCount(long context);

--- a/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegLibrary.java
+++ b/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegLibrary.java
@@ -15,7 +15,9 @@
  */
 package com.google.android.exoplayer2.ext.ffmpeg;
 
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
+import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.util.LibraryLoader;
 import com.google.android.exoplayer2.util.MimeTypes;
 
@@ -62,19 +64,20 @@ public final class FfmpegLibrary {
    * Returns whether the underlying library supports the specified MIME type.
    *
    * @param mimeType The MIME type to check.
+   * @param pcmEncoding
    */
-  public static boolean supportsFormat(String mimeType) {
+  public static boolean supportsFormat(String mimeType, @C.PcmEncoding int pcmEncoding) {
     if (!isAvailable()) {
       return false;
     }
-    String codecName = getCodecName(mimeType);
+    String codecName = getCodecName(mimeType, pcmEncoding);
     return codecName != null && ffmpegHasDecoder(codecName);
   }
 
   /**
    * Returns the name of the FFmpeg decoder that could be used to decode {@code mimeType}.
    */
-  /* package */ static String getCodecName(String mimeType) {
+  /* package */ static String getCodecName(String mimeType, @C.PcmEncoding int pcmEncoding) {
     switch (mimeType) {
       case MimeTypes.AUDIO_AAC:
         return "aac";
@@ -103,6 +106,23 @@ public final class FfmpegLibrary {
         return "flac";
       case MimeTypes.AUDIO_ALAC:
         return "alac";
+      case MimeTypes.AUDIO_RAW:
+        switch (pcmEncoding) {
+          case C.ENCODING_PCM_8BIT:
+            return "pcm_u8";
+          case C.ENCODING_PCM_16BIT:
+            return "pcm_s16le";
+          case C.ENCODING_PCM_24BIT:
+            return "pcm_s24le";
+          case C.ENCODING_PCM_32BIT:
+            return "pcm_s32le";
+          case C.ENCODING_PCM_FLOAT:
+            return "pcm_f32le";
+          default:
+          case C.ENCODING_INVALID:
+          case Format.NO_VALUE:
+            return null;
+        }
       default:
         return null;
     }

--- a/extensions/ffmpeg/src/main/jni/ffmpeg_jni.cc
+++ b/extensions/ffmpeg/src/main/jni/ffmpeg_jni.cc
@@ -60,6 +60,9 @@ extern "C" {
 // Request a format corresponding to AudioFormat.ENCODING_PCM_16BIT.
 static const AVSampleFormat OUTPUT_FORMAT = AV_SAMPLE_FMT_S16;
 
+// Request a format corresponding to AudioFormat.ENCODING_PCM_FLOAT.
+static const AVSampleFormat OUTPUT_FORMAT_32FLOAT = AV_SAMPLE_FMT_FLT;
+
 /**
  * Returns the AVCodec with the specified name, or NULL if it is not available.
  */
@@ -71,7 +74,7 @@ AVCodec *getCodecByName(JNIEnv* env, jstring codecName);
  * Returns the created context.
  */
 AVCodecContext *createContext(JNIEnv *env, AVCodec *codec,
-                              jbyteArray extraData);
+                              jbyteArray extraData, jboolean use32BitFloatOutput);
 
 /**
  * Decodes the packet into the output buffer, returning the number of bytes
@@ -107,13 +110,13 @@ LIBRARY_FUNC(jboolean, ffmpegHasDecoder, jstring codecName) {
   return getCodecByName(env, codecName) != NULL;
 }
 
-DECODER_FUNC(jlong, ffmpegInitialize, jstring codecName, jbyteArray extraData) {
+DECODER_FUNC(jlong, ffmpegInitialize, jstring codecName, jbyteArray extraData, jboolean use32BitFloatOutput) {
   AVCodec *codec = getCodecByName(env, codecName);
   if (!codec) {
     LOGE("Codec not found.");
     return 0L;
   }
-  return (jlong) createContext(env, codec, extraData);
+  return (jlong) createContext(env, codec, extraData, use32BitFloatOutput);
 }
 
 DECODER_FUNC(jint, ffmpegDecode, jlong context, jobject inputData,
@@ -169,6 +172,8 @@ DECODER_FUNC(jlong, ffmpegReset, jlong jContext, jbyteArray extraData) {
 
   AVCodecID codecId = context->codec_id;
   if (codecId == AV_CODEC_ID_TRUEHD) {
+
+    const bool use32BitFloatOutput = context->request_sample_fmt == OUTPUT_FORMAT_32FLOAT;
     // Release and recreate the context if the codec is TrueHD.
     // TODO: Figure out why flushing doesn't work for this codec.
     releaseContext(context);
@@ -177,7 +182,7 @@ DECODER_FUNC(jlong, ffmpegReset, jlong jContext, jbyteArray extraData) {
       LOGE("Unexpected error finding codec %d.", codecId);
       return 0L;
     }
-    return (jlong) createContext(env, codec, extraData);
+    return (jlong) createContext(env, codec, extraData, use32BitFloatOutput);
   }
 
   avcodec_flush_buffers(context);
@@ -201,13 +206,13 @@ AVCodec *getCodecByName(JNIEnv* env, jstring codecName) {
 }
 
 AVCodecContext *createContext(JNIEnv *env, AVCodec *codec,
-                              jbyteArray extraData) {
+                              jbyteArray extraData, jboolean use32BitFloatOutput) {
   AVCodecContext *context = avcodec_alloc_context3(codec);
   if (!context) {
     LOGE("Failed to allocate context.");
     return NULL;
   }
-  context->request_sample_fmt = OUTPUT_FORMAT;
+  context->request_sample_fmt = use32BitFloatOutput ? OUTPUT_FORMAT_32FLOAT : OUTPUT_FORMAT;
   if (extraData) {
     jsize size = env->GetArrayLength(extraData);
     context->extradata_size = size;
@@ -275,7 +280,7 @@ int decodePacket(AVCodecContext *context, AVPacket *packet,
       av_opt_set_int(resampleContext, "in_sample_rate", sampleRate, 0);
       av_opt_set_int(resampleContext, "out_sample_rate", sampleRate, 0);
       av_opt_set_int(resampleContext, "in_sample_fmt", sampleFormat, 0);
-      av_opt_set_int(resampleContext, "out_sample_fmt", OUTPUT_FORMAT, 0);
+      av_opt_set_int(resampleContext, "out_sample_fmt", context->request_sample_fmt, 0);
       result = avresample_open(resampleContext);
       if (result < 0) {
         logError("avresample_open", result);
@@ -285,7 +290,7 @@ int decodePacket(AVCodecContext *context, AVPacket *packet,
       context->opaque = resampleContext;
     }
     int inSampleSize = av_get_bytes_per_sample(sampleFormat);
-    int outSampleSize = av_get_bytes_per_sample(OUTPUT_FORMAT);
+    int outSampleSize = av_get_bytes_per_sample(context->request_sample_fmt);
     int outSamples = avresample_get_out_samples(resampleContext, sampleCount);
     int bufferOutSize = outSampleSize * channelCount * outSamples;
     if (outSize + bufferOutSize > outputSize) {

--- a/extensions/ffmpeg/src/main/jni/ffmpeg_jni.cc
+++ b/extensions/ffmpeg/src/main/jni/ffmpeg_jni.cc
@@ -29,6 +29,7 @@ extern "C" {
 #include <libavresample/avresample.h>
 #include <libavutil/error.h>
 #include <libavutil/opt.h>
+#include <libavutil/channel_layout.h>
 }
 
 #define LOG_TAG "ffmpeg_jni"
@@ -74,7 +75,8 @@ AVCodec *getCodecByName(JNIEnv* env, jstring codecName);
  * Returns the created context.
  */
 AVCodecContext *createContext(JNIEnv *env, AVCodec *codec,
-                              jbyteArray extraData, jboolean use32BitFloatOutput);
+                              jbyteArray extraData, jboolean use32BitFloatOutput,
+                              jint inputChannelCount, jint inputSampleRate);
 
 /**
  * Decodes the packet into the output buffer, returning the number of bytes
@@ -110,13 +112,15 @@ LIBRARY_FUNC(jboolean, ffmpegHasDecoder, jstring codecName) {
   return getCodecByName(env, codecName) != NULL;
 }
 
-DECODER_FUNC(jlong, ffmpegInitialize, jstring codecName, jbyteArray extraData, jboolean use32BitFloatOutput) {
+DECODER_FUNC(jlong, ffmpegInitialize, jstring codecName, jbyteArray extraData,
+    jboolean use32BitFloatOutput, jint inputChannelCount, jint inputSampleRate) {
   AVCodec *codec = getCodecByName(env, codecName);
   if (!codec) {
     LOGE("Codec not found.");
     return 0L;
   }
-  return (jlong) createContext(env, codec, extraData, use32BitFloatOutput);
+  return (jlong) createContext(env, codec, extraData,
+      use32BitFloatOutput, inputChannelCount, inputSampleRate);
 }
 
 DECODER_FUNC(jint, ffmpegDecode, jlong context, jobject inputData,
@@ -174,6 +178,8 @@ DECODER_FUNC(jlong, ffmpegReset, jlong jContext, jbyteArray extraData) {
   if (codecId == AV_CODEC_ID_TRUEHD) {
 
     const bool use32BitFloatOutput = context->request_sample_fmt == OUTPUT_FORMAT_32FLOAT;
+    const int channelCount = context->channels;
+    const int sampleRate = context->sample_rate;
     // Release and recreate the context if the codec is TrueHD.
     // TODO: Figure out why flushing doesn't work for this codec.
     releaseContext(context);
@@ -182,7 +188,8 @@ DECODER_FUNC(jlong, ffmpegReset, jlong jContext, jbyteArray extraData) {
       LOGE("Unexpected error finding codec %d.", codecId);
       return 0L;
     }
-    return (jlong) createContext(env, codec, extraData, use32BitFloatOutput);
+    return (jlong) createContext(env, codec, extraData,
+        use32BitFloatOutput, channelCount, sampleRate);
   }
 
   avcodec_flush_buffers(context);
@@ -206,15 +213,19 @@ AVCodec *getCodecByName(JNIEnv* env, jstring codecName) {
 }
 
 AVCodecContext *createContext(JNIEnv *env, AVCodec *codec,
-                              jbyteArray extraData, jboolean use32BitFloatOutput) {
+                              jbyteArray extraData, jboolean use32BitFloatOutput,
+                              jint inputChannelCount, jint inputSampleRate) {
   AVCodecContext *context = avcodec_alloc_context3(codec);
   if (!context) {
     LOGE("Failed to allocate context.");
     return NULL;
   }
 
-    LOGE("Use float %d", use32BitFloatOutput);
   context->request_sample_fmt = use32BitFloatOutput ? OUTPUT_FORMAT_32FLOAT : OUTPUT_FORMAT;
+  AVCodecID codecId = context->codec_id;
+  const bool isPCMInput = (codecId == AV_CODEC_ID_PCM_U8 || codecId == AV_CODEC_ID_PCM_S16LE ||
+                           codecId == AV_CODEC_ID_PCM_S24LE || codecId == AV_CODEC_ID_PCM_S32LE ||
+                           codecId == AV_CODEC_ID_PCM_F32LE);
   if (extraData) {
     jsize size = env->GetArrayLength(extraData);
     context->extradata_size = size;
@@ -226,20 +237,47 @@ AVCodecContext *createContext(JNIEnv *env, AVCodec *codec,
       return NULL;
     }
     env->GetByteArrayRegion(extraData, 0, size, (jbyte *) context->extradata);
-    AVCodecID codecId = context->codec_id;
-      if (codecId == AV_CODEC_ID_PCM_U8 ||
-          codecId == AV_CODEC_ID_PCM_S16LE ||
-          codecId == AV_CODEC_ID_PCM_S24LE ||
-          codecId == AV_CODEC_ID_PCM_S32LE ||
-          codecId == AV_CODEC_ID_PCM_F32LE) {
-        context->channels = ((uint16_t *) context->extradata)[1];
-        context->sample_rate = ((uint32_t *) context->extradata)[1];
-        // if it's a WAVEFORMATEXTENSIBLE get the layout
-        if (0xFFFE == ((uint16_t *) context->extradata)[0] && 24 <= size) {
-          uint32_t layout = ((uint32_t *) context->extradata)[5];
-          context->channel_layout = (uint64_t) layout;
-        }
+    if (isPCMInput) {
+      context->channels = ((uint16_t *) context->extradata)[1];
+      context->sample_rate = ((uint32_t *) context->extradata)[1];
+      // if it's a WAVEFORMATEXTENSIBLE get the layout
+      if (0xFFFE == ((uint16_t *) context->extradata)[0] && 24 <= size) {
+        uint32_t layout = ((uint32_t *) context->extradata)[5];
+        context->channel_layout = (uint64_t) layout;
       }
+    }
+  } else if (isPCMInput) {
+    // we should only get in here in the case of mono pcm tracks (maybe stereo?)
+    // surround tracks should have extra data with them
+    context->channels = inputChannelCount;
+    context->sample_rate = inputSampleRate;
+    switch(inputChannelCount) {
+     case 0:
+     case 1:
+       context->channel_layout = AV_CH_LAYOUT_MONO;
+       break;
+     case 2:
+       context->channel_layout = AV_CH_LAYOUT_STEREO;
+       break;
+     case 3:
+       context->channel_layout = AV_CH_LAYOUT_2POINT1;
+       break;
+     case 4:
+       context->channel_layout = AV_CH_LAYOUT_4POINT0;
+       break;
+     case 5:
+       context->channel_layout = AV_CH_LAYOUT_4POINT1;
+       break;
+     case 6:
+       context->channel_layout = AV_CH_LAYOUT_5POINT1;
+       break;
+     case 7:
+       context->channel_layout = AV_CH_LAYOUT_6POINT1;
+       break;
+     case 8:
+       context->channel_layout = AV_CH_LAYOUT_7POINT1;
+       break;
+    }
   }
   int result = avcodec_open2(context, codec, NULL);
   if (result < 0) {

--- a/library/core/src/main/java/com/google/android/exoplayer2/DefaultRenderersFactory.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/DefaultRenderersFactory.java
@@ -263,9 +263,9 @@ public class DefaultRenderersFactory implements RenderersFactory {
       Class<?> clazz =
           Class.forName("com.google.android.exoplayer2.ext.ffmpeg.FfmpegAudioRenderer");
       Constructor<?> constructor = clazz.getConstructor(Handler.class,
-          AudioRendererEventListener.class, AudioProcessor[].class);
+          AudioRendererEventListener.class, AudioCapabilities.class, AudioProcessor[].class);
       Renderer renderer = (Renderer) constructor.newInstance(eventHandler, eventListener,
-          audioProcessors);
+          AudioCapabilities.getCapabilities(context), audioProcessors);
       out.add(extensionRendererIndex++, renderer);
       Log.i(TAG, "Loaded FfmpegAudioRenderer.");
     } catch (ClassNotFoundException e) {

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/mkv/MatroskaExtractor.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/mkv/MatroskaExtractor.java
@@ -1685,6 +1685,7 @@ public final class MatroskaExtractor implements Extractor {
           mimeType = MimeTypes.AUDIO_RAW;
           if (parseMsAcmCodecPrivate(new ParsableByteArray(codecPrivate))) {
             pcmEncoding = Util.getPcmEncoding(audioBitDepth);
+            initializationData = Collections.singletonList(codecPrivate);
             if (pcmEncoding == C.ENCODING_INVALID) {
               pcmEncoding = Format.NO_VALUE;
               mimeType = MimeTypes.AUDIO_UNKNOWN;

--- a/library/core/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -33,6 +33,7 @@ import android.view.WindowManager;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
 import com.google.android.exoplayer2.ParserException;
+import com.google.android.exoplayer2.audio.AudioCapabilities;
 import com.google.android.exoplayer2.upstream.DataSource;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -1240,4 +1241,8 @@ public final class Util {
       0XBCB4666D, 0XB8757BDA, 0XB5365D03, 0XB1F740B4
   };
 
+  public static boolean canHandleFloatAudio(AudioCapabilities audioCapabilities, int channelCount) {
+    return (audioCapabilities != null && audioCapabilities.supportsEncoding(C.ENCODING_PCM_FLOAT)
+     && ((Util.SDK_INT > 20 && channelCount <= 2) || (Util.SDK_INT >= 24)));
+  }
 }


### PR DESCRIPTION
This should solve two use cases.

1) enabled 32 float output for ffmpeg (if supported always on, currently)
2) enable PCM stream input for u8, s16, s24, s32, f32.  I'm not sure if there is much use having u8 and s16 capabilities, but the other formats can leverage float output to avoid dithering. 