### PR TITLE
More permissive SegmentTemplate format string handling

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/UrlTemplate.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/UrlTemplate.java
@@ -135,13 +135,10 @@ public final class UrlTemplate {
         if (identifier.equals(REPRESENTATION)) {
           identifiers[identifierCount] = REPRESENTATION_ID;
         } else {
-          int formatTagIndex = identifier.indexOf("%0");
+          int formatTagIndex = identifier.indexOf("%");
           String formatTag = DEFAULT_FORMAT_TAG;
           if (formatTagIndex != -1) {
             formatTag = identifier.substring(formatTagIndex);
-            if (!formatTag.endsWith("d")) {
-              formatTag += "d";
-            }
             identifier = identifier.substring(0, formatTagIndex);
           }
           switch (identifier) {


### PR DESCRIPTION
Permit all IEEE 1003.1 integer format specifiers; %d, %i, %o, %u, %x, %X.

Don't require zero-padding width to be specified.

Fixes erroneous handling of `$Number%08x$` or `$Number%u$` (which had an extra "d" suffix in the generated URL), and no longer accepts `$Number%0$` which is malformed.

ISO/IEC 23009-1:2014 § 5.3.9.4.4 is the relevant spec. The wording is a bit ambiguous but it appears to me that the intention is that all IEEE 1003.1 integer formats be accepted (otherwise why cite the IEEE spec just for zero-padded decimal?).