### PR TITLE
Fix order of REGEX_METHOD pattern

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -118,11 +118,11 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
               + "|"
               + METHOD_AES_128
               + "|"
-              + METHOD_SAMPLE_AES
-              + "|"
               + METHOD_SAMPLE_AES_CENC
               + "|"
               + METHOD_SAMPLE_AES_CTR
+              + "|"
+              + METHOD_SAMPLE_AES
               + ")");
   private static final Pattern REGEX_KEYFORMAT = Pattern.compile("KEYFORMAT=\"(.+?)\"");
   private static final Pattern REGEX_URI = Pattern.compile("URI=\"(.+?)\"");


### PR DESCRIPTION
I'm trying to play a content of `HLS + WideVine + cenc` , and I found that the content is not playing properly on pre-Nougat devices.

`HLS + WideVine + cenc` should be playable according to [this](https://google.github.io/ExoPlayer/supported-formats.html)

After I debugging the code, it seems like ExoPlayer judges the content `cbcs` mode, even if the content is `cenc` mode at [this](https://github.com/google/ExoPlayer/blob/release-v2/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java#L428) point.  

Shouldn't `METHOD_SAMPLE_AES ` be put after `METHOD_SAMPLE_AES_CENC `, `METHOD_SAMPLE_AES_CTR `??, otherwise `METHOD_SAMPLE_AES_CENC`, `METHOD_SAMPLE_AES_CTR` would never match.



```
#EXTM3U
#EXT-X-VERSION:6
## Generated with https://github.com/google/shaka-packager version 2453c93f91-release
#EXT-X-TARGETDURATION:12
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MAP:URI="init.mp4"
#EXTINF:10.000,
1.m4s
#EXT-X-DISCONTINUITY
#EXT-X-KEY:METHOD=SAMPLE-AES-CTR,URI="data:text/plain;base64,AAAAN3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABciD3Rlc3QgY29udGVudCBpZEjj3JWbBg==",KEYID=0x6D76F25CB17F5E16B8EAEF6BBF582D8E,KEYFORMATVERSIONS="1",KEYFORMAT="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"
#EXTINF:10.792,
2.m4s
#EXTINF:9.792,
3.m4s
#EXTINF:10.000,
```

```java
  private static final String METHOD_NONE = "NONE";
  private static final String METHOD_AES_128 = "AES-128";
  private static final String METHOD_SAMPLE_AES = "SAMPLE-AES";
  // Replaced by METHOD_SAMPLE_AES_CTR. Keep for backward compatibility.
  private static final String METHOD_SAMPLE_AES_CENC = "SAMPLE-AES-CENC";
  private static final String METHOD_SAMPLE_AES_CTR = "SAMPLE-AES-CTR";
  private static final Pattern REGEX_METHOD =
      Pattern.compile(
          "METHOD=("
              + METHOD_NONE
              + "|"
              + METHOD_AES_128
              + "|"
              + METHOD_SAMPLE_AES
              + "|"
              + METHOD_SAMPLE_AES_CENC
              + "|"
              + METHOD_SAMPLE_AES_CTR
              + ")");
Matcher matcher = REGEX_METHOD.matcher("#EXT-X-KEY:METHOD=SAMPLE-AES-CTR,URI=\"data:text/plain;base64,AAAAN3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABciD3Rlc3QgY29udGVudCBpZEjj3JWbBg==\",KEYID=0x6D76F25CB17F5E16B8EAEF6BBF582D8E,KEYFORMATVERSIONS=\"1\",KEYFORMAT=\"urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed\"");
matcher.find() ? matcher.group(1) : null;
// ↑ this returns "SAMPLE-AES" because SAMPLE-AES is before METHOD_SAMPLE_AES_CTR
```

