### PR TITLE
Add test for setForceHighestSupportedBitrate in DefaultTrackSelector

### DIFF
--- a/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
@@ -1061,6 +1061,9 @@ public final class DefaultTrackSelectorTest {
       throws Exception {
     trackSelector.setParameters(new ParametersBuilder().setForceLowestBitrate(true).build());
 
+    Format exceedsBitrateFormat =
+        Format.createAudioSampleFormat("exceedsBitrateFormat", MimeTypes.AUDIO_AAC, null, 5000,
+                    Format.NO_VALUE, 2, 44100, null, null, 0, null);
     Format lowerBitrateFormat =
         Format.createAudioSampleFormat("lowerBitrateFormat", MimeTypes.AUDIO_AAC, null, 15000,
             Format.NO_VALUE, 2, 44100, null, null, 0, null);
@@ -1068,10 +1071,17 @@ public final class DefaultTrackSelectorTest {
         Format.createAudioSampleFormat("higherBitrateFormat", MimeTypes.AUDIO_AAC, null, 30000,
             Format.NO_VALUE, 2, 44100, null, null, 0, null);
 
+    Map<String, Integer> mappedCapabilities = new HashMap<>();
+    mappedCapabilities.put(exceedsBitrateFormat.id, FORMAT_EXCEEDS_CAPABILITIES);
+    mappedCapabilities.put(lowerBitrateFormat.id, FORMAT_HANDLED);
+    mappedCapabilities.put(higherBitrateFormat.id, FORMAT_HANDLED);
+    RendererCapabilities mappedAudioRendererCapabilities =
+            new FakeMappedRendererCapabilities(C.TRACK_TYPE_AUDIO, mappedCapabilities);
+
     TrackSelectorResult result =
         trackSelector.selectTracks(
-            new RendererCapabilities[] {ALL_AUDIO_FORMAT_SUPPORTED_RENDERER_CAPABILITIES},
-            singleTrackGroup(lowerBitrateFormat, higherBitrateFormat),
+            new RendererCapabilities[] {mappedAudioRendererCapabilities},
+            singleTrackGroup(exceedsBitrateFormat, lowerBitrateFormat, higherBitrateFormat),
             periodId,
             TIMELINE);
 
@@ -1094,11 +1104,21 @@ public final class DefaultTrackSelectorTest {
     Format higherBitrateFormat =
             Format.createAudioSampleFormat("higherBitrateFormat", MimeTypes.AUDIO_AAC, null, 30000,
                     Format.NO_VALUE, 2, 44100, null, null, 0, null);
+    Format exceedsBitrateFormat =
+            Format.createAudioSampleFormat("exceedsBitrateFormat", MimeTypes.AUDIO_AAC, null, 45000,
+                    Format.NO_VALUE, 2, 44100, null, null, 0, null);
+
+    Map<String, Integer> mappedCapabilities = new HashMap<>();
+    mappedCapabilities.put(lowerBitrateFormat.id, FORMAT_HANDLED);
+    mappedCapabilities.put(higherBitrateFormat.id, FORMAT_HANDLED);
+    mappedCapabilities.put(exceedsBitrateFormat.id, FORMAT_EXCEEDS_CAPABILITIES);
+    RendererCapabilities mappedAudioRendererCapabilities =
+            new FakeMappedRendererCapabilities(C.TRACK_TYPE_AUDIO, mappedCapabilities);
 
     TrackSelectorResult result =
             trackSelector.selectTracks(
-                    new RendererCapabilities[] {ALL_AUDIO_FORMAT_SUPPORTED_RENDERER_CAPABILITIES},
-                    singleTrackGroup(lowerBitrateFormat, higherBitrateFormat),
+                    new RendererCapabilities[] {mappedAudioRendererCapabilities},
+                    singleTrackGroup(lowerBitrateFormat, higherBitrateFormat, exceedsBitrateFormat),
                     periodId,
                     TIMELINE);
 

--- a/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
@@ -1075,6 +1075,7 @@ public final class DefaultTrackSelectorTest {
             periodId,
             TIMELINE);
 
+    assertThat(result.selections.get(0).length()).isEqualTo(1);
     assertThat(result.selections.get(0).getSelectedFormat()).isEqualTo(lowerBitrateFormat);
   }
 
@@ -1101,6 +1102,7 @@ public final class DefaultTrackSelectorTest {
                     periodId,
                     TIMELINE);
 
+    assertThat(result.selections.get(0).length()).isEqualTo(1);
     assertThat(result.selections.get(0).getSelectedFormat()).isEqualTo(higherBitrateFormat);
   }
 

--- a/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
@@ -1053,8 +1053,8 @@ public final class DefaultTrackSelectorTest {
   }
 
   /**
-   * Tests that track selector will select audio tracks with lower bitrate when {@link Parameters}
-   * indicate lowest bitrate preference, even when tracks are within capabilities.
+   * Tests that track selector will select the lowest supported audio track when
+   * {@link Parameters#forceLowestBitrate} is set.
    */
   @Test
   public void testSelectTracksWithinCapabilitiesAndForceLowestBitrateSelectLowerBitrate()
@@ -1080,8 +1080,8 @@ public final class DefaultTrackSelectorTest {
   }
 
   /**
-   * Tests that track selector will select audio tracks with higher bitrate when {@link Parameters}
-   * indicate highest bitrate preference, even when tracks are within capabilities.
+   * Tests that track selector will select the highest supported audio track when
+   * {@link Parameters#forceHighestSupportedBitrate} is set.
    */
   @Test
   public void testSelectTracksWithinCapabilitiesAndForceHighestBitrateSelectHigherBitrate()

--- a/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
@@ -1062,10 +1062,10 @@ public final class DefaultTrackSelectorTest {
     trackSelector.setParameters(new ParametersBuilder().setForceLowestBitrate(true).build());
 
     Format lowerBitrateFormat =
-        Format.createAudioSampleFormat("audioFormat", MimeTypes.AUDIO_AAC, null, 15000,
+        Format.createAudioSampleFormat("lowerBitrateFormat", MimeTypes.AUDIO_AAC, null, 15000,
             Format.NO_VALUE, 2, 44100, null, null, 0, null);
     Format higherBitrateFormat =
-        Format.createAudioSampleFormat("audioFormat", MimeTypes.AUDIO_AAC, null, 30000,
+        Format.createAudioSampleFormat("higherBitrateFormat", MimeTypes.AUDIO_AAC, null, 30000,
             Format.NO_VALUE, 2, 44100, null, null, 0, null);
 
     TrackSelectorResult result =
@@ -1089,10 +1089,10 @@ public final class DefaultTrackSelectorTest {
     trackSelector.setParameters(new ParametersBuilder().setForceHighestSupportedBitrate(true).build());
 
     Format lowerBitrateFormat =
-            Format.createAudioSampleFormat("audioFormat", MimeTypes.AUDIO_AAC, null, 15000,
+            Format.createAudioSampleFormat("lowerBitrateFormat", MimeTypes.AUDIO_AAC, null, 15000,
                     Format.NO_VALUE, 2, 44100, null, null, 0, null);
     Format higherBitrateFormat =
-            Format.createAudioSampleFormat("audioFormat", MimeTypes.AUDIO_AAC, null, 30000,
+            Format.createAudioSampleFormat("higherBitrateFormat", MimeTypes.AUDIO_AAC, null, 30000,
                     Format.NO_VALUE, 2, 44100, null, null, 0, null);
 
     TrackSelectorResult result =

--- a/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelectorTest.java
@@ -1078,6 +1078,33 @@ public final class DefaultTrackSelectorTest {
     assertThat(result.selections.get(0).getSelectedFormat()).isEqualTo(lowerBitrateFormat);
   }
 
+  /**
+   * Tests that track selector will select audio tracks with higher bitrate when {@link Parameters}
+   * indicate highest bitrate preference, even when tracks are within capabilities.
+   */
+  @Test
+  public void testSelectTracksWithinCapabilitiesAndForceHighestBitrateSelectHigherBitrate()
+          throws Exception {
+    trackSelector.setParameters(new ParametersBuilder().setForceHighestSupportedBitrate(true).build());
+
+    Format lowerBitrateFormat =
+            Format.createAudioSampleFormat("audioFormat", MimeTypes.AUDIO_AAC, null, 15000,
+                    Format.NO_VALUE, 2, 44100, null, null, 0, null);
+    Format higherBitrateFormat =
+            Format.createAudioSampleFormat("audioFormat", MimeTypes.AUDIO_AAC, null, 30000,
+                    Format.NO_VALUE, 2, 44100, null, null, 0, null);
+
+    TrackSelectorResult result =
+            trackSelector.selectTracks(
+                    new RendererCapabilities[] {ALL_AUDIO_FORMAT_SUPPORTED_RENDERER_CAPABILITIES},
+                    singleTrackGroup(lowerBitrateFormat, higherBitrateFormat),
+                    periodId,
+                    TIMELINE);
+
+    assertThat(result.selections.get(0).getSelectedFormat()).isEqualTo(higherBitrateFormat);
+  }
+
+
   @Test
   public void testSelectTracksWithMultipleAudioTracksReturnsAdaptiveTrackSelection()
       throws Exception {


### PR DESCRIPTION
There is already a test for setForceLowestBitrate(boolean forceLowestBitrate). This PR adds a test for the opposing method setForceHighestSupportedBitrate(boolean forceHighestSupportedBitrate).