### PR TITLE
Support vector drawables to be used as default artwork

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
@@ -1079,6 +1079,9 @@ public class PlayerView extends FrameLayout {
   private boolean setDrawableArtwork(Drawable drawable) {
     if(drawable != null) {
       artworkView.setImageDrawable(drawable);
+      if(contentFrame != null) {
+        contentFrame.setAspectRatio(0);
+      }
     }
     return true;
   }

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
@@ -22,10 +22,15 @@ import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.RectF;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -368,7 +373,7 @@ public class PlayerView extends FrameLayout {
     artworkView = findViewById(R.id.exo_artwork);
     this.useArtwork = useArtwork && artworkView != null;
     if (defaultArtworkId != 0) {
-      defaultArtwork = BitmapFactory.decodeResource(context.getResources(), defaultArtworkId);
+      defaultArtwork = loadFromResource(defaultArtworkId);
     }
 
     // Subtitle view.
@@ -414,6 +419,21 @@ public class PlayerView extends FrameLayout {
     this.controllerHideDuringAds = controllerHideDuringAds;
     this.useController = useController && controller != null;
     hideController();
+  }
+
+  private Bitmap loadFromResource(int defaultArtworkId) {
+    Drawable drawable = ContextCompat.getDrawable(getContext(), defaultArtworkId);
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+      drawable = (DrawableCompat.wrap(drawable)).mutate();
+    }
+
+    Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(),
+            drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+    Canvas canvas = new Canvas(bitmap);
+    drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+    drawable.draw(canvas);
+
+    return bitmap;
   }
 
   /**

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
@@ -22,16 +22,13 @@ import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.RectF;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.graphics.drawable.DrawableCompat;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -568,7 +565,9 @@ public class PlayerView extends FrameLayout {
    * present in the media.
    *
    * @param defaultArtwork the default artwork to display.
+   * @deprecated use (@link {@link #setDefaultArtwork(Drawable)} instead.
    */
+  @Deprecated
   public void setDefaultArtwork(Bitmap defaultArtwork) {
     setDefaultArtwork(new BitmapDrawable(getResources(), defaultArtwork));
   }
@@ -1071,35 +1070,17 @@ public class PlayerView extends FrameLayout {
       if (metadataEntry instanceof ApicFrame) {
         byte[] bitmapData = ((ApicFrame) metadataEntry).pictureData;
         Bitmap bitmap = BitmapFactory.decodeByteArray(bitmapData, 0, bitmapData.length);
-        return setArtworkFromBitmap(new BitmapDrawable(getResources(), bitmap));
+        return setDrawableArtwork(new BitmapDrawable(getResources(), bitmap));
       }
     }
     return false;
   }
 
   private boolean setDrawableArtwork(Drawable drawable) {
-    if(drawable instanceof BitmapDrawable) {
-      return setArtworkFromBitmap(((BitmapDrawable) drawable));
-    } else {
+    if(drawable != null) {
       artworkView.setImageDrawable(drawable);
     }
     return true;
-  }
-
-  private boolean setArtworkFromBitmap(BitmapDrawable bitmapDrawable) {
-    if (bitmapDrawable != null) {
-      int bitmapWidth = bitmapDrawable.getBitmap().getWidth();
-      int bitmapHeight = bitmapDrawable.getBitmap().getHeight();
-      if (bitmapWidth > 0 && bitmapHeight > 0) {
-        if (contentFrame != null) {
-          contentFrame.setAspectRatio((float) bitmapWidth / bitmapHeight);
-        }
-        artworkView.setImageBitmap(bitmapDrawable.getBitmap());
-        artworkView.setVisibility(VISIBLE);
-        return true;
-      }
-    }
-    return false;
   }
 
   private void hideArtwork() {


### PR DESCRIPTION
Currently references to vector drawables for the default artwork of the PlayerView are not supported (the call to `BitmapFactory.decodeResource(context.getResources(), defaultArtworkId);` returns `null` if vector drawable is referenced), and this PR will allow vector drawables to be used as well.