### PR TITLE
Allow specifying the default live presentation delay

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
@@ -79,6 +79,7 @@ public final class DashMediaSource extends BaseMediaSource {
     private CompositeSequenceableLoaderFactory compositeSequenceableLoaderFactory;
     private int minLoadableRetryCount;
     private long livePresentationDelayMs;
+    private long defaultLivePresentationDelayMs;
     private boolean isCreateCalled;
     private @Nullable Object tag;
 
@@ -98,6 +99,7 @@ public final class DashMediaSource extends BaseMediaSource {
       this.manifestDataSourceFactory = manifestDataSourceFactory;
       minLoadableRetryCount = DEFAULT_MIN_LOADABLE_RETRY_COUNT;
       livePresentationDelayMs = DEFAULT_LIVE_PRESENTATION_DELAY_PREFER_MANIFEST_MS;
+      defaultLivePresentationDelayMs = DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS;
       compositeSequenceableLoaderFactory = new DefaultCompositeSequenceableLoaderFactory();
     }
 
@@ -146,6 +148,23 @@ public final class DashMediaSource extends BaseMediaSource {
       Assertions.checkState(!isCreateCalled);
       this.livePresentationDelayMs = livePresentationDelayMs;
       return this;
+    }
+     
+    /**
+     * Sets the duration in milliseconds by which the default start position should precede the end
+     * of the live window for live playbacks if the value is not present in the manifest. The default value is {@link
+     * #DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS}.
+     *
+     * @param defaultLivePresentationDelayMs For live playbacks, the duration in milliseconds by which the
+     *     default start position should precede the end of the live window if the duration is not specifed in the manifest
+     *     or overwritten using @{link setLivePresentationDelayMs).
+     * @return This factory, for convenience.
+     * @throws IllegalStateException If one of the {@code create} methods has already been called.
+     */
+    public Factory setDefaultLivePresentationDelayMs(long defaultLivePresentationDelayMs) {
+        Assertions.checkState(!isCreateCalled);
+        this.defaultLivePresentationDelayMs = defaultLivePresentationDelayMs;
+        return this
     }
 
     /**
@@ -885,7 +904,7 @@ public final class DashMediaSource extends BaseMediaSource {
       long presentationDelayForManifestMs = livePresentationDelayMs;
       if (presentationDelayForManifestMs == DEFAULT_LIVE_PRESENTATION_DELAY_PREFER_MANIFEST_MS) {
         presentationDelayForManifestMs = manifest.suggestedPresentationDelayMs != C.TIME_UNSET
-            ? manifest.suggestedPresentationDelayMs : DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS;
+            ? manifest.suggestedPresentationDelayMs : defaultLivePresentationDelayMs;
       }
       // Snap the default position to the start of the segment containing it.
       windowDefaultStartPositionUs = windowDurationUs - C.msToUs(presentationDelayForManifestMs);

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
@@ -154,13 +154,13 @@ public final class DashMediaSource extends BaseMediaSource {
      * Sets the duration in milliseconds by which the default start position should precede the end
      * of the live window for live playbacks if the value is not present in the manifest. 
      * The default value is {@link #DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS}. This value is only 
-     * used when {@link setLivePresentationDelayMs) has not overwritten the presentation delay to a
+     * used when {@link setLivePresentationDelayMs} has not overwritten the presentation delay to a
      * value other than #DEFAULT_LIVE_PRESENTATION_DELAY_PREFER_MANIFEST_MS
      *
      * @param defaultLivePresentationDelayMs For live playbacks, the duration in milliseconds by 
      *     which the default start position should precede the end of the live window if the
      *     duration is not specifed in the manifest or overwritten using
-     *     {@link setLivePresentationDelayMs).
+     *     {@link setLivePresentationDelayMs}.
      * @return This factory, for convenience.
      * @throws IllegalStateException If one of the {@code create} methods has already been called.
      */

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
@@ -153,11 +153,12 @@ public final class DashMediaSource extends BaseMediaSource {
     /**
      * Sets the duration in milliseconds by which the default start position should precede the end
      * of the live window for live playbacks if the value is not present in the manifest. The default value is {@link
-     * #DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS}.
+     * #DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS}. This value is only used when {@link setLivePresentationDelayMs) has not 
+     * overwritten the presentation delay to a value other than #DEFAULT_LIVE_PRESENTATION_DELAY_PREFER_MANIFEST_MS
      *
      * @param defaultLivePresentationDelayMs For live playbacks, the duration in milliseconds by which the
      *     default start position should precede the end of the live window if the duration is not specifed in the manifest
-     *     or overwritten using @{link setLivePresentationDelayMs).
+     *     or overwritten using {@link setLivePresentationDelayMs).
      * @return This factory, for convenience.
      * @throws IllegalStateException If one of the {@code create} methods has already been called.
      */
@@ -220,6 +221,7 @@ public final class DashMediaSource extends BaseMediaSource {
           compositeSequenceableLoaderFactory,
           minLoadableRetryCount,
           livePresentationDelayMs,
+          defaultLivePresentationDelayMs,
           tag);
     }
 
@@ -260,6 +262,7 @@ public final class DashMediaSource extends BaseMediaSource {
           compositeSequenceableLoaderFactory,
           minLoadableRetryCount,
           livePresentationDelayMs,
+          defaultLivePresentationDelayMs,
           tag);
     }
 
