### PR TITLE
Added parsing of optional human-readable title #EXTINF:<duration>,[<title>]

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - oraclejdk7

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,0 @@
-jdk:
-  - oraclejdk7

--- a/library/hls/src/androidTest/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylistParserTest.java
+++ b/library/hls/src/androidTest/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylistParserTest.java
@@ -42,17 +42,17 @@ public class HlsMediaPlaylistParserTest extends TestCase {
         + "#EXT-X-DISCONTINUITY-SEQUENCE:4\n"
         + "#EXT-X-ALLOW-CACHE:YES\n"
         + "\n"
-        + "#EXTINF:7.975,\n"
+        + "#EXTINF:7.975,This is a human-readable title string.\n"
         + "#EXT-X-BYTERANGE:51370@0\n"
         + "https://priv.example.com/fileSequence2679.ts\n"
         + "\n"
         + "#EXT-X-KEY:METHOD=AES-128,URI=\"https://priv.example.com/key.php?r=2680\",IV=0x1566B\n"
-        + "#EXTINF:7.975,\n"
+        + "#EXTINF:7.975,Title with a url https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.2.1\n"
         + "#EXT-X-BYTERANGE:51501@2147483648\n"
         + "https://priv.example.com/fileSequence2680.ts\n"
         + "\n"
         + "#EXT-X-KEY:METHOD=NONE\n"
-        + "#EXTINF:7.941,\n"
+        + "#EXTINF:7.941,Title with a uuid 123e4567-e89b-12d3-a456-426655440000\n"
         + "#EXT-X-BYTERANGE:51501\n" // @2147535149
         + "https://priv.example.com/fileSequence2681.ts\n"
         + "\n"
@@ -85,6 +85,7 @@ public class HlsMediaPlaylistParserTest extends TestCase {
       Segment segment = segments.get(0);
       assertEquals(4, mediaPlaylist.discontinuitySequence + segment.relativeDiscontinuitySequence);
       assertEquals(7975000, segment.durationUs);
+      assertEquals("This is a human-readable title string.", segment.title);
       assertNull(segment.fullSegmentEncryptionKeyUri);
       assertNull(segment.encryptionIV);
       assertEquals(51370, segment.byterangeLength);
@@ -94,6 +95,7 @@ public class HlsMediaPlaylistParserTest extends TestCase {
       segment = segments.get(1);
       assertEquals(0, segment.relativeDiscontinuitySequence);
       assertEquals(7975000, segment.durationUs);
+      assertEquals("Title with a url https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.2.1", segment.title);
       assertEquals("https://priv.example.com/key.php?r=2680", segment.fullSegmentEncryptionKeyUri);
       assertEquals("0x1566B", segment.encryptionIV);
       assertEquals(51501, segment.byterangeLength);
@@ -103,6 +105,7 @@ public class HlsMediaPlaylistParserTest extends TestCase {
       segment = segments.get(2);
       assertEquals(0, segment.relativeDiscontinuitySequence);
       assertEquals(7941000, segment.durationUs);
+      assertEquals("Title with a uuid 123e4567-e89b-12d3-a456-426655440000", segment.title);
       assertNull(segment.fullSegmentEncryptionKeyUri);
       assertEquals(null, segment.encryptionIV);
       assertEquals(51501, segment.byterangeLength);
@@ -112,6 +115,7 @@ public class HlsMediaPlaylistParserTest extends TestCase {
       segment = segments.get(3);
       assertEquals(1, segment.relativeDiscontinuitySequence);
       assertEquals(7975000, segment.durationUs);
+      assertEquals(null, segment.title);
       assertEquals("https://priv.example.com/key.php?r=2682", segment.fullSegmentEncryptionKeyUri);
       // 0xA7A == 2682.
       assertNotNull(segment.encryptionIV);
@@ -123,6 +127,7 @@ public class HlsMediaPlaylistParserTest extends TestCase {
       segment = segments.get(4);
       assertEquals(1, segment.relativeDiscontinuitySequence);
       assertEquals(7975000, segment.durationUs);
+      assertEquals(null, segment.title);
       assertEquals("https://priv.example.com/key.php?r=2682", segment.fullSegmentEncryptionKeyUri);
       // 0xA7B == 2683.
       assertNotNull(segment.encryptionIV);

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
@@ -42,6 +42,10 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
      */
     public final long durationUs;
     /**
+     * The human-readable title of the segment as defined by #EXTINF.
+     */
+    public final String title;
+    /**
      * The number of #EXT-X-DISCONTINUITY tags in the playlist before the segment.
      */
     public final int relativeDiscontinuitySequence;
@@ -70,12 +74,13 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
     public final long byterangeLength;
 
     public Segment(String uri, long byterangeOffset, long byterangeLength) {
-      this(uri, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength);
+      this(uri, 0, null, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength);
     }
 
     /**
      * @param url See {@link #url}.
      * @param durationUs See {@link #durationUs}.
+     * @param title See {@link #title}.
      * @param relativeDiscontinuitySequence See {@link #relativeDiscontinuitySequence}.
      * @param relativeStartTimeUs See {@link #relativeStartTimeUs}.
      * @param fullSegmentEncryptionKeyUri See {@link #fullSegmentEncryptionKeyUri}.
@@ -83,11 +88,12 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
      * @param byterangeOffset See {@link #byterangeOffset}.
      * @param byterangeLength See {@link #byterangeLength}.
      */
-    public Segment(String url, long durationUs, int relativeDiscontinuitySequence,
+    public Segment(String url, long durationUs, String title, int relativeDiscontinuitySequence,
         long relativeStartTimeUs, String fullSegmentEncryptionKeyUri,
         String encryptionIV, long byterangeOffset, long byterangeLength) {
       this.url = url;
       this.durationUs = durationUs;
+      this.title = title;
       this.relativeDiscontinuitySequence = relativeDiscontinuitySequence;
       this.relativeStartTimeUs = relativeStartTimeUs;
       this.fullSegmentEncryptionKeyUri = fullSegmentEncryptionKeyUri;


### PR DESCRIPTION
Hi Googlers, 

We added parsing of the #EXTINF tag's optional human-readable titles per:
[https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.2.1](https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.2.1) and I'm hoping it can be incorporated back into your upstream branch.

I know the <title> tag in HLS M3U8 playlists is kind of a left over from music playlist days but it is still a valid part of the HLS spec. In most if not all HLS implementations the value of the tag  it is typically ignored or discarded. 

However, As it is a valid attribute for a valid tag and it helps us solve for use cases like this:  https://github.com/google/ExoPlayer/issues/1414 , this: https://github.com/google/ExoPlayer/pull/1847 and this https://github.com/google/ExoPlayer/issues/2176 without inserting a bunch of proprietary tags in the process. This way we can access the parsed value in the mediaplaylist and use that value for tracking various things in our Apps.

If you have any questions please let me know. We made our changes against the release-v2 branch not the dev-v2 so I'm not sure how hard it is to merge.

-Daniel
 