### PR TITLE
Saving current subtitle cues on SimpleExoPlayer

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
@@ -92,7 +92,7 @@ public class SimpleExoPlayer implements ExoPlayer, Player.VideoComponent, Player
   private AudioAttributes audioAttributes;
   private float audioVolume;
   private MediaSource mediaSource;
-  private List<Cue> currentCues;
+  private @Nullable List<Cue> currentCues;
 
   /**
    * @param renderersFactory A factory for creating {@link Renderer}s to be used by the instance.
@@ -503,7 +503,9 @@ public class SimpleExoPlayer implements ExoPlayer, Player.VideoComponent, Player
 
   @Override
   public void addTextOutput(TextOutput listener) {
-    listener.onCues(currentCues);
+    if(currentCues != null) {
+      listener.onCues(currentCues);
+    }
     textOutputs.add(listener);
   }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
@@ -92,6 +92,7 @@ public class SimpleExoPlayer implements ExoPlayer, Player.VideoComponent, Player
   private AudioAttributes audioAttributes;
   private float audioVolume;
   private MediaSource mediaSource;
+  private List<Cue> currentCues;
 
   /**
    * @param renderersFactory A factory for creating {@link Renderer}s to be used by the instance.
@@ -502,6 +503,7 @@ public class SimpleExoPlayer implements ExoPlayer, Player.VideoComponent, Player
 
   @Override
   public void addTextOutput(TextOutput listener) {
+    listener.onCues(currentCues);
     textOutputs.add(listener);
   }
 
@@ -775,6 +777,7 @@ public class SimpleExoPlayer implements ExoPlayer, Player.VideoComponent, Player
       mediaSource = null;
       analyticsCollector.resetForNewMediaSource();
     }
+    currentCues = null;
   }
 
   @Override
@@ -790,6 +793,7 @@ public class SimpleExoPlayer implements ExoPlayer, Player.VideoComponent, Player
     if (mediaSource != null) {
       mediaSource.removeEventListener(analyticsCollector);
     }
+    currentCues = null;
   }
 
   @Override
@@ -1095,6 +1099,7 @@ public class SimpleExoPlayer implements ExoPlayer, Player.VideoComponent, Player
 
     @Override
     public void onCues(List<Cue> cues) {
+      currentCues = cues;
       for (TextOutput textOutput : textOutputs) {
         textOutput.onCues(cues);
       }


### PR DESCRIPTION
When attaching a player to a different `PlayerView` the current subtitles are not shown, as it's possible to see bellow:
![not-fixed](https://user-images.githubusercontent.com/1148205/40003981-9ddaa014-578c-11e8-9b55-a87c9213df96.gif)

This PR aims at solving that problem by saving the current subtitles cues to memory and restore them when a `TextOutput` is added, therefore solving the problem.

(Thanks @tonihei for the feedback on #4243)