@@ -321,6 +324,7 @@ public final class DashMediaSource extends BaseMediaSource {
   private final CompositeSequenceableLoaderFactory compositeSequenceableLoaderFactory;
   private final int minLoadableRetryCount;
   private final long livePresentationDelayMs;
+  private final long defaultLivePresentationDelayMs;
   private final EventDispatcher manifestEventDispatcher;
   private final ParsingLoadable.Parser<? extends DashManifest> manifestParser;
   private final ManifestCallback manifestCallback;
@@ -398,6 +402,7 @@ public final class DashMediaSource extends BaseMediaSource {
         new DefaultCompositeSequenceableLoaderFactory(),
         minLoadableRetryCount,
         DEFAULT_LIVE_PRESENTATION_DELAY_PREFER_MANIFEST_MS,
+        DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS,
         /* tag= */ null);
     if (eventHandler != null && eventListener != null) {
       addEventListener(eventHandler, eventListener);
@@ -495,6 +500,7 @@ public final class DashMediaSource extends BaseMediaSource {
         new DefaultCompositeSequenceableLoaderFactory(),
         minLoadableRetryCount,
         livePresentationDelayMs,
+        DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS,
         /* tag= */ null);
     if (eventHandler != null && eventListener != null) {
       addEventListener(eventHandler, eventListener);
@@ -510,6 +516,7 @@ public final class DashMediaSource extends BaseMediaSource {
       CompositeSequenceableLoaderFactory compositeSequenceableLoaderFactory,
       int minLoadableRetryCount,
       long livePresentationDelayMs,
+      long defaultLivePresentationDelayMs,
       @Nullable Object tag) {
     this.initialManifestUri = manifestUri;
     this.manifest = manifest;
@@ -519,6 +526,7 @@ public final class DashMediaSource extends BaseMediaSource {
     this.chunkSourceFactory = chunkSourceFactory;
     this.minLoadableRetryCount = minLoadableRetryCount;
     this.livePresentationDelayMs = livePresentationDelayMs;
+    this.defaultLivePresentationDelayMs = defaultLivePresentationDelayMs;
     this.compositeSequenceableLoaderFactory = compositeSequenceableLoaderFactory;
     this.tag = tag;
     sideloadedManifest = manifest != null;

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
@@ -152,13 +152,15 @@ public final class DashMediaSource extends BaseMediaSource {
      
     /**
      * Sets the duration in milliseconds by which the default start position should precede the end
-     * of the live window for live playbacks if the value is not present in the manifest. The default value is {@link
-     * #DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS}. This value is only used when {@link setLivePresentationDelayMs) has not 
-     * overwritten the presentation delay to a value other than #DEFAULT_LIVE_PRESENTATION_DELAY_PREFER_MANIFEST_MS
+     * of the live window for live playbacks if the value is not present in the manifest. 
+     * The default value is {@link #DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS}. This value is only 
+     * used when {@link setLivePresentationDelayMs) has not overwritten the presentation delay to a
+     * value other than #DEFAULT_LIVE_PRESENTATION_DELAY_PREFER_MANIFEST_MS
      *
-     * @param defaultLivePresentationDelayMs For live playbacks, the duration in milliseconds by which the
-     *     default start position should precede the end of the live window if the duration is not specifed in the manifest
-     *     or overwritten using {@link setLivePresentationDelayMs).
+     * @param defaultLivePresentationDelayMs For live playbacks, the duration in milliseconds by 
+     *     which the default start position should precede the end of the live window if the
+     *     duration is not specifed in the manifest or overwritten using
+     *     {@link setLivePresentationDelayMs).
      * @return This factory, for convenience.
      * @throws IllegalStateException If one of the {@code create} methods has already been called.
      */

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaSource.java
@@ -162,9 +162,9 @@ public final class DashMediaSource extends BaseMediaSource {
      * @throws IllegalStateException If one of the {@code create} methods has already been called.
      */
     public Factory setDefaultLivePresentationDelayMs(long defaultLivePresentationDelayMs) {
-        Assertions.checkState(!isCreateCalled);
-        this.defaultLivePresentationDelayMs = defaultLivePresentationDelayMs;
-        return this
+      Assertions.checkState(!isCreateCalled);
+      this.defaultLivePresentationDelayMs = defaultLivePresentationDelayMs;
+      return this;
     }
 
     /**


### PR DESCRIPTION
When the suggestedPresentationDelay is missing from the manifest, a fallback value is used (DEFAULT_LIVE_PRESENTATION_DELAY_FIXED_MS). This PR adds a method to the factory to override this value