### PR TITLE
Add support for groupId in Format class

### DIFF
--- a/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacExtractor.java
+++ b/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacExtractor.java
@@ -277,6 +277,7 @@ public final class FlacExtractor implements Extractor {
             /* drmInitData= */ null,
             /* selectionFlags= */ 0,
             /* language= */ null,
+            /* groupId= */ null,
             isId3MetadataDisabled ? null : id3Metadata);
     trackOutput.format(mediaFormat);
   }

--- a/library/core/src/main/java/com/google/android/exoplayer2/Format.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/Format.java
@@ -162,6 +162,9 @@ public final class Format implements Parcelable {
   /** The language, or null if unknown or not applicable. */
   public final @Nullable String language;
 
+  /** The group id for the , or null if unknown or not applicable. */
+  public final @Nullable String groupId;
+
   /**
    * The Accessibility channel, or {@link #NO_VALUE} if not known or applicable.
    */
@@ -233,6 +236,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         selectionFlags,
         /* language= */ null,
+        /* groupId= */ null,
         /* accessibilityChannel= */ NO_VALUE,
         OFFSET_SAMPLE_RELATIVE,
         initializationData,
@@ -336,6 +340,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         /* selectionFlags= */ 0,
         /* language= */ null,
+        /* groupId= */ null,
         /* accessibilityChannel= */ NO_VALUE,
         OFFSET_SAMPLE_RELATIVE,
         initializationData,
@@ -368,7 +373,8 @@ public final class Format implements Parcelable {
         sampleRate,
         initializationData,
         selectionFlags,
-        language);
+        language,
+        /* groupId= */ null);
   }
 
   public static Format createAudioContainerFormat(
@@ -382,7 +388,8 @@ public final class Format implements Parcelable {
       int sampleRate,
       @Nullable List<byte[]> initializationData,
       @C.SelectionFlags int selectionFlags,
-      @Nullable String language) {
+      @Nullable String language,
+      @Nullable String groupId) {
     return new Format(
         id,
         label,
@@ -406,6 +413,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         selectionFlags,
         language,
+        groupId,
         /* accessibilityChannel= */ NO_VALUE,
         OFFSET_SAMPLE_RELATIVE,
         initializationData,
@@ -468,6 +476,7 @@ public final class Format implements Parcelable {
         drmInitData,
         selectionFlags,
         language,
+        /* groupId= */ null,
         /* metadata= */ null);
   }
 
@@ -486,6 +495,7 @@ public final class Format implements Parcelable {
       @Nullable DrmInitData drmInitData,
       @C.SelectionFlags int selectionFlags,
       @Nullable String language,
+      @Nullable String groupId,
       @Nullable Metadata metadata) {
     return new Format(
         id,
@@ -510,6 +520,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         /* accessibilityChannel= */ NO_VALUE,
         OFFSET_SAMPLE_RELATIVE,
         initializationData,
@@ -536,7 +547,8 @@ public final class Format implements Parcelable {
         codecs,
         bitrate,
         selectionFlags,
-        language);
+        language,
+        /* groupId= */ null);
   }
 
   public static Format createTextContainerFormat(
@@ -547,7 +559,8 @@ public final class Format implements Parcelable {
       @Nullable String codecs,
       int bitrate,
       @C.SelectionFlags int selectionFlags,
-      @Nullable String language) {
+      @Nullable String language,
+      @Nullable String groupId) {
     return createTextContainerFormat(
         id,
         label,
@@ -557,6 +570,7 @@ public final class Format implements Parcelable {
         bitrate,
         selectionFlags,
         language,
+        groupId,
         /* accessibilityChannel= */ NO_VALUE);
   }
 
@@ -569,6 +583,7 @@ public final class Format implements Parcelable {
       int bitrate,
       @C.SelectionFlags int selectionFlags,
       @Nullable String language,
+      @Nullable String groupId,
       int accessibilityChannel) {
     return new Format(
         id,
@@ -593,6 +608,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         OFFSET_SAMPLE_RELATIVE,
         /* initializationData= */ null,
@@ -705,6 +721,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         selectionFlags,
         language,
+        /* groupId= */ null,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -746,6 +763,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         selectionFlags,
         language,
+        /* groupId= */ null,
         /* accessibilityChannel= */ NO_VALUE,
         OFFSET_SAMPLE_RELATIVE,
         initializationData,
@@ -807,6 +825,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         selectionFlags,
         language,
+        /* groupId= */ null,
         /* accessibilityChannel= */ NO_VALUE,
         OFFSET_SAMPLE_RELATIVE,
         /* initializationData= */ null,
@@ -839,6 +858,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         /* selectionFlags= */ 0,
         /* language= */ null,
+        /* groupId= */ null,
         /* accessibilityChannel= */ NO_VALUE,
         subsampleOffsetUs,
         /* initializationData= */ null,
@@ -875,6 +895,7 @@ public final class Format implements Parcelable {
         /* encoderPadding= */ NO_VALUE,
         /* selectionFlags= */ 0,
         /* language= */ null,
+        /* groupId= */ null,
         /* accessibilityChannel= */ NO_VALUE,
         OFFSET_SAMPLE_RELATIVE,
         /* initializationData= */ null,
@@ -905,6 +926,7 @@ public final class Format implements Parcelable {
       int encoderPadding,
       @C.SelectionFlags int selectionFlags,
       @Nullable String language,
+      @Nullable String groupId,
       int accessibilityChannel,
       long subsampleOffsetUs,
       @Nullable List<byte[]> initializationData,
@@ -933,6 +955,7 @@ public final class Format implements Parcelable {
     this.encoderPadding = encoderPadding == Format.NO_VALUE ? 0 : encoderPadding;
     this.selectionFlags = selectionFlags;
     this.language = language;
+    this.groupId = groupId;
     this.accessibilityChannel = accessibilityChannel;
     this.subsampleOffsetUs = subsampleOffsetUs;
     this.initializationData =
@@ -966,6 +989,7 @@ public final class Format implements Parcelable {
     encoderPadding = in.readInt();
     selectionFlags = in.readInt();
     language = in.readString();
+    groupId = in.readString();
     accessibilityChannel = in.readInt();
     subsampleOffsetUs = in.readLong();
     int initializationDataSize = in.readInt();
@@ -1001,6 +1025,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -1032,6 +1057,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -1072,6 +1098,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -1094,9 +1121,14 @@ public final class Format implements Parcelable {
     // Prefer manifest values, but fill in from sample format if missing.
     String label = manifestFormat.label != null ? manifestFormat.label : this.label;
     String language = this.language;
-    if ((trackType == C.TRACK_TYPE_TEXT || trackType == C.TRACK_TYPE_AUDIO)
-        && manifestFormat.language != null) {
-      language = manifestFormat.language;
+    String groupId = this.groupId;
+    if ((trackType == C.TRACK_TYPE_TEXT || trackType == C.TRACK_TYPE_AUDIO)) {
+      if (manifestFormat.language != null) {
+        language = manifestFormat.language;
+      }
+      if (manifestFormat.groupId != null) {
+        groupId = manifestFormat.groupId;
+      }
     }
 
     // Prefer sample format values, but fill in from manifest if missing.
@@ -1143,6 +1175,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -1174,6 +1207,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -1205,6 +1239,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -1236,6 +1271,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -1267,6 +1303,7 @@ public final class Format implements Parcelable {
         encoderPadding,
         selectionFlags,
         language,
+        groupId,
         accessibilityChannel,
         subsampleOffsetUs,
         initializationData,
@@ -1299,6 +1336,8 @@ public final class Format implements Parcelable {
         + ", "
         + language
         + ", ["
+        + groupId
+        + ", ["
         + width
         + ", "
         + height
@@ -1326,6 +1365,7 @@ public final class Format implements Parcelable {
       result = 31 * result + channelCount;
       result = 31 * result + sampleRate;
       result = 31 * result + (language == null ? 0 : language.hashCode());
+      result = 31 * result + (groupId == null ? 0 : groupId.hashCode());
       result = 31 * result + accessibilityChannel;
       result = 31 * result + (drmInitData == null ? 0 : drmInitData.hashCode());
       result = 31 * result + (metadata == null ? 0 : metadata.hashCode());
@@ -1376,6 +1416,7 @@ public final class Format implements Parcelable {
         && Util.areEqual(id, other.id)
         && Util.areEqual(label, other.label)
         && Util.areEqual(language, other.language)
+        && Util.areEqual(groupId, other.groupId)
         && accessibilityChannel == other.accessibilityChannel
         && Util.areEqual(containerMimeType, other.containerMimeType)
         && Util.areEqual(sampleMimeType, other.sampleMimeType)
@@ -1437,6 +1478,9 @@ public final class Format implements Parcelable {
     if (format.language != null) {
       builder.append(", language=").append(format.language);
     }
+    if (format.groupId != null) {
+      builder.append(", groupId=").append(format.groupId);
+    }
     if (format.label != null) {
       builder.append(", label=").append(format.label);
     }
@@ -1477,6 +1521,7 @@ public final class Format implements Parcelable {
     dest.writeInt(encoderPadding);
     dest.writeInt(selectionFlags);
     dest.writeString(language);
+    dest.writeString(groupId);
     dest.writeInt(accessibilityChannel);
     dest.writeLong(subsampleOffsetUs);
     int initializationDataSize = initializationData.size();

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp3/Mp3Extractor.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp3/Mp3Extractor.java
@@ -196,6 +196,7 @@ public final class Mp3Extractor implements Extractor {
               /* drmInitData= */ null,
               /* selectionFlags= */ 0,
               /* language= */ null,
+              /* groupId= */ null,
               (flags & FLAG_DISABLE_ID3_METADATA) != 0 ? null : metadata));
     }
     return readSample(input);

--- a/library/core/src/test/java/com/google/android/exoplayer2/FormatTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/FormatTest.java
@@ -88,6 +88,7 @@ public final class FormatTest {
             /* encoderPadding= */ 1002,
             C.SELECTION_FLAG_DEFAULT,
             "language",
+            "groupId",
             /* accessibilityChannel= */ Format.NO_VALUE,
             Format.OFFSET_SAMPLE_RELATIVE,
             INIT_DATA,

--- a/library/core/src/test/java/com/google/android/exoplayer2/extractor/rawcc/RawCcExtractorTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/extractor/rawcc/RawCcExtractorTest.java
@@ -42,6 +42,7 @@ public final class RawCcExtractorTest {
                     /* bitrate= */ Format.NO_VALUE,
                     /* selectionFlags= */ 0,
                     /* language= */ null,
+                    /* groupId= */ null,
                     /* accessibilityChannel= */ 1)),
         "rawcc/sample.rawcc");
   }

--- a/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
@@ -1298,7 +1298,8 @@ public final class DefaultTrackSelectorTest {
         /* codecs= */ null,
         /* bitrate= */ Format.NO_VALUE,
         selectionFlags,
-        language);
+        language,
+        /* groupId= */ null);
   }
 
   /**

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestParser.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestParser.java
@@ -596,7 +596,8 @@ public class DashManifestParser extends DefaultHandler
             audioSamplingRate,
             /* initializationData= */ null,
             selectionFlags,
-            language);
+            language,
+            /* groupId= */ null);
       } else if (mimeTypeIsRawText(sampleMimeType)) {
         int accessibilityChannel;
         if (MimeTypes.APPLICATION_CEA608.equals(sampleMimeType)) {
@@ -615,6 +616,7 @@ public class DashManifestParser extends DefaultHandler
             bitrate,
             selectionFlags,
             language,
+            /* groupId= */ null,
             accessibilityChannel);
       }
     }

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java
@@ -583,7 +583,8 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsSampleStreamWrapper
         /* sampleRate= */ Format.NO_VALUE,
         /* initializationData= */ null,
         selectionFlags,
-        language);
+        language,
+        /* groupId= */ null);
   }
 
 }

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -358,7 +358,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
                   /* sampleRate= */ Format.NO_VALUE,
                   /* initializationData= */ null,
                   selectionFlags,
-                  language);
+                  language,
+                  groupId);
           if (uri == null) {
             muxedAudioFormat = format;
           } else {
@@ -375,7 +376,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
                   /* codecs= */ null,
                   /* bitrate= */ Format.NO_VALUE,
                   selectionFlags,
-                  language);
+                  language,
+                  groupId);
           subtitles.add(new HlsMasterPlaylist.HlsUrl(uri, format));
           break;
         case TYPE_CLOSED_CAPTIONS:
@@ -402,6 +404,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
                   /* bitrate= */ Format.NO_VALUE,
                   selectionFlags,
                   language,
+                  groupId,
                   accessibilityChannel));
           break;
         default:

