### PR TITLE
Fix pending Metadata timestamp relative to subsample offset

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/metadata/MetadataRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/metadata/MetadataRenderer.java
@@ -128,7 +128,7 @@ public final class MetadataRenderer extends BaseRenderer implements Callback {
           try {
             int index = (pendingMetadataIndex + pendingMetadataCount) % MAX_PENDING_METADATA_COUNT;
             pendingMetadata[index] = decoder.decode(buffer);
-            pendingMetadataTimestamps[index] = buffer.timeUs;
+            pendingMetadataTimestamps[index] = buffer.timeUs + buffer.subsampleOffsetUs;
             pendingMetadataCount++;
           } catch (MetadataDecoderException e) {
             throw ExoPlaybackException.createForRenderer(e, getIndex());


### PR DESCRIPTION
Since MetadataRenderer queues events until event times are current
position, this leads to metadata event like SCTE-35 not being delivered.

To compare to player timestamp, we need to include subsample offset.