### PR TITLE
ClearKey API < 26 fix

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
@@ -153,8 +153,9 @@ public final class FrameworkMediaDrm implements ExoMediaDrm<FrameworkMediaCrypto
     }
 
     // Prior to API level 26 the ClearKey CDM only accepted "cenc" as the scheme for MP4.
+    // For APIs less than 27 ClearKey UUID is changed to Common PSSH UUID in the constructor
     if (Util.SDK_INT < 26
-        && C.CLEARKEY_UUID.equals(uuid)
+        && C.COMMON_PSSH_UUID.equals(uuid)
         && (MimeTypes.VIDEO_MP4.equals(mimeType) || MimeTypes.AUDIO_MP4.equals(mimeType))) {
       mimeType = CENC_SCHEME_MIME_TYPE;
     }


### PR DESCRIPTION
Setting mimeType to CENC_SCHEME_MIME_TYPE for APIs prior to 26 in getKeyRequest never executed, because UUID was checked against ClearKey UUID. For APIs less than 27 ClearKey UUID is changed to Common PSSH UUID in the constructor.