### PR TITLE
Create unique id for HLS audio and text tracks

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistParser.java
@@ -341,6 +341,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
       String name = parseStringAttr(line, REGEX_NAME, variableDefinitions);
       String language = parseOptionalStringAttr(line, REGEX_LANGUAGE, variableDefinitions);
       String groupId = parseOptionalStringAttr(line, REGEX_GROUP_ID, variableDefinitions);
+      String id = String.format("%s:%s", groupId, name);
       Format format;
       switch (parseStringAttr(line, REGEX_TYPE, variableDefinitions)) {
         case TYPE_AUDIO:
@@ -348,7 +349,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
           String sampleMimeType = codecs != null ? MimeTypes.getMediaMimeType(codecs) : null;
           format =
               Format.createAudioContainerFormat(
-                  /* id= */ name,
+                  /* id= */ id,
                   /* label= */ name,
                   /* containerMimeType= */ MimeTypes.APPLICATION_M3U8,
                   sampleMimeType,
@@ -368,7 +369,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
         case TYPE_SUBTITLES:
           format =
               Format.createTextContainerFormat(
-                  /* id= */ name,
+                  /* id= */ id,
                   /* label= */ name,
                   /* containerMimeType= */ MimeTypes.APPLICATION_M3U8,
                   /* sampleMimeType= */ MimeTypes.TEXT_VTT,
@@ -394,7 +395,7 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
           }
           muxedCaptionFormats.add(
               Format.createTextContainerFormat(
-                  /* id= */ name,
+                  /* id= */ id,
                   /* label= */ name,
                   /* containerMimeType= */ null,
                   /* sampleMimeType= */ mimeType,

--- a/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylistParserTest.java
+++ b/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylistParserTest.java
@@ -75,7 +75,7 @@ public class HlsMasterPlaylistParserTest {
 
   private static final String PLAYLIST_WITH_CC =
       " #EXTM3U \n"
-          + "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,"
+          + "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"cc1\","
           + "LANGUAGE=\"es\",NAME=\"Eng\",INSTREAM-ID=\"SERVICE4\"\n"
           + "#EXT-X-STREAM-INF:BANDWIDTH=1280000,"
           + "CODECS=\"mp4a.40.2,avc1.66.30\",RESOLUTION=304x128\n"
@@ -88,6 +88,14 @@ public class HlsMasterPlaylistParserTest {
           + "#EXT-X-STREAM-INF:BANDWIDTH=1280000,"
           + "CODECS=\"mp4a.40.2,avc1.66.30\",RESOLUTION=304x128,"
           + "CLOSED-CAPTIONS=NONE\n"
+          + "http://example.com/low.m3u8\n";
+
+  private static final String PLAYLIST_WITH_SUBTITLES =
+      " #EXTM3U \n"
+          + "#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID=\"sub1\","
+          + "LANGUAGE=\"es\",NAME=\"Eng\"\n"
+          + "#EXT-X-STREAM-INF:BANDWIDTH=1280000,"
+          + "CODECS=\"mp4a.40.2,avc1.66.30\",RESOLUTION=304x128\n"
           + "http://example.com/low.m3u8\n";
 
   private static final String PLAYLIST_WITH_AUDIO_MEDIA_TAG =
@@ -214,6 +222,33 @@ public class HlsMasterPlaylistParserTest {
     Format secondAudioFormat = playlist.audios.get(1).format;
     assertThat(secondAudioFormat.codecs).isEqualTo("ac-3");
     assertThat(secondAudioFormat.sampleMimeType).isEqualTo(MimeTypes.AUDIO_AC3);
+  }
+
+  @Test
+  public void testAudioIdPropagation() throws IOException {
+    HlsMasterPlaylist playlist = parseMasterPlaylist(PLAYLIST_URI, PLAYLIST_WITH_AUDIO_MEDIA_TAG);
+
+    Format firstAudioFormat = playlist.audios.get(0).format;
+    assertThat(firstAudioFormat.id).isEqualTo("aud1:English");
+
+    Format secondAudioFormat = playlist.audios.get(1).format;
+    assertThat(secondAudioFormat.id).isEqualTo("aud2:English");
+  }
+
+  @Test
+  public void testCCIdPropagation() throws IOException {
+    HlsMasterPlaylist playlist = parseMasterPlaylist(PLAYLIST_URI, PLAYLIST_WITH_CC);
+
+    Format firstTextFormat = playlist.muxedCaptionFormats.get(0);
+    assertThat(firstTextFormat.id).isEqualTo("cc1:Eng");
+  }
+
+  @Test
+  public void testSubtitleIdPropagation() throws IOException {
+    HlsMasterPlaylist playlist = parseMasterPlaylist(PLAYLIST_URI, PLAYLIST_WITH_SUBTITLES);
+
+    Format firstTextFormat = playlist.subtitles.get(0).format;
+    assertThat(firstTextFormat.id).isEqualTo("sub1:Eng");
   }
 
   @Test


### PR DESCRIPTION
In HLS, we can end up with text and audio tracks that have duplicated names, which yield non-unique ids in the format object. This PR combines groupId and name for id uniqueness. Because the spec defines the group as requiring unique names, the hope is that between groupId and id (within format) tracks may then have a unique id.

```
4.4.4.1.1.  Rendition Groups
   A set of one or more EXT-X-MEDIA tags with the same GROUP-ID value
   and the same TYPE value defines a Group of Renditions.  Each member
   of the Group MUST be an alternative Rendition of the same content;
   otherwise, playback errors can occur.
   All EXT-X-MEDIA tags in a Playlist MUST meet the following
   constraints:
   o  All EXT-X-MEDIA tags in the same Group MUST have different NAME
      attributes.
   o  A Group MUST NOT have more than one member with a DEFAULT
      attribute of YES.
   o  Each EXT-X-MEDIA tag with an AUTOSELECT=YES attribute SHOULD have
      a combination of LANGUAGE [RFC5646], ASSOC-LANGUAGE, FORCED, and
      CHARACTERISTICS attributes that is distinct from those of other
      AUTOSELECT=YES members of its Group.
```

This is the replacement for https://github.com/google/ExoPlayer/pull/4910