### PR TITLE
support drm init data per discontinuity

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -360,7 +360,7 @@ import java.util.List;
             isTimestampMaster,
             timestampAdjuster,
             previous,
-            mediaPlaylist.drmInitData,
+            segment.drmInitData,
             encryptionKey,
             encryptionIv);
   }

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
@@ -42,6 +42,11 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
      * used for all segments that share an EXT-X-MAP tag.
      */
     @Nullable public final Segment initializationSegment;
+    /**
+     * DRM initialization data for sample decryption, or null if none of the segment uses sample
+     * encryption.
+     */
+    @Nullable public final DrmInitData drmInitData;
     /** The duration of the segment in microseconds, as defined by #EXTINF. */
     public final long durationUs;
     /**
@@ -81,7 +86,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
      * @param byterangeLength See {@link #byterangeLength}.
      */
     public Segment(String uri, long byterangeOffset, long byterangeLength) {
-      this(uri, null, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength, false);
+      this(uri, null, null, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength, false);
     }
 
     /**
@@ -99,6 +104,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
     public Segment(
         String url,
         Segment initializationSegment,
+        @Nullable DrmInitData drmInitData,
         long durationUs,
         int relativeDiscontinuitySequence,
         long relativeStartTimeUs,
@@ -109,6 +115,7 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         boolean hasGapTag) {
       this.url = url;
       this.initializationSegment = initializationSegment;
+      this.drmInitData = drmInitData;
       this.durationUs = durationUs;
       this.relativeDiscontinuitySequence = relativeDiscontinuitySequence;
       this.relativeStartTimeUs = relativeStartTimeUs;
@@ -184,11 +191,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
    */
   public final boolean hasProgramDateTime;
   /**
-   * DRM initialization data for sample decryption, or null if none of the segment uses sample
-   * encryption.
-   */
-  public final DrmInitData drmInitData;
-  /**
    * The list of segments in the playlist.
    */
   public final List<Segment> segments;
