### PR TITLE
support multiple #EXT-X-MAP tags

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -320,11 +320,14 @@ import java.util.List;
     }
 
     DataSpec initDataSpec = null;
-    Segment initSegment = mediaPlaylist.initializationSegment;
-    if (initSegment != null) {
-      Uri initSegmentUri = UriUtil.resolveToUri(mediaPlaylist.baseUri, initSegment.url);
-      initDataSpec = new DataSpec(initSegmentUri, initSegment.byterangeOffset,
-          initSegment.byterangeLength, null);
+    if (segment.initializationSegmentIndex != -1) {
+      Segment initSegment =
+          mediaPlaylist.initializationSegments.get(segment.initializationSegmentIndex);
+      if (initSegment != null) {
+        Uri initSegmentUri = UriUtil.resolveToUri(mediaPlaylist.baseUri, initSegment.url);
+        initDataSpec = new DataSpec(initSegmentUri, initSegment.byterangeOffset,
+            initSegment.byterangeLength, null);
+      }
     }
 
     // Compute start time of the next chunk.

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -320,14 +320,12 @@ import java.util.List;
     }
 
     DataSpec initDataSpec = null;
-    if (segment.initializationSegmentIndex != -1) {
-      Segment initSegment =
-          mediaPlaylist.initializationSegments.get(segment.initializationSegmentIndex);
-      if (initSegment != null) {
-        Uri initSegmentUri = UriUtil.resolveToUri(mediaPlaylist.baseUri, initSegment.url);
-        initDataSpec = new DataSpec(initSegmentUri, initSegment.byterangeOffset,
-            initSegment.byterangeLength, null);
-      }
+    Segment initSegment =
+        mediaPlaylist.initializationSegments.get(segment.relativeDiscontinuitySequence);
+    if (initSegment != null) {
+      Uri initSegmentUri = UriUtil.resolveToUri(mediaPlaylist.baseUri, initSegment.url);
+      initDataSpec = new DataSpec(initSegmentUri, initSegment.byterangeOffset,
+          initSegment.byterangeLength, null);
     }
 
     // Compute start time of the next chunk.

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/offline/HlsDownloader.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/offline/HlsDownloader.java
@@ -90,9 +90,9 @@ public final class HlsDownloader extends SegmentDownloader<HlsMasterPlaylist, St
         continue;
       }
 
-      HlsMediaPlaylist.Segment initSegment = mediaPlaylist.initializationSegment;
-      if (initSegment != null) {
-        addSegment(segments, mediaPlaylist, initSegment, encryptionKeyUris);
+      List<HlsMediaPlaylist.Segment> initSegments = mediaPlaylist.initializationSegments;
+      for (int i = 0; i < initSegments.size(); i++) {
+        addSegment(segments, mediaPlaylist, initSegments.get(i), encryptionKeyUris);
       }
 
       List<HlsMediaPlaylist.Segment> hlsSegments = mediaPlaylist.segments;

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/offline/HlsDownloader.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/offline/HlsDownloader.java
@@ -93,7 +93,7 @@ public final class HlsDownloader extends SegmentDownloader<HlsMasterPlaylist, St
 
       SparseArray<HlsMediaPlaylist.Segment> initSegments = mediaPlaylist.initializationSegments;
       for (int i = 0; i < initSegments.size(); i++) {
-        addSegment(segments, mediaPlaylist, initSegments.get(i), encryptionKeyUris);
+        addSegment(segments, mediaPlaylist, initSegments.valueAt(i), encryptionKeyUris);
       }
 
       List<HlsMediaPlaylist.Segment> hlsSegments = mediaPlaylist.segments;

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/offline/HlsDownloader.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/offline/HlsDownloader.java
@@ -16,6 +16,7 @@
 package com.google.android.exoplayer2.source.hls.offline;
 
 import android.net.Uri;
+import android.util.SparseArray;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.offline.DownloaderConstructorHelper;
 import com.google.android.exoplayer2.offline.SegmentDownloader;
@@ -90,7 +91,7 @@ public final class HlsDownloader extends SegmentDownloader<HlsMasterPlaylist, St
         continue;
       }
 
-      List<HlsMediaPlaylist.Segment> initSegments = mediaPlaylist.initializationSegments;
+      SparseArray<HlsMediaPlaylist.Segment> initSegments = mediaPlaylist.initializationSegments;
       for (int i = 0; i < initSegments.size(); i++) {
         addSegment(segments, mediaPlaylist, initSegments.get(i), encryptionKeyUris);
       }

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
@@ -72,13 +72,16 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
     /** Whether the segment is tagged with #EXT-X-GAP. */
     public final boolean hasGapTag;
 
