### PR TITLE
Fix timebar scrubber notify wrong start position

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/DefaultTimeBar.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/DefaultTimeBar.java
@@ -408,8 +408,8 @@ public class DefaultTimeBar extends View implements TimeBar {
     switch (event.getAction()) {
       case MotionEvent.ACTION_DOWN:
         if (isInSeekBar(x, y)) {
-          startScrubbing();
           positionScrubber(x);
+          startScrubbing();
           scrubPosition = getScrubberPosition();
           update();
           invalidate();


### PR DESCRIPTION
`startScrubbing()` should notify callback with latest scrub position, so it should be called after `positionScrubber()`.