### PR TITLE
[ AdsMediaSource ] Prevent releasing already null listener

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/source/ads/AdsMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/ads/AdsMediaSource.java
@@ -390,8 +390,10 @@ public final class AdsMediaSource extends CompositeMediaSource<MediaPeriodId> {
   @Override
   public void releaseSourceInternal() {
     super.releaseSourceInternal();
-    componentListener.release();
-    componentListener = null;
+    if (componentListener != null) {
+      componentListener.release();
+      componentListener = null;
+    }
     deferredMediaPeriodByAdMediaSource.clear();
     contentTimeline = null;
     contentManifest = null;


### PR DESCRIPTION
This is a fix for issue https://github.com/google/ExoPlayer/issues/4973

Currently if release is called before prepare, componentListener will be null. This is probably a state people shouldn't ever find themselves in, but better safe than sorry. 😄 