### PR TITLE
Make DefaultTrackSelector.AudioTrackScore protected

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelector.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelector.java
@@ -2141,7 +2141,7 @@ public class DefaultTrackSelector extends MappingTrackSelector {
   }
 
   /** Represents how well an audio track matches the selection {@link Parameters}. */
-  private static final class AudioTrackScore implements Comparable<AudioTrackScore> {
+  protected static final class AudioTrackScore implements Comparable<AudioTrackScore> {
 
     private final Parameters parameters;
     private final int withinRendererCapabilitiesScore;


### PR DESCRIPTION
This allows selectAudioTrack() to be overridden.