### PR TITLE
Add withSkippedAd method to AdPlaybackState. 

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/source/ads/AdPlaybackState.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/ads/AdPlaybackState.java
@@ -368,6 +368,14 @@ public final class AdPlaybackState {
     return new AdPlaybackState(adGroupTimesUs, adGroups, adResumePositionUs, contentDurationUs);
   }
 
+  /** Returns an instance with the specified ad marked as skipped. */
+  @CheckResult
+  public AdPlaybackState withSkippedAd(int adGroupIndex, int adIndexInAdGroup) {
+    AdGroup[] adGroups = Arrays.copyOf(this.adGroups, this.adGroups.length);
+    adGroups[adGroupIndex] = adGroups[adGroupIndex].withAdState(AD_STATE_SKIPPED, adIndexInAdGroup);
+    return new AdPlaybackState(adGroupTimesUs, adGroups, adResumePositionUs, contentDurationUs);
+  }
+
   /** Returns an instance with the specified ad marked as having a load error. */
   @CheckResult
   public AdPlaybackState withAdLoadError(int adGroupIndex, int adIndexInAdGroup) {

--- a/library/core/src/test/java/com/google/android/exoplayer2/source/ads/AdPlaybackStateTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/source/ads/AdPlaybackStateTest.java
@@ -90,6 +90,19 @@ public final class AdPlaybackStateTest {
   }
 
   @Test
+  public void testGetFirstAdIndexToPlaySkipsSkippedAd() {
+    state = state.withAdCount(/* adGroupIndex= */ 0, /* adCount= */ 3);
+    state = state.withAdUri(/* adGroupIndex= */ 0, /* adIndexInAdGroup= */ 0, TEST_URI);
+    state = state.withAdUri(/* adGroupIndex= */ 0, /* adIndexInAdGroup= */ 2, TEST_URI);
+
+    state = state.withSkippedAd(/* adGroupIndex= */ 0, /* adIndexInAdGroup= */ 0);
+
+    assertThat(state.adGroups[0].getFirstAdIndexToPlay()).isEqualTo(1);
+    assertThat(state.adGroups[0].states[1]).isEqualTo(AdPlaybackState.AD_STATE_UNAVAILABLE);
+    assertThat(state.adGroups[0].states[2]).isEqualTo(AdPlaybackState.AD_STATE_AVAILABLE);
+  }
+
+  @Test
   public void testGetFirstAdIndexToPlaySkipsErrorAds() {
     state = state.withAdCount(/* adGroupIndex= */ 0, /* adCount= */ 3);
     state = state.withAdUri(/* adGroupIndex= */ 0, /* adIndexInAdGroup= */ 0, TEST_URI);


### PR DESCRIPTION
Currently there is no way to "skip" an individual ad within an ad group. We can only skip entire ad groups with `withSkippedAdGroup`.

My use case here is that I have multiple pre rolls of unknown length in which some may or may not be skippable. Making multiple ad groups with a single ad each is cumbersome here. 

As a workaround I'm using `withPlayedAd` which pretty much has the effect I'm after but seems slightly incorrect to me when in truth I'm skipping the ad. 

Feel free to close if you think `withPlayedAd` is still a preferable way to achieve this (and possibly explain why). 