+    /** index of {@link HlsMediaPlaylist#initializationSegments} */
+    public final int initializationSegmentIndex;
+
     /**
      * @param uri See {@link #url}.
      * @param byterangeOffset See {@link #byterangeOffset}.
      * @param byterangeLength See {@link #byterangeLength}.
      */
     public Segment(String uri, long byterangeOffset, long byterangeLength) {
-      this(uri, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength, false);
+      this(uri, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength, false, -1);
     }
 
     /**
@@ -91,6 +94,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
      * @param byterangeOffset See {@link #byterangeOffset}.
      * @param byterangeLength See {@link #byterangeLength}.
      * @param hasGapTag See {@link #hasGapTag}.
+     * @param initializationSegmentIndex See {@link #initializationSegmentIndex}.
      */
     public Segment(
         String url,
@@ -101,7 +105,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         String encryptionIV,
         long byterangeOffset,
         long byterangeLength,
-        boolean hasGapTag) {
+        boolean hasGapTag,
+        int initializationSegmentIndex) {
       this.url = url;
       this.durationUs = durationUs;
       this.relativeDiscontinuitySequence = relativeDiscontinuitySequence;
@@ -111,6 +116,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       this.byterangeOffset = byterangeOffset;
       this.byterangeLength = byterangeLength;
       this.hasGapTag = hasGapTag;
+      this.initializationSegmentIndex = initializationSegmentIndex;
     }
 
     @Override
@@ -185,7 +191,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
   /**
    * The initialization segment, as defined by #EXT-X-MAP.
    */
-  public final Segment initializationSegment;
+  public final List<Segment>  initializationSegments;
   /**
    * The list of segments in the playlist.
    */
