### PR TITLE
Upgrade library version

### DIFF
--- a/extensions/rtmp/build.gradle
+++ b/extensions/rtmp/build.gradle
@@ -26,7 +26,7 @@ android {
 
 dependencies {
     compile project(modulePrefix + 'library-core')
-    compile 'net.butterflytv.utils:rtmp-client:3.0.0'
+    compile 'net.butterflytv.utils:rtmp-client:3.0.1'
 }
 
 ext {


### PR DESCRIPTION
There was a bug in the lib. Exoplayer crashes if rtmp server is down. It is fixed.