### PR TITLE
Fix initializationData check for SSA subtitles

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -59,7 +59,7 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
    */
   public SsaDecoder(List<byte[]> initializationData) {
     super("SsaDecoder");
-    if (initializationData != null) {
+    if (initializationData != null && initializationData.size() > 0) {
       haveInitializationData = true;
       String formatLine = new String(initializationData.get(0));
       Assertions.checkArgument(formatLine.startsWith(FORMAT_LINE_PREFIX));


### PR DESCRIPTION
The `SssDecoder` supports not having `initializationData` provided, and will therefore try to parse this from the header/event body. However, it uses a `null` check on the `initializationData`. It doesn't appear to be possible to create a `Format` for text that actually uses `null` here. 

 - `Format.createTextSampleFormat` will use `Collections.<byte[]>emptyList()`
 - If you do manually specify a `null` parameter, the constructor converts this: `initializationData == null ? Collections.<byte[]>emptyList() : initializationData;`