@@ -211,7 +213,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
    * @param hasIndependentSegmentsTag See {@link #hasIndependentSegmentsTag}.
    * @param hasEndTag See {@link #hasEndTag}.
    * @param hasProgramDateTime See {@link #hasProgramDateTime}.
-   * @param drmInitData See {@link #drmInitData}.
    * @param segments See {@link #segments}.
    */
   public HlsMediaPlaylist(
@@ -228,7 +229,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
       boolean hasIndependentSegmentsTag,
       boolean hasEndTag,
       boolean hasProgramDateTime,
-      DrmInitData drmInitData,
       List<Segment> segments) {
     super(baseUri, tags);
     this.playlistType = playlistType;
@@ -241,7 +241,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
     this.hasIndependentSegmentsTag = hasIndependentSegmentsTag;
     this.hasEndTag = hasEndTag;
     this.hasProgramDateTime = hasProgramDateTime;
-    this.drmInitData = drmInitData;
     this.segments = Collections.unmodifiableList(segments);
     if (!segments.isEmpty()) {
       Segment last = segments.get(segments.size() - 1);
@@ -309,7 +308,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         hasIndependentSegmentsTag,
         hasEndTag,
         hasProgramDateTime,
-        drmInitData,
         segments);
   }
 
@@ -337,7 +335,6 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
         hasIndependentSegmentsTag,
         /* hasEndTag= */ true,
         hasProgramDateTime,
-        drmInitData,
         segments);
   }
 

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylist.java
@@ -43,8 +43,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
      */
     @Nullable public final Segment initializationSegment;
     /**
-     * DRM initialization data for sample decryption, or null if none of the segment uses sample
-     * encryption.
+     * {@link DrmInitData} for sample decryption, or null if the segment's samples are not
+     * DRM-protected.
      */
     @Nullable public final DrmInitData drmInitData;
     /** The duration of the segment in microseconds, as defined by #EXTINF. */
@@ -86,7 +86,8 @@ public final class HlsMediaPlaylist extends HlsPlaylist {
      * @param byterangeLength See {@link #byterangeLength}.
      */
     public Segment(String uri, long byterangeOffset, long byterangeLength) {
-      this(uri, null, null, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength, false);
+      this(uri, null, null, 0, -1, C.TIME_UNSET, null, null, byterangeOffset, byterangeLength,
+          false);
     }
 
     /**

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -433,6 +433,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
                       schemeData);
             }
           }
+        } else {
+          drmInitData = null;
         }
       } else if (line.startsWith(TAG_BYTERANGE)) {
         String byteRange = parseStringAttr(line, REGEX_BYTERANGE);

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -17,6 +17,7 @@ package com.google.android.exoplayer2.source.hls.playlist;
 
 import android.net.Uri;
 import android.util.Base64;
+import android.util.SparseArray;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.ParserException;
@@ -424,8 +425,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
           } else if (method != null) {
             SchemeData schemeData = parseWidevineSchemeData(line, keyFormat);
             if (schemeData != null) {
-              drmInitData =
-                  new DrmInitData(
+              drmInitData = new DrmInitData(
                       (METHOD_SAMPLE_AES_CENC.equals(method)
                               || METHOD_SAMPLE_AES_CTR.equals(method))
                           ? C.CENC_TYPE_cenc
@@ -475,6 +475,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
             new Segment(
                 line,
                 initializationSegment,
+                drmInitData,
                 segmentDurationUs,
                 relativeDiscontinuitySequence,
                 segmentStartTimeUs,
@@ -506,7 +507,6 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
         hasIndependentSegmentsTag,
         hasEndTag,
         /* hasProgramDateTime= */ playlistStartTimeUs != 0,
-        drmInitData,
         segments);
   }
 

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -17,7 +17,6 @@ package com.google.android.exoplayer2.source.hls.playlist;
 
 import android.net.Uri;
 import android.util.Base64;
-import android.util.SparseArray;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.ParserException;
@@ -425,7 +424,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
           } else if (method != null) {
             SchemeData schemeData = parseWidevineSchemeData(line, keyFormat);
             if (schemeData != null) {
-              drmInitData = new DrmInitData(
+              drmInitData =
+                  new DrmInitData(
                       (METHOD_SAMPLE_AES_CENC.equals(method)
                               || METHOD_SAMPLE_AES_CTR.equals(method))
                           ? C.CENC_TYPE_cenc

--- a/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylistParserTest.java
+++ b/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/playlist/HlsMediaPlaylistParserTest.java
@@ -160,8 +160,9 @@ public class HlsMediaPlaylistParserTest {
         new ByteArrayInputStream(playlistString.getBytes(Charset.forName(C.UTF8_NAME)));
     HlsMediaPlaylist playlist =
         (HlsMediaPlaylist) new HlsPlaylistParser().parse(playlistUri, inputStream);
-    assertThat(playlist.drmInitData.schemeType).isEqualTo(C.CENC_TYPE_cbcs);
-    assertThat(playlist.drmInitData.get(0).matches(C.WIDEVINE_UUID)).isTrue();
+    assertThat(playlist.segments.get(0).drmInitData).isNull();
+    assertThat(playlist.segments.get(1).drmInitData.schemeType).isEqualTo(C.CENC_TYPE_cbcs);
+    assertThat(playlist.segments.get(1).drmInitData.get(0).matches(C.WIDEVINE_UUID)).isTrue();
   }
 
   @Test
@@ -184,8 +185,9 @@ public class HlsMediaPlaylistParserTest {
         new ByteArrayInputStream(playlistString.getBytes(Charset.forName(C.UTF8_NAME)));
     HlsMediaPlaylist playlist =
         (HlsMediaPlaylist) new HlsPlaylistParser().parse(playlistUri, inputStream);
-    assertThat(playlist.drmInitData.schemeType).isEqualTo(C.CENC_TYPE_cenc);
-    assertThat(playlist.drmInitData.get(0).matches(C.WIDEVINE_UUID)).isTrue();
+    assertThat(playlist.segments.get(0).drmInitData).isNull();
+    assertThat(playlist.segments.get(1).drmInitData.schemeType).isEqualTo(C.CENC_TYPE_cenc);
+    assertThat(playlist.segments.get(1).drmInitData.get(0).matches(C.WIDEVINE_UUID)).isTrue();
   }
 
   @Test
@@ -208,8 +210,46 @@ public class HlsMediaPlaylistParserTest {
         new ByteArrayInputStream(playlistString.getBytes(Charset.forName(C.UTF8_NAME)));
     HlsMediaPlaylist playlist =
         (HlsMediaPlaylist) new HlsPlaylistParser().parse(playlistUri, inputStream);
-    assertThat(playlist.drmInitData.schemeType).isEqualTo(C.CENC_TYPE_cenc);
-    assertThat(playlist.drmInitData.get(0).matches(C.WIDEVINE_UUID)).isTrue();
+    assertThat(playlist.segments.get(0).drmInitData).isNull();
+    assertThat(playlist.segments.get(1).drmInitData.schemeType).isEqualTo(C.CENC_TYPE_cenc);
+    assertThat(playlist.segments.get(1).drmInitData.get(0).matches(C.WIDEVINE_UUID)).isTrue();
+  }
+
+  @Test
+  public void testParseMultipleEncryptionsMethod() throws Exception {
+    Uri playlistUri = Uri.parse("https://example.com/test.m3u8");
+    String playlistString =
+        "#EXTM3U\n"
+            + "#EXT-X-MEDIA-SEQUENCE:0\n"
+            + "#EXTINF:8,\n"
+            + "https://priv.example.com/1.ts\n"
+            + "\n"
+            + "#EXT-X-KEY:URI=\"data:text/plain;base64,VGhpcyBpcyBhbiBlYXN0ZXIgZWdn\","
+            + "IV=0x9358382AEB449EE23C3D809DA0B9CCD3,KEYFORMATVERSIONS=\"1\","
+            + "KEYFORMAT=\"urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed\","
+            + "IV=0x1566B,METHOD=SAMPLE-AES-CENC \n"
+            + "#EXTINF:8,\n"
+            + "https://priv.example.com/2.ts\n"
+            + "#EXT-X-KEY:METHOD=NONE\n"
+            + "#EXTINF:8,\n"
+            + "https://priv.example.com/3.ts\n"
+            + "#EXT-X-KEY:URI=\"data:text/plain;base64,VGhpcyBpcyBhbiBlYXN0ZXIgZWdn\","
+            + "IV=0x9358382AEB449EE23C3D809DA0B9CCD3,KEYFORMATVERSIONS=\"1\","
+            + "KEYFORMAT=\"urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed\","
+            + "IV=0x1566B,METHOD=SAMPLE-AES-CENC \n"
+            + "#EXTINF:8,\n"
+            + "https://priv.example.com/4.ts\n"
+            + "#EXT-X-ENDLIST\n";
+    InputStream inputStream =
+        new ByteArrayInputStream(playlistString.getBytes(Charset.forName(C.UTF8_NAME)));
+    HlsMediaPlaylist playlist =
+        (HlsMediaPlaylist) new HlsPlaylistParser().parse(playlistUri, inputStream);
+    assertThat(playlist.segments.get(0).drmInitData).isNull();
+    assertThat(playlist.segments.get(1).drmInitData.schemeType).isEqualTo(C.CENC_TYPE_cenc);
+    assertThat(playlist.segments.get(1).drmInitData.get(0).matches(C.WIDEVINE_UUID)).isTrue();
+    assertThat(playlist.segments.get(2).drmInitData).isNull();
+    assertThat(playlist.segments.get(3).drmInitData.schemeType).isEqualTo(C.CENC_TYPE_cenc);
+    assertThat(playlist.segments.get(3).drmInitData.get(0).matches(C.WIDEVINE_UUID)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Im trying to play a HLS content, which has a DRM content and a non-DRM content separated by `#EXT-X-DISCONTINUITY`, it seems like ExoPlayer uses secure decoder even when playing non-DRM content.

I think it is because ExoPlayer holds a single `drmInitData`.

I fixed to let ExoPlayer have `drmInitData` per  `#EXT-X-DISCONTINUITY`, and I confirmed ExoPlayer switches decoder between a DRM content and a non-DRM content.


You can use the [hls url](http://160.16.54.236:8081/exoplayer/hls-drm-aes/playlist.m3u8) that I prepared, but this would only work after successfully these my pull requests merged.

 - https://github.com/google/ExoPlayer/pull/4164
 - https://github.com/google/ExoPlayer/pull/4145


I hope this pr would be acceptable. 