@@ -210,7 +216,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
    * @param hasEndTag See {@link #hasEndTag}.
    * @param hasProgramDateTime See {@link #hasProgramDateTime}.
    * @param drmInitData See {@link #drmInitData}.
-   * @param initializationSegment See {@link #initializationSegment}.
+   * @param initializationSegments See {@link #initializationSegments}.
    * @param segments See {@link #segments}.
    */
   public HlsMediaPlaylist(
@@ -228,7 +234,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       boolean hasEndTag,
       boolean hasProgramDateTime,
       DrmInitData drmInitData,
-      Segment initializationSegment,
+      List<Segment> initializationSegments,
       List<Segment> segments) {
     super(baseUri, tags);
     this.playlistType = playlistType;
@@ -242,7 +248,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
     this.hasEndTag = hasEndTag;
     this.hasProgramDateTime = hasProgramDateTime;
     this.drmInitData = drmInitData;
-    this.initializationSegment = initializationSegment;
+    this.initializationSegments = initializationSegments;
     this.segments = Collections.unmodifiableList(segments);
     if (!segments.isEmpty()) {
       Segment last = segments.get(segments.size() - 1);
@@ -293,7 +299,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
   public HlsMediaPlaylist copyWith(long startTimeUs, int discontinuitySequence) {
     return new HlsMediaPlaylist(playlistType, baseUri, tags, startOffsetUs, startTimeUs, true,
         discontinuitySequence, mediaSequence, version, targetDurationUs, hasIndependentSegmentsTag,
-        hasEndTag, hasProgramDateTime, drmInitData, initializationSegment, segments);
+        hasEndTag, hasProgramDateTime, drmInitData, initializationSegments, segments);
   }
 
   /**
@@ -308,7 +314,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
     }
     return new HlsMediaPlaylist(playlistType, baseUri, tags, startOffsetUs, startTimeUs,
         hasDiscontinuitySequence, discontinuitySequence, mediaSequence, version, targetDurationUs,
-        hasIndependentSegmentsTag, true, hasProgramDateTime, drmInitData, initializationSegment,
+        hasIndependentSegmentsTag, true, hasProgramDateTime, drmInitData, initializationSegments,
         segments);
   }
 

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
@@ -17,6 +17,7 @@ package com.google.android.exoplayer2.source.hls.playlist;
 
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
+import android.util.SparseArray;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.drm.DrmInitData;
 import java.lang.annotation.Retention;
@@ -72,16 +73,13 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
     /** Whether the segment is tagged with #EXT-X-GAP. */
     public final boolean hasGapTag;
 
-    /** index of {@link HlsMediaPlaylist#initializationSegments} */
-    public final int initializationSegmentIndex;
-
     /**
      * @param uri See {@link #url}.
      * @param byterangeOffset See {@link #byterangeOffset}.
      * @param byterangeLength See {@link #byterangeLength}.
      */
     public Segment(String uri, long byterangeOffset, long byterangeLength) {
-      this(uri, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength, false, -1);
+      this(uri, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength, false);
     }
 
     /**
@@ -94,7 +92,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
      * @param byterangeOffset See {@link #byterangeOffset}.
      * @param byterangeLength See {@link #byterangeLength}.
      * @param hasGapTag See {@link #hasGapTag}.
-     * @param initializationSegmentIndex See {@link #initializationSegmentIndex}.
      */
     public Segment(
         String url,
@@ -105,8 +102,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         String encryptionIV,
         long byterangeOffset,
         long byterangeLength,
-        boolean hasGapTag,
-        int initializationSegmentIndex) {
+        boolean hasGapTag) {
       this.url = url;
       this.durationUs = durationUs;
       this.relativeDiscontinuitySequence = relativeDiscontinuitySequence;
@@ -116,7 +112,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       this.byterangeOffset = byterangeOffset;
       this.byterangeLength = byterangeLength;
       this.hasGapTag = hasGapTag;
-      this.initializationSegmentIndex = initializationSegmentIndex;
     }
 
     @Override
@@ -189,9 +184,9 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
    */
   public final DrmInitData drmInitData;
   /**
-   * The initialization segment, as defined by #EXT-X-MAP.
+   * The initialization segments, as defined by #EXT-X-MAP.
    */
-  public final List<Segment>  initializationSegments;
+  public final SparseArray<Segment> initializationSegments;
   /**
    * The list of segments in the playlist.
    */
@@ -234,7 +229,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       boolean hasEndTag,
       boolean hasProgramDateTime,
       DrmInitData drmInitData,
-      List<Segment> initializationSegments,
+      SparseArray<Segment> initializationSegments,
       List<Segment> segments) {
     super(baseUri, tags);
     this.playlistType = playlistType;

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -345,7 +345,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
     long targetDurationUs = C.TIME_UNSET;
     boolean hasIndependentSegmentsTag = false;
     boolean hasEndTag = false;
-    Segment initializationSegment = null;
+    int initializationSegmentIndex = -1;
+    List<Segment> initializationSegments = new ArrayList<>();
     List<Segment> segments = new ArrayList<>();
     List<String> tags = new ArrayList<>();
 
@@ -392,7 +393,9 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
             segmentByteRangeOffset = Long.parseLong(splitByteRange[1]);
           }
         }
-        initializationSegment = new Segment(uri, segmentByteRangeOffset, segmentByteRangeLength);
+        initializationSegments.add(
+            new Segment(uri, segmentByteRangeOffset, segmentByteRangeLength));
+        initializationSegmentIndex++;
         segmentByteRangeOffset = 0;
         segmentByteRangeLength = C.LENGTH_UNSET;
       } else if (line.startsWith(TAG_TARGET_DURATION)) {
@@ -480,7 +483,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
                 segmentEncryptionIV,
                 segmentByteRangeOffset,
                 segmentByteRangeLength,
-                hasGapTag));
+                hasGapTag,
+                initializationSegmentIndex));
         segmentStartTimeUs += segmentDurationUs;
         segmentDurationUs = 0;
         if (segmentByteRangeLength != C.LENGTH_UNSET) {
@@ -493,7 +497,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
     return new HlsMediaPlaylist(playlistType, baseUri, tags, startOffsetUs, playlistStartTimeUs,
         hasDiscontinuitySequence, playlistDiscontinuitySequence, mediaSequence, version,
         targetDurationUs, hasIndependentSegmentsTag, hasEndTag, playlistStartTimeUs != 0,
-        drmInitData, initializationSegment, segments);
+        drmInitData, initializationSegments, segments);
   }
 
   private static SchemeData parseWidevineSchemeData(String line, String keyFormat)

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -17,6 +17,7 @@ package com.google.android.exoplayer2.source.hls.playlist;
 
 import android.net.Uri;
 import android.util.Base64;
+import android.util.SparseArray;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.ParserException;
@@ -345,8 +346,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
     long targetDurationUs = C.TIME_UNSET;
     boolean hasIndependentSegmentsTag = false;
     boolean hasEndTag = false;
-    int initializationSegmentIndex = -1;
-    List<Segment> initializationSegments = new ArrayList<>();
+    SparseArray<Segment> initializationSegments = new SparseArray<>();
     List<Segment> segments = new ArrayList<>();
     List<String> tags = new ArrayList<>();
 
@@ -393,9 +393,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
             segmentByteRangeOffset = Long.parseLong(splitByteRange[1]);
           }
         }
