### PR TITLE
Updating TextRenderer output if last subtitle is not fully played

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/TextRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/TextRenderer.java
@@ -189,6 +189,8 @@ public final class TextRenderer extends BaseRenderer implements Callback {
             releaseBuffers();
             outputStreamEnded = true;
           }
+        } else {
+          textRendererNeedsUpdate = true;
         }
       } else if (nextSubtitle.timeUs <= positionUs) {
         // Advance to the next subtitle. Sync the next event index and trigger an update.


### PR DESCRIPTION
When the `TextRenderer` treats EOS but the last subtitle has not been fully played out, the renderer should update the output by setting `textRendererNeedsUpdate` to `true`. Not updating it causes situations where the current subtitle will not be show (e.g.:  attaching the player to another `PlayerView`)

- ### Here's a GIF of the problematic situation:
![not-fixed](https://user-images.githubusercontent.com/1148205/39938996-b38778ca-554c-11e8-965d-1458a3bd2d29.gif)

- ### And here's a GIF with the implemented fix:
![fixed](https://user-images.githubusercontent.com/1148205/39938997-b547d524-554c-11e8-8180-474248aba11e.gif)
