### PR TITLE
#4304 - Add option to show buffering view when setPlayWhenReady is false

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
@@ -666,13 +666,13 @@ public class PlayerView extends FrameLayout {
    * Sets whether a buffering spinner is displayed when the player is in the buffering state. The
    * buffering spinner is not displayed by default.
    *
-   * Deprecated, use {@link #setShowBuffering(int)}
+   * @deprecated Use {@link #setShowBuffering(int)}
    *
    * @param showBuffering Whether the buffering icon is displayed
    */
   @Deprecated
   public void setShowBuffering(boolean showBuffering) {
-    setShowBuffering(showBuffering ? SHOW_BUFFERING_ALWAYS : SHOW_BUFFERING_NEVER);
+    setShowBuffering(showBuffering ? SHOW_BUFFERING_WHEN_PLAYING : SHOW_BUFFERING_NEVER);
   }
 
   /**
@@ -683,7 +683,7 @@ public class PlayerView extends FrameLayout {
    * <li>{@link #SHOW_BUFFERING_ALWAYS} displayed always when buffering
    * <li>{@link #SHOW_BUFFERING_NEVER} not displayed at all
    * <li>{@link #SHOW_BUFFERING_WHEN_PLAYING} displayed only when playing and buffering
-   * </p></ul>
+   * </ul></p>
    *
    * @param showBuffering Buffering strategy that defines when the buffering icon is displayed
    */

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
@@ -25,6 +25,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.graphics.RectF;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
@@ -61,6 +62,8 @@ import com.google.android.exoplayer2.util.ErrorMessageProvider;
 import com.google.android.exoplayer2.util.RepeatModeUtil;
 import com.google.android.exoplayer2.util.Util;
 import com.google.android.exoplayer2.video.VideoListener;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.List;
 
 /**
@@ -237,6 +240,14 @@ public class PlayerView extends FrameLayout {
   private static final int SURFACE_TYPE_TEXTURE_VIEW = 2;
   private static final int SURFACE_TYPE_MONO360_VIEW = 3;
 
+  public static final int SHOW_BUFFERING_NEVER = 0;
+  public static final int SHOW_BUFFERING_ALWAYS = 1;
+  public static final int SHOW_BUFFERING_WHEN_PLAYING = 2;
+
+  @IntDef({SHOW_BUFFERING_NEVER, SHOW_BUFFERING_WHEN_PLAYING, SHOW_BUFFERING_ALWAYS})
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface ShowBuffering {}
+
   private final AspectRatioFrameLayout contentFrame;
   private final View shutterView;
   private final View surfaceView;
@@ -252,7 +263,7 @@ public class PlayerView extends FrameLayout {
   private boolean useController;
   private boolean useArtwork;
   private Bitmap defaultArtwork;
-  private boolean showBuffering;
+  private @ShowBuffering int showBuffering;
   private boolean keepContentOnPlayerReset;
   private @Nullable ErrorMessageProvider<? super ExoPlaybackException> errorMessageProvider;
   private @Nullable CharSequence customErrorMessage;
@@ -306,7 +317,7 @@ public class PlayerView extends FrameLayout {
     boolean controllerHideOnTouch = true;
     boolean controllerAutoShow = true;
     boolean controllerHideDuringAds = true;
-    boolean showBuffering = false;
+    int showBuffering = SHOW_BUFFERING_NEVER;
     if (attrs != null) {
       TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.PlayerView, 0, 0);
       try {
@@ -324,7 +335,7 @@ public class PlayerView extends FrameLayout {
         controllerHideOnTouch =
             a.getBoolean(R.styleable.PlayerView_hide_on_touch, controllerHideOnTouch);
         controllerAutoShow = a.getBoolean(R.styleable.PlayerView_auto_show, controllerAutoShow);
-        showBuffering = a.getBoolean(R.styleable.PlayerView_show_buffering, showBuffering);
+        showBuffering = a.getInteger(R.styleable.PlayerView_show_buffering, showBuffering);
         keepContentOnPlayerReset =
             a.getBoolean(
                 R.styleable.PlayerView_keep_content_on_player_reset, keepContentOnPlayerReset);
@@ -655,9 +666,28 @@ public class PlayerView extends FrameLayout {
    * Sets whether a buffering spinner is displayed when the player is in the buffering state. The
    * buffering spinner is not displayed by default.
    *
+   * Deprecated, use {@link #setShowBuffering(int)}
+   *
    * @param showBuffering Whether the buffering icon is displayed
    */
+  @Deprecated
   public void setShowBuffering(boolean showBuffering) {
+    setShowBuffering(showBuffering ? SHOW_BUFFERING_ALWAYS : SHOW_BUFFERING_NEVER);
+  }
+
+  /**
+   * Sets whether a buffering spinner is displayed when the player is in the buffering state. The
+   * buffering spinner is not displayed by default (initial value {@link #SHOW_BUFFERING_NEVER})
+   *
+   * <p><ul>
+   * <li>{@link #SHOW_BUFFERING_ALWAYS} displayed always when buffering
+   * <li>{@link #SHOW_BUFFERING_NEVER} not displayed at all
+   * <li>{@link #SHOW_BUFFERING_WHEN_PLAYING} displayed only when playing and buffering
+   * </p></ul>
+   *
+   * @param showBuffering Buffering strategy that defines when the buffering icon is displayed
+   */
+  public void setShowBuffering(@ShowBuffering int showBuffering) {
     if (this.showBuffering != showBuffering) {
       this.showBuffering = showBuffering;
       updateBuffering();
@@ -1139,11 +1169,23 @@ public class PlayerView extends FrameLayout {
 
   private void updateBuffering() {
     if (bufferingView != null) {
-      boolean showBufferingSpinner =
-          showBuffering
-              && player != null
-              && player.getPlaybackState() == Player.STATE_BUFFERING
-              && player.getPlayWhenReady();
+
+      boolean showBufferingSpinner = false;
+
+      if (player != null && player.getPlaybackState() == Player.STATE_BUFFERING) {
+        switch (showBuffering) {
+          case SHOW_BUFFERING_ALWAYS:
+            showBufferingSpinner = true;
+            break;
+          case SHOW_BUFFERING_NEVER:
+            showBufferingSpinner = false;
+            break;
+          case SHOW_BUFFERING_WHEN_PLAYING:
+            showBufferingSpinner = player.getPlayWhenReady();
+            break;
+        }
+      }
+
       bufferingView.setVisibility(showBufferingSpinner ? View.VISIBLE : View.GONE);
     }
   }

--- a/library/ui/src/main/res/values/attrs.xml
+++ b/library/ui/src/main/res/values/attrs.xml
@@ -52,9 +52,9 @@
     <attr name="hide_during_ads" format="boolean"/>
     <attr name="auto_show" format="boolean"/>
     <attr name="show_buffering" format="enum">
-      <enum name="show_buffering_never" value="0"/>
-      <enum name="show_buffering_always" value="1"/>
-      <enum name="show_buffering_when_playing" value="2"/>
+      <enum name="never" value="0"/>
+      <enum name="always" value="1"/>
+      <enum name="when_playing" value="2"/>
     </attr>
     <attr name="keep_content_on_player_reset" format="boolean"/>
     <attr name="resize_mode"/>

--- a/library/ui/src/main/res/values/attrs.xml
+++ b/library/ui/src/main/res/values/attrs.xml
@@ -51,7 +51,11 @@
     <attr name="hide_on_touch" format="boolean"/>
     <attr name="hide_during_ads" format="boolean"/>
     <attr name="auto_show" format="boolean"/>
-    <attr name="show_buffering" format="boolean"/>
+    <attr name="show_buffering" format="enum">
+      <enum name="show_buffering_never" value="0"/>
+      <enum name="show_buffering_always" value="1"/>
+      <enum name="show_buffering_when_playing" value="2"/>
+    </attr>
     <attr name="keep_content_on_player_reset" format="boolean"/>
     <attr name="resize_mode"/>
     <attr name="surface_type"/>


### PR DESCRIPTION
Added an option to show buffering view when ```playWhenReady``` is set to false. So from now the visibility state can be defined with the following options:

1. ```SHOW_BUFFERING_NEVER```
2. ```SHOW_BUFFERING_ALWAYS```
3. ```SHOW_BUFFERING_WHEN_PLAYING```

Checked on emulator where I tweaked the network type / signal strength to be able to test it and it seemed OK to me in every case. 

Link to the original issue: https://github.com/google/ExoPlayer/issues/4304