-        initializationSegments.add(
+        initializationSegments.put(relativeDiscontinuitySequence,
             new Segment(uri, segmentByteRangeOffset, segmentByteRangeLength));
-        initializationSegmentIndex++;
         segmentByteRangeOffset = 0;
         segmentByteRangeLength = C.LENGTH_UNSET;
       } else if (line.startsWith(TAG_TARGET_DURATION)) {
@@ -483,8 +482,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
                 segmentEncryptionIV,
                 segmentByteRangeOffset,
                 segmentByteRangeLength,
-                hasGapTag,
-                initializationSegmentIndex));
+                hasGapTag));
         segmentStartTimeUs += segmentDurationUs;
         segmentDurationUs = 0;
         if (segmentByteRangeLength != C.LENGTH_UNSET) {


### PR DESCRIPTION
I'm trying to play HLS + fmp4 contents, and it didn't work when the HLS playlist has multiple contents separated by `#EXT-X-DISCONTINUITY`. 

It looks like `HlsPlaylistParser.java` captures the only one initialSegment the parser found at last eventually, but I think there is a situation where multiple init files exist separated by `#EXT-X-DISCONTINUITY`.

According to the [spec](https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.2.5), it says
> The EXT-X-MAP tag specifies how to obtain the Media Initialization
   Section (Section 3) required to parse the applicable Media Segments.
   It applies to every Media Segment that appears after it in the
   Playlist until the next EXT-X-MAP tag or until the end of the
   playlist.

what shown below is what i tested for this pr.

### content description

this HLS [url](http://160.16.54.236:8081/exoplayer/hls-drm-aes/playlist.m3u8) is available and it can be reproduced, this is what I prepared.

#### playlist.m3u8
```playlist.m3u8
#EXTM3U
#EXT-X-VERSION:6
## Generated with https://github.com/google/shaka-packager version 2453c93f91-release
#EXT-X-TARGETDURATION:12
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-MAP:URI="video1/init.mp4"
#EXT-X-KEY:METHOD=SAMPLE-AES-CTR,URI="data:text/plain;base64,AAAAN3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABciD3Rlc3QgY29udGVudCBpZEjj3JWbBg==",KEYID=0x6D76F25CB17F5E16B8EAEF6BBF582D8E,KEYFORMATVERSIONS="1",KEYFORMAT="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"
#EXTINF:10.000,
video1/1.m4s
#EXTINF:10.792,
video1/2.m4s
#EXTINF:9.792,
...
#EXTINF:10.000,
video1/59.m4s
#EXTINF:5.500,
video1/60.m4s
#EXT-X-DISCONTINUITY
#EXT-X-KEY:METHOD=AES-128,URI="http://160.16.54.236:8081/nondrm/hls-two-encryption/test2.key",IV=0x0123456789ABCDEF0123456789ABCDEF
#EXT-X-MAP:URI="video2/init.mp4"
#EXTINF:3.436770,
video2/segment_0000.mp4
#EXTINF:4.004004,
video2/segment_0001.mp4
#EXTINF:3.236570,
video2/segment_0002.mp4
#EXTINF:7.340674,
...
video2/segment_0030.mp4
#EXTINF:3.303303,
video2/segment_0031.mp4
#EXT-X-ENDLIST
```


#### how I made each content.

##### the first content (widevine) using shaka-packager
i used test widevine test credential (https://google.github.io/shaka-packager/html/tutorials/widevine.html#widevine-test-credential)
```sh
packager \
'in=input1.mp4,stream=video,init_segment=video1/init.mp4,segment_template=video1/$Number$.m4s,playlist_name=video.m3u8' \
  --hls_master_playlist_output playlist2.m3u8 \
  --enable_widevine_encryption \
  --key_server_url https://license.uat.widevine.com/cenc/getcontentkey/widevine_test \
  --content_id 7465737420636f6e74656e74206964 \
  --signer widevine_test \
  --aes_signing_key 1ae8ccd0e7985cc0b6203a55855a1034afc252980e970ca90e5202689f947ab9 \
  --aes_signing_iv d58ce954203b7c9a9a9d467f59839249 \
  --protection_scheme cenc
```

##### the second content (aes-128) using ffmpeg
```sh
ffmpeg -i input2.mp4 -c:v copy -an -hls_segment_type fmp4 -segment_time 20 -hls_segment_filename video2/segment_%04d.mp4 -hls_base_url video2/ -hls_fmp4_init_filename video2/init.mp4 -hls_list_size 0 playlist2.m3u8
```