### PR TITLE
Fix NPE in ExtractorMediaSource

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/source/ExtractorMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/ExtractorMediaSource.java
@@ -204,8 +204,10 @@ public final class ExtractorMediaSource implements MediaSource, ExtractorMediaPe
   private void notifySourceInfoRefreshed(long durationUs, boolean isSeekable) {
     timelineDurationUs = durationUs;
     timelineIsSeekable = isSeekable;
-    sourceListener.onSourceInfoRefreshed(
-        this, new SinglePeriodTimeline(timelineDurationUs, timelineIsSeekable), null);
+    if (sourceListener != null) {
+      sourceListener.onSourceInfoRefreshed(this,
+              new SinglePeriodTimeline(timelineDurationUs, timelineIsSeekable), null);
+    }
   }
 
 }


### PR DESCRIPTION
```
E/AndroidRuntime: FATAL EXCEPTION: ExoPlayerImplInternal:Handler
                                                                    Process: com.nike.ntc.inhouse, PID: 8388
                                                                    java.lang.NullPointerException: Attempt to invoke interface method 'void com.google.android.exoplayer2.source.MediaSource$Listener.onSourceInfoRefreshed(com.google.android.exoplayer2.source.MediaSource, com.google.android.exoplayer2.Timeline, java.lang.Object)' on a null object reference
                                                                        at com.google.android.exoplayer2.source.ExtractorMediaSource.notifySourceInfoRefreshed(ExtractorMediaSource.java:207)
                                                                        at com.google.android.exoplayer2.source.ExtractorMediaSource.onSourceInfoRefreshed(ExtractorMediaSource.java:199)
                                                                        at com.google.android.exoplayer2.source.ExtractorMediaPeriod.maybeFinishPrepare(ExtractorMediaPeriod.java:512)
                                                                        at com.google.android.exoplayer2.source.ExtractorMediaPeriod.access$000(ExtractorMediaPeriod.java:49)
                                                                        at com.google.android.exoplayer2.source.ExtractorMediaPeriod$1.run(ExtractorMediaPeriod.java:148)
                                                                        at android.os.Handler.handleCallback(Handler.java:790)
                                                                        at android.os.Handler.dispatchMessage(Handler.java:99)
                                                                        at android.os.Looper.loop(Looper.java:164)
                                                                        at android.os.HandlerThread.run(HandlerThread.java:65)
```