### PR TITLE
close initDataSource after reading

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
@@ -212,7 +212,7 @@ import java.util.concurrent.atomic.AtomicInteger;
         initSegmentBytesLoaded = (int) (input.getPosition() - initDataSpec.absoluteStreamPosition);
       }
     } finally {
-      Util.closeQuietly(dataSource);
+      Util.closeQuietly(initDataSource);
     }
     initLoadCompleted = true;
   }


### PR DESCRIPTION
I found that exoplayer stops playing when playing HLS + fmp4 + LIVE that has init data declared by EXT-X-MAP.

I think `Util.closeQuietly(dataSource);` should be ` Util.closeQuietly(initDataSource);`

the error is ↓, and i guess DefaultDataSource is opening a spec before another datasource inside the defaultDataSource is closed.

```
    Unexpected exception loading stream
    java.lang.IllegalStateException
        at com.google.android.exoplayer2.util.Assertions.checkState(Assertions.java:81)
        at com.google.android.exoplayer2.upstream.DefaultDataSource.open(DefaultDataSource.java:126)
        at com.google.android.exoplayer2.source.hls.HlsMediaChunk.maybeLoadInitData(HlsMediaChunk.java:235)
        at com.google.android.exoplayer2.source.hls.HlsMediaChunk.load(HlsMediaChunk.java:216)
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:317)
```