### PR TITLE
Enable flac to seek without SEEKTABLE

### DIFF
--- a/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacDecoderJni.java
+++ b/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacDecoderJni.java
@@ -86,10 +86,11 @@ import java.nio.ByteBuffer;
    * This method is called from the native code.
    *
    * @param target A target {@link ByteBuffer} into which data should be written.
+   * @param offset The offset into the target array at which to write.
    * @return Returns the number of bytes read, or -1 on failure. It's not an error if this returns
    * zero; it just means all the data read from the source.
    */
-  public int read(ByteBuffer target) throws IOException, InterruptedException {
+  public int read(ByteBuffer target, int offset) throws IOException, InterruptedException {
     int byteCount = target.remaining();
     if (byteBufferData != null) {
       byteCount = Math.min(byteCount, byteBufferData.remaining());
@@ -100,6 +101,11 @@ import java.nio.ByteBuffer;
 
       byteBufferData.limit(originalLimit);
     } else if (extractorInput != null) {
+      int skip = offset - ((int) extractorInput.getPosition());
+      if (skip < 0) {
+        return -1;
+      }
+      extractorInput.skipFully(skip);
       byteCount = Math.min(byteCount, TEMP_BUFFER_SIZE);
       int read = readFromExtractorInput(0, byteCount);
       if (read < 4) {
@@ -181,6 +187,10 @@ import java.nio.ByteBuffer;
     flacRelease(nativeDecoderContext);
   }
 
+  public void seekAbsolute(long timeUs) {
+    flacSeekAbsolute(nativeDecoderContext, timeUs);
+  }
+
   private int readFromExtractorInput(int offset, int length)
       throws IOException, InterruptedException {
     int read = extractorInput.read(tempBuffer, offset, length);
@@ -204,6 +214,7 @@ import java.nio.ByteBuffer;
   private native String flacGetStateString(long context);
   private native void flacFlush(long context);
   private native void flacReset(long context, long newPosition);
+  private native void flacSeekAbsolute(long context, long timeUs);
   private native void flacRelease(long context);
 
 }

--- a/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacDecoderJni.java
+++ b/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacDecoderJni.java
@@ -116,6 +116,17 @@ import java.nio.ByteBuffer;
     return byteCount;
   }
 
+  /**
+   * This method is called from the native code.
+   */
+  public long getStreamLength() {
+    if (extractorInput != null) {
+      return extractorInput.getLength();
+    } else {
+      return -1;
+    }
+  }
+
   public FlacStreamInfo decodeMetadata() throws IOException, InterruptedException {
     return flacDecodeMetadata(nativeDecoderContext);
   }

--- a/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacExtractor.java
+++ b/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacExtractor.java
@@ -66,6 +66,7 @@ public final class FlacExtractor implements Extractor {
 
   private ParsableByteArray outputBuffer;
   private ByteBuffer outputByteBuffer;
+  private long absoluteSeekTimeUs = 0;
 
   @Override
   public void init(ExtractorOutput output) {
@@ -105,11 +106,7 @@ public final class FlacExtractor implements Extractor {
       }
       metadataParsed = true;
 
-      boolean isSeekable = decoderJni.getSeekPosition(0) != -1;
-      extractorOutput.seekMap(
-          isSeekable
-              ? new FlacSeekMap(streamInfo.durationUs(), decoderJni)
-              : new SeekMap.Unseekable(streamInfo.durationUs(), 0));
+      extractorOutput.seekMap(new FlacSeekMap(streamInfo.durationUs(), decoderJni));
       Format mediaFormat =
           Format.createAudioSampleFormat(
               null,
@@ -131,6 +128,10 @@ public final class FlacExtractor implements Extractor {
     }
 
     outputBuffer.reset();
+    if (absoluteSeekTimeUs != 0) {
+      decoderJni.seekAbsolute(absoluteSeekTimeUs);
+      absoluteSeekTimeUs = 0;
+    }
     long lastDecodePosition = decoderJni.getDecodePosition();
     int size;
     try {
@@ -158,6 +159,9 @@ public final class FlacExtractor implements Extractor {
       metadataParsed = false;
     }
     if (decoderJni != null) {
+      if (position == 0){
+        absoluteSeekTimeUs = timeUs;
+      }
       decoderJni.reset(position);
     }
   }
@@ -188,7 +192,8 @@ public final class FlacExtractor implements Extractor {
     @Override
     public SeekPoints getSeekPoints(long timeUs) {
       // TODO: Access the seek table via JNI to return two seek points when appropriate.
-      return new SeekPoints(new SeekPoint(timeUs, decoderJni.getSeekPosition(timeUs)));
+      long pos = decoderJni.getSeekPosition(timeUs);
+      return new SeekPoints(new SeekPoint(timeUs, pos == -1 ? 0 : pos));
     }
 
     @Override

--- a/extensions/flac/src/main/jni/flac_jni.cc
+++ b/extensions/flac/src/main/jni/flac_jni.cc
@@ -46,7 +46,7 @@ class JavaDataSource : public DataSource {
 
   ssize_t readAt(off64_t offset, void *const data, size_t size) {
     jobject byteBuffer = env->NewDirectByteBuffer(data, size);
-    int result = env->CallIntMethod(flacDecoderJni, readMethodId(), byteBuffer);
+    int result = env->CallIntMethod(flacDecoderJni, readMethodId(), byteBuffer, offset);
     if (env->ExceptionCheck()) {
       // Exception is thrown in Java when returning from the native call.
       result = -1;
@@ -66,7 +66,7 @@ class JavaDataSource : public DataSource {
 
   jmethodID readMethodId() {
     jclass cls = env->GetObjectClass(flacDecoderJni);
-    jmethodID mid = env->GetMethodID(cls, "read", "(Ljava/nio/ByteBuffer;)I");
+    jmethodID mid = env->GetMethodID(cls, "read", "(Ljava/nio/ByteBuffer;I)I");
     env->DeleteLocalRef(cls);
     return mid;
   }
@@ -172,6 +172,11 @@ DECODER_FUNC(void, flacFlush, jlong jContext) {
 DECODER_FUNC(void, flacReset, jlong jContext, jlong newPosition) {
   Context *context = reinterpret_cast<Context *>(jContext);
   context->parser->reset(newPosition);
+}
+
+DECODER_FUNC(void, flacSeekAbsolute, jlong jContext, jlong timeUs) {
+  Context *context = reinterpret_cast<Context *>(jContext);
+  context->parser->seekAbsolute(timeUs);
 }
 
 DECODER_FUNC(void, flacRelease, jlong jContext) {

--- a/extensions/flac/src/main/jni/flac_parser.cc
+++ b/extensions/flac/src/main/jni/flac_parser.cc
@@ -139,7 +139,12 @@ FLAC__StreamDecoderTellStatus FLACParser::tellCallback(
 
 FLAC__StreamDecoderLengthStatus FLACParser::lengthCallback(
     FLAC__uint64 *stream_length) {
-  return FLAC__STREAM_DECODER_LENGTH_STATUS_UNSUPPORTED;
+  ssize_t length = (FLAC__uint64)mDataSource->getStreamLength();
+  if (length == -1) {
+    return FLAC__STREAM_DECODER_LENGTH_STATUS_UNSUPPORTED;
+  }
+  *stream_length = (FLAC__uint64)length;
+  return FLAC__STREAM_DECODER_LENGTH_STATUS_OK;
 }
 
 FLAC__bool FLACParser::eofCallback() { return mEOF; }

--- a/extensions/flac/src/main/jni/include/data_source.h
+++ b/extensions/flac/src/main/jni/include/data_source.h
@@ -27,6 +27,8 @@ class DataSource {
   // this returns zero; it just means the given offset is equal to, or
   // beyond, the end of the source.
   virtual ssize_t readAt(off64_t offset, void* const data, size_t size) = 0;
+
+  virtual ssize_t getStreamLength() = 0;
 };
 
 #endif  // INCLUDE_DATA_SOURCE_H_

--- a/extensions/flac/src/main/jni/include/flac_parser.h
+++ b/extensions/flac/src/main/jni/include/flac_parser.h
@@ -70,6 +70,13 @@ class FLACParser {
     }
   }
 
+  void seekAbsolute(int64_t timeUs) {
+    if (mDecoder != NULL) {
+      mEOF = false;
+      FLAC__stream_decoder_seek_absolute(mDecoder, (timeUs * getSampleRate()) / 1000000LL);
+    }
+  }
+
   int64_t getDecodePosition() {
     uint64_t position;
     if (mDecoder != NULL


### PR DESCRIPTION
Pull request for #1808.
In the case flac has no SEEKTABLE, search seek position by libflac function.