### PR TITLE
build libvpx with NDK r16

### DIFF
--- a/extensions/vp9/README.md
+++ b/extensions/vp9/README.md
@@ -29,8 +29,6 @@ VP9_EXT_PATH="${EXOPLAYER_ROOT}/extensions/vp9/src/main"
 ```
 
 * Download the [Android NDK][] and set its location in an environment variable.
-Only versions up to NDK 15c are supported currently (see [#3520][]).
-
 ```
 NDK_PATH="<path to Android NDK>"
 ```

--- a/extensions/vp9/src/main/jni/generate_libvpx_android_configs.sh
+++ b/extensions/vp9/src/main/jni/generate_libvpx_android_configs.sh
@@ -102,7 +102,7 @@ for i in $(seq 0 ${limit}); do
   # configure and make
   echo "build_android_configs: "
   echo "configure ${config[${i}]} ${common_params}"
-  ../../libvpx/configure ${config[${i}]} ${common_params}
+  ../../libvpx/configure ${config[${i}]} ${common_params} --extra-cflags="-isystem $ndk/sysroot/usr/include/arm-linux-androideabi -isystem $ndk/sysroot/usr/include"
   rm -f libvpx_srcs.txt
   for f in ${allowed_files}; do
     # the build system supports multiple different configurations. avoid


### PR DESCRIPTION
A minimal workaround to have libvpx built with NDK r16.