### PR TITLE
Issue #4185: Shaka vs ExoPlayer behaviour difference. Multi-Periods d…

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -1013,8 +1013,14 @@ import java.io.IOException;
       return;
     }
 
+    // Issue #4185: If end of Period is reached then this triggers next Period also
+    boolean isAtEndOfPeriod = false;
+    if (playingPeriodHolder != null && playingPeriodHolder.next != null) {
+      isAtEndOfPeriod = (rendererPositionUs >= playingPeriodHolder.next.rendererPositionOffsetUs);
+    }
+
     for (Renderer renderer : enabledRenderers) {
-      if (!renderer.hasReadStreamToEnd()) {
+      if (!renderer.hasReadStreamToEnd() && !isAtEndOfPeriod) {
         return;
       }
     }


### PR DESCRIPTION
…o not advance whilst media renderer has more data

A static MPD with multiple Periods can play out differently between Shaka (e.g. PC/Chromecast) vs Android and AndroidTV devices.

Looking further it seems that the logic in updatePeriods() is the reason for this because Periods will not advance to the next Period when there might still be some audio/video data remaining to be rendered.