### PR TITLE
Fiximaextension

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -683,7 +683,8 @@ public final class ImaAdsLoader extends Player.DefaultEventListener implements A
     if (DEBUG) {
       Log.d(TAG, "pauseAd");
     }
-    if (imaAdState == IMA_AD_STATE_NONE) {
+    //If there is ad playing, dont trigger this function
+    if (imaAdState == IMA_AD_STATE_NONE || imaAdState == IMA_AD_STATE_PLAYING) {
       // This method is called after content is resumed.
       return;
     }
@@ -883,6 +884,10 @@ public final class ImaAdsLoader extends Player.DefaultEventListener implements A
         if (ad.isSkippable()) {
           focusSkipButton();
         }
+        break;
+      case RESUMED:
+        //After resumed, update the ima state back to playing
+        imaAdState = IMA_AD_STATE_PLAYING;
         break;
       case TAPPED:
         if (eventListener != null) {


### PR DESCRIPTION
Set the **imaAdState** back to **IMA_AD_STATE_PLAYING** when the ads resumed, This can prevent some playback issue when pause and resume the player.
I encountered this issue when i have three 10 seconds ads and one 15 seconds ads in my playlist. When i pause the 15 seconds ads and resume it, the remaining ads will be skipped.
This commit can fix the issue.