--- a/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylistParserTest.java
+++ b/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylistParserTest.java
@@ -75,7 +75,7 @@ public class HlsMasterPlaylistParserTest {
 
   private static final String PLAYLIST_WITH_CC =
       " #EXTM3U \n"
-          + "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,"
+          + "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"cc1\","
           + "LANGUAGE=\"es\",NAME=\"Eng\",INSTREAM-ID=\"SERVICE4\"\n"
           + "#EXT-X-STREAM-INF:BANDWIDTH=1280000,"
           + "CODECS=\"mp4a.40.2,avc1.66.30\",RESOLUTION=304x128\n"
@@ -89,6 +89,14 @@ public class HlsMasterPlaylistParserTest {
           + "CODECS=\"mp4a.40.2,avc1.66.30\",RESOLUTION=304x128,"
           + "CLOSED-CAPTIONS=NONE\n"
           + "http://example.com/low.m3u8\n";
+
+  private static final String PLAYLIST_WITH_SUBTITLES =
+      " #EXTM3U \n"
+              + "#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID=\"sub1\","
+              + "LANGUAGE=\"es\",NAME=\"Eng\"\n"
+              + "#EXT-X-STREAM-INF:BANDWIDTH=1280000,"
+              + "CODECS=\"mp4a.40.2,avc1.66.30\",RESOLUTION=304x128\n"
+              + "http://example.com/low.m3u8\n";
 
   private static final String PLAYLIST_WITH_AUDIO_MEDIA_TAG =
       "#EXTM3U\n"
@@ -214,6 +222,33 @@ public class HlsMasterPlaylistParserTest {
     Format secondAudioFormat = playlist.audios.get(1).format;
     assertThat(secondAudioFormat.codecs).isEqualTo("ac-3");
     assertThat(secondAudioFormat.sampleMimeType).isEqualTo(MimeTypes.AUDIO_AC3);
+  }
+
+  @Test
+  public void testAudioGroupIdPropagation() throws IOException {
+    HlsMasterPlaylist playlist = parseMasterPlaylist(PLAYLIST_URI, PLAYLIST_WITH_AUDIO_MEDIA_TAG);
+
+    Format firstAudioFormat = playlist.audios.get(0).format;
+    assertThat(firstAudioFormat.groupId).isEqualTo("aud1");
+
+    Format secondAudioFormat = playlist.audios.get(1).format;
+    assertThat(secondAudioFormat.groupId).isEqualTo("aud2");
+  }
+
+  @Test
+  public void testCCGroupIdPropagation() throws IOException {
+    HlsMasterPlaylist playlist = parseMasterPlaylist(PLAYLIST_URI, PLAYLIST_WITH_CC);
+
+    Format firstTextFormat = playlist.muxedCaptionFormats.get(0);
+    assertThat(firstTextFormat.groupId).isEqualTo("cc1");
+  }
+
+  @Test
+  public void testSubtitleGroupIdPropagation() throws IOException {
+    HlsMasterPlaylist playlist = parseMasterPlaylist(PLAYLIST_URI, PLAYLIST_WITH_SUBTITLES);
+
+    Format firstTextFormat = playlist.subtitles.get(0).format;
+    assertThat(firstTextFormat.groupId).isEqualTo("sub1");
   }
 
   @Test

--- a/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/manifest/SsManifestParser.java
+++ b/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/manifest/SsManifestParser.java
@@ -662,7 +662,8 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
                 samplingRate,
                 codecSpecificData,
                 /* selectionFlags= */ 0,
-                language);
+                language,
+                /* groupId= */ null);
       } else if (type == C.TRACK_TYPE_TEXT) {
         String language = (String) getNormalizedAttribute(KEY_LANGUAGE);
         format =
@@ -674,7 +675,8 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
                 /* codecs= */ null,
                 bitrate,
                 /* selectionFlags= */ 0,
-                language);
+                language,
+                /* groupId= */ null);
       } else {
         format =
             Format.createContainerFormat(


### PR DESCRIPTION
In HLS, we can end up with text and audio tracks that have duplicated names, which yield non-unique ids in the format object. This PR adds support for the (already parsed) groupId. Because the spec defines the group as requiring unique names, the hope is that between groupId and id (within format) tracks may then have a unique id.

```
4.4.4.1.1.  Rendition Groups
   A set of one or more EXT-X-MEDIA tags with the same GROUP-ID value
   and the same TYPE value defines a Group of Renditions.  Each member
   of the Group MUST be an alternative Rendition of the same content;
   otherwise, playback errors can occur.
   All EXT-X-MEDIA tags in a Playlist MUST meet the following
   constraints:
   o  All EXT-X-MEDIA tags in the same Group MUST have different NAME
      attributes.
   o  A Group MUST NOT have more than one member with a DEFAULT
      attribute of YES.
   o  Each EXT-X-MEDIA tag with an AUTOSELECT=YES attribute SHOULD have
      a combination of LANGUAGE [RFC5646], ASSOC-LANGUAGE, FORCED, and
      CHARACTERISTICS attributes that is distinct from those of other
      AUTOSELECT=YES members of its Group.
```