### PR TITLE
Support emsg box for HLS + fmp4 playback

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/DefaultHlsExtractorFactory.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/DefaultHlsExtractorFactory.java
@@ -74,7 +74,8 @@ public final class DefaultHlsExtractorFactory implements HlsExtractorFactory {
     } else if (lastPathSegment.endsWith(MP4_FILE_EXTENSION)
         || lastPathSegment.startsWith(M4_FILE_EXTENSION_PREFIX, lastPathSegment.length() - 4)
         || lastPathSegment.startsWith(MP4_FILE_EXTENSION_PREFIX, lastPathSegment.length() - 5)) {
-      extractor = new FragmentedMp4Extractor(0, timestampAdjuster, null, drmInitData,
+      extractor = new FragmentedMp4Extractor(FragmentedMp4Extractor.FLAG_ENABLE_EMSG_TRACK,
+          timestampAdjuster, null, drmInitData,
           muxedCaptionFormats != null ? muxedCaptionFormats : Collections.<Format>emptyList());
     } else {
       // For any other file extension, we assume TS format.


### PR DESCRIPTION
It seems like emsg box is disabled when playing HLS + fmp4.

When I enabled and test it, it worked without any problems.

Do you have any reasons of disabling emsg box for HLS playback?