### PR TITLE
Public notification manager createnotification

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerNotificationManager.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerNotificationManager.java
@@ -397,6 +397,21 @@ public class PlayerNotificationManager {
   }
 
   /**
+   * Creates the notification given the current player state.
+   *
+   * @param largeIcon The large icon to be used.
+   * @return The {@link Notification} which has been built.
+   */
+  public Notification createNotification(@Nullable Bitmap largeIcon) {
+    if (player != null) {
+      Notification notification = createNotification(player, largeIcon);
+      notificationManager.notify(notificationId, notification);
+      return notification;
+    }
+    return null
+  }
+
+  /**
    * Sets the {@link Player}.
    *
    * <p>Setting the player starts a notification immediately unless the player is in {@link
@@ -797,7 +812,7 @@ public class PlayerNotificationManager {
    * @param largeIcon The large icon to be used.
    * @return The {@link Notification} which has been built.
    */
-  public Notification createNotification(Player player, @Nullable Bitmap largeIcon) {
+  protected Notification createNotification(Player player, @Nullable Bitmap largeIcon) {
     boolean isPlayingAd = player.isPlayingAd();
     NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId);
     List<String> actionNames = getActions(player);

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerNotificationManager.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerNotificationManager.java
@@ -797,7 +797,7 @@ public class PlayerNotificationManager {
    * @param largeIcon The large icon to be used.
    * @return The {@link Notification} which has been built.
    */
-  protected Notification createNotification(Player player, @Nullable Bitmap largeIcon) {
+  public Notification createNotification(Player player, @Nullable Bitmap largeIcon) {
     boolean isPlayingAd = player.isPlayingAd();
     NotificationCompat.Builder builder = new NotificationCompat.Builder(context, channelId);
     List<String> actionNames = getActions(player);


### PR DESCRIPTION
PlayerNotificationManager is saving me a ton of work, thank you.

There is a case when we pause a player, we need to stop foreground service. But when we want to resume the playback and start foreground service, there is no way to obtain notification from player state.

This PR will create public PlayerNotificationManager.createNotification which will return notification instance to be used with startForeground method. Sorry, I'm not good at Java programming.

Please review @ojw28