### PR TITLE
[ ImaAdsLoader ] Prevent acting on null player in detach method

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -516,8 +516,10 @@ public final class ImaAdsLoader
     lastVolumePercentage = getVolume();
     lastAdProgress = getAdProgress();
     lastContentProgress = getContentProgress();
-    player.removeListener(this);
-    player = null;
+    if (player != null) {
+      player.removeListener(this);
+      player = null;
+    }
     eventListener = null;
   }
 


### PR DESCRIPTION
Similar to https://github.com/google/ExoPlayer/pull/4974
Currently if detachPlayer is called before attachPlayer, player will be null. This is probably a state people shouldn't ever find themselves in, but better safe than sorry. 😄