### PR TITLE
Add parsing a-law and mu-law atom types

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp4/Atom.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp4/Atom.java
@@ -143,6 +143,8 @@ import java.util.List;
   public static final int TYPE_vpcC = Util.getIntegerCodeForString("vpcC");
   public static final int TYPE_camm = Util.getIntegerCodeForString("camm");
   public static final int TYPE_alac = Util.getIntegerCodeForString("alac");
+  public static final int TYPE_alaw = Util.getIntegerCodeForString("alaw");
+  public static final int TYPE_ulaw = Util.getIntegerCodeForString("ulaw");
 
   public final int type;
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -660,7 +660,8 @@ import java.util.List;
           || childAtomType == Atom.TYPE_dtsh || childAtomType == Atom.TYPE_dtsl
           || childAtomType == Atom.TYPE_samr || childAtomType == Atom.TYPE_sawb
           || childAtomType == Atom.TYPE_lpcm || childAtomType == Atom.TYPE_sowt
-          || childAtomType == Atom.TYPE__mp3 || childAtomType == Atom.TYPE_alac) {
+          || childAtomType == Atom.TYPE__mp3 || childAtomType == Atom.TYPE_alac
+          || childAtomType == Atom.TYPE_alaw || childAtomType == Atom.TYPE_ulaw ) {
         parseAudioSampleEntry(stsd, childAtomType, childStartPosition, childAtomSize, trackId,
             language, isQuickTime, drmInitData, out, i);
       } else if (childAtomType == Atom.TYPE_TTML || childAtomType == Atom.TYPE_tx3g
@@ -953,6 +954,10 @@ import java.util.List;
       mimeType = MimeTypes.AUDIO_MPEG;
     } else if (atomType == Atom.TYPE_alac) {
       mimeType = MimeTypes.AUDIO_ALAC;
+    } else if (atomType == Atom.TYPE_alaw) {
+      mimeType = MimeTypes.AUDIO_ALAW;
+    } else if (atomType == Atom.TYPE_ulaw ) {
+      mimeType = MimeTypes.AUDIO_MLAW;
     }
 
     byte[] initializationData = null;


### PR DESCRIPTION
I had a problem similar to https://github.com/google/ExoPlayer/issues/4360. In my case, the MP4 container had 2 streams: _avc1_ for video data and _alaw_ for audio data. The video stream was playing correctly whereas there was no audio. The changes I made in this PR "enabled" audio for me.