### PR TITLE
Customize ads rendering settings more

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -40,6 +40,7 @@ import com.google.ads.interactivemedia.v3.api.AdsRequest;
 import com.google.ads.interactivemedia.v3.api.CompanionAdSlot;
 import com.google.ads.interactivemedia.v3.api.ImaSdkFactory;
 import com.google.ads.interactivemedia.v3.api.ImaSdkSettings;
+import com.google.ads.interactivemedia.v3.api.UiElement;
 import com.google.ads.interactivemedia.v3.api.player.ContentProgressProvider;
 import com.google.ads.interactivemedia.v3.api.player.VideoAdPlayer;
 import com.google.ads.interactivemedia.v3.api.player.VideoProgressUpdate;
@@ -69,6 +70,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Loads ads using the IMA SDK. All methods are called on the main thread. */
 public final class ImaAdsLoader
@@ -91,6 +93,7 @@ public final class ImaAdsLoader
 
     private @Nullable ImaSdkSettings imaSdkSettings;
     private @Nullable AdEventListener adEventListener;
+    private @Nullable Set<UiElement> adUiElements;
     private int vastLoadTimeoutMs;
     private int mediaLoadTimeoutMs;
     private int mediaBitrateKbps;
@@ -132,6 +135,18 @@ public final class ImaAdsLoader
      */
     public Builder setAdEventListener(AdEventListener adEventListener) {
       this.adEventListener = Assertions.checkNotNull(adEventListener);
+      return this;
+    }
+
+    /**
+     * Sets the ad UI elements to be rendered by the IMA SDK.
+     *
+     * @param adUiElements The ad UI elements to be rendered by the IMA SDK.
+     * @return This builder, for convenience.
+     * @see AdsRenderingSettings#setUiElements(Set)
+     */
+    public Builder setAdUiElements(Set<UiElement> adUiElements) {
+      this.adUiElements = Assertions.checkNotNull(adUiElements);
       return this;
     }
 
@@ -197,6 +212,7 @@ public final class ImaAdsLoader
           vastLoadTimeoutMs,
           mediaLoadTimeoutMs,
           mediaBitrateKbps,
+          adUiElements,
           adEventListener,
           imaFactory);
     }
@@ -217,6 +233,7 @@ public final class ImaAdsLoader
           vastLoadTimeoutMs,
           mediaLoadTimeoutMs,
           mediaBitrateKbps,
+          adUiElements,
           adEventListener,
           imaFactory);
     }
@@ -271,6 +288,7 @@ public final class ImaAdsLoader
   private final int vastLoadTimeoutMs;
   private final int mediaLoadTimeoutMs;
   private final int mediaBitrateKbps;
+  private final @Nullable Set<UiElement> adUiElements;
   private final @Nullable AdEventListener adEventListener;
   private final ImaFactory imaFactory;
   private final Timeline.Period period;
@@ -358,6 +376,7 @@ public final class ImaAdsLoader
         /* vastLoadTimeoutMs= */ TIMEOUT_UNSET,
         /* mediaLoadTimeoutMs= */ TIMEOUT_UNSET,
         /* mediaBitrateKpbs= */ BITRATE_UNSET,
+        /* adUiElements= */ null,
         /* adEventListener= */ null,
         /* imaFactory= */ new DefaultImaFactory());
   }
@@ -383,6 +402,7 @@ public final class ImaAdsLoader
         /* vastLoadTimeoutMs= */ TIMEOUT_UNSET,
         /* mediaLoadTimeoutMs= */ TIMEOUT_UNSET,
         /* mediaBitrateKbps= */ BITRATE_UNSET,
+        /* adUiElements= */ null,
         /* adEventListener= */ null,
         /* imaFactory= */ new DefaultImaFactory());
   }
@@ -395,6 +415,7 @@ public final class ImaAdsLoader
       int vastLoadTimeoutMs,
       int mediaLoadTimeoutMs,
       int mediaBitrateKbps,
+      @Nullable Set<UiElement> adUiElements,
       @Nullable AdEventListener adEventListener,
       ImaFactory imaFactory) {
     Assertions.checkArgument(adTagUri != null || adsResponse != null);
@@ -403,6 +424,7 @@ public final class ImaAdsLoader
     this.vastLoadTimeoutMs = vastLoadTimeoutMs;
     this.mediaLoadTimeoutMs = mediaLoadTimeoutMs;
     this.mediaBitrateKbps = mediaBitrateKbps;
+    this.adUiElements = adUiElements;
     this.adEventListener = adEventListener;
     this.imaFactory = imaFactory;
     if (imaSdkSettings == null) {
@@ -951,6 +973,9 @@ public final class ImaAdsLoader
     }
     if (mediaBitrateKbps != BITRATE_UNSET) {
       adsRenderingSettings.setBitrateKbps(mediaBitrateKbps);
+    }
+    if (adUiElements != null) {
+      adsRenderingSettings.setUiElements(adUiElements);
     }
 
     // Set up the ad playback state, skipping ads based on the start position as required.

--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -93,6 +93,7 @@ public final class ImaAdsLoader
     private @Nullable AdEventListener adEventListener;
     private int vastLoadTimeoutMs;
     private int mediaLoadTimeoutMs;
+    private int mediaBitrateKbps;
     private ImaFactory imaFactory;
 
     /**
@@ -104,6 +105,7 @@ public final class ImaAdsLoader
       this.context = Assertions.checkNotNull(context);
       vastLoadTimeoutMs = TIMEOUT_UNSET;
       mediaLoadTimeoutMs = TIMEOUT_UNSET;
+      mediaBitrateKbps = BITRATE_UNSET;
       imaFactory = new DefaultImaFactory();
     }
 
@@ -159,6 +161,19 @@ public final class ImaAdsLoader
       return this;
     }
 
+    /**
+     * Sets the ad media maximum recommended bitrate, in Kbps.
+     *
+     * @param mediaBitrateKbps The ad media maximum recommended bitrate, in Kbps.
+     * @return This builder, for convenience.
+     * @see AdsRenderingSettings#setBitrateKbps(int)
+     */
+    public Builder setMediaBitrateKbps(int mediaBitrateKbps) {
+      Assertions.checkArgument(mediaBitrateKbps > 0);
+      this.mediaBitrateKbps = mediaBitrateKbps;
+      return this;
+    }
+
     // @VisibleForTesting
     /* package */ Builder setImaFactory(ImaFactory imaFactory) {
       this.imaFactory = Assertions.checkNotNull(imaFactory);
@@ -181,6 +196,7 @@ public final class ImaAdsLoader
           null,
           vastLoadTimeoutMs,
           mediaLoadTimeoutMs,
+          mediaBitrateKbps,
           adEventListener,
           imaFactory);
     }
@@ -200,6 +216,7 @@ public final class ImaAdsLoader
           adsResponse,
           vastLoadTimeoutMs,
           mediaLoadTimeoutMs,
+          mediaBitrateKbps,
           adEventListener,
           imaFactory);
     }
@@ -229,6 +246,7 @@ public final class ImaAdsLoader
   private static final long MAXIMUM_PRELOAD_DURATION_MS = 8000;
 
   private static final int TIMEOUT_UNSET = -1;
+  private static final int BITRATE_UNSET = -1;
 
   /** The state of ad playback. */
   @Documented
@@ -252,6 +270,7 @@ public final class ImaAdsLoader
   private final @Nullable String adsResponse;
   private final int vastLoadTimeoutMs;
   private final int mediaLoadTimeoutMs;
+  private final int mediaBitrateKbps;
   private final @Nullable AdEventListener adEventListener;
   private final ImaFactory imaFactory;
   private final Timeline.Period period;
@@ -338,6 +357,7 @@ public final class ImaAdsLoader
         /* adsResponse= */ null,
         /* vastLoadTimeoutMs= */ TIMEOUT_UNSET,
         /* mediaLoadTimeoutMs= */ TIMEOUT_UNSET,
+        /* mediaBitrateKpbs= */ BITRATE_UNSET,
         /* adEventListener= */ null,
         /* imaFactory= */ new DefaultImaFactory());
   }
@@ -362,6 +382,7 @@ public final class ImaAdsLoader
         /* adsResponse= */ null,
         /* vastLoadTimeoutMs= */ TIMEOUT_UNSET,
         /* mediaLoadTimeoutMs= */ TIMEOUT_UNSET,
+        /* mediaBitrateKbps= */ BITRATE_UNSET,
         /* adEventListener= */ null,
         /* imaFactory= */ new DefaultImaFactory());
   }
@@ -373,6 +394,7 @@ public final class ImaAdsLoader
       @Nullable String adsResponse,
       int vastLoadTimeoutMs,
       int mediaLoadTimeoutMs,
+      int mediaBitrateKbps,
       @Nullable AdEventListener adEventListener,
       ImaFactory imaFactory) {
     Assertions.checkArgument(adTagUri != null || adsResponse != null);
@@ -380,6 +402,7 @@ public final class ImaAdsLoader
     this.adsResponse = adsResponse;
     this.vastLoadTimeoutMs = vastLoadTimeoutMs;
     this.mediaLoadTimeoutMs = mediaLoadTimeoutMs;
+    this.mediaBitrateKbps = mediaBitrateKbps;
     this.adEventListener = adEventListener;
     this.imaFactory = imaFactory;
     if (imaSdkSettings == null) {
@@ -925,6 +948,9 @@ public final class ImaAdsLoader
     adsRenderingSettings.setMimeTypes(supportedMimeTypes);
     if (mediaLoadTimeoutMs != TIMEOUT_UNSET) {
       adsRenderingSettings.setLoadVideoTimeout(mediaLoadTimeoutMs);
+    }
+    if (mediaBitrateKbps != BITRATE_UNSET) {
+      adsRenderingSettings.setBitrateKbps(mediaBitrateKbps);
     }
 
     // Set up the ad playback state, skipping ads based on the start position as required.

--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -68,6 +68,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -146,7 +147,7 @@ public final class ImaAdsLoader
      * @see AdsRenderingSettings#setUiElements(Set)
      */
     public Builder setAdUiElements(Set<UiElement> adUiElements) {
-      this.adUiElements = Assertions.checkNotNull(adUiElements);
+      this.adUiElements = new HashSet<>(Assertions.checkNotNull(adUiElements));
       return this;
     }
 

--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -96,7 +96,7 @@ public final class ImaAdsLoader
     private @Nullable Set<UiElement> adUiElements;
     private int vastLoadTimeoutMs;
     private int mediaLoadTimeoutMs;
-    private int mediaBitrateKbps;
+    private int mediaBitrate;
     private ImaFactory imaFactory;
 
     /**
@@ -108,7 +108,7 @@ public final class ImaAdsLoader
       this.context = Assertions.checkNotNull(context);
       vastLoadTimeoutMs = TIMEOUT_UNSET;
       mediaLoadTimeoutMs = TIMEOUT_UNSET;
-      mediaBitrateKbps = BITRATE_UNSET;
+      mediaBitrate = BITRATE_UNSET;
       imaFactory = new DefaultImaFactory();
     }
 
@@ -177,15 +177,15 @@ public final class ImaAdsLoader
     }
 
     /**
-     * Sets the ad media maximum recommended bitrate, in Kbps.
+     * Sets the ad media maximum recommended bitrate, in bps.
      *
-     * @param mediaBitrateKbps The ad media maximum recommended bitrate, in Kbps.
+     * @param bitrate The ad media maximum recommended bitrate, in bps.
      * @return This builder, for convenience.
      * @see AdsRenderingSettings#setBitrateKbps(int)
      */
-    public Builder setMediaBitrateKbps(int mediaBitrateKbps) {
-      Assertions.checkArgument(mediaBitrateKbps > 0);
-      this.mediaBitrateKbps = mediaBitrateKbps;
+    public Builder setMaxMediaBitrate(int bitrate) {
+      Assertions.checkArgument(bitrate > 0);
+      this.mediaBitrate = bitrate;
       return this;
     }
 
@@ -211,7 +211,7 @@ public final class ImaAdsLoader
           null,
           vastLoadTimeoutMs,
           mediaLoadTimeoutMs,
-          mediaBitrateKbps,
+          mediaBitrate,
           adUiElements,
           adEventListener,
           imaFactory);
@@ -232,7 +232,7 @@ public final class ImaAdsLoader
           adsResponse,
           vastLoadTimeoutMs,
           mediaLoadTimeoutMs,
-          mediaBitrateKbps,
+          mediaBitrate,
           adUiElements,
           adEventListener,
           imaFactory);
@@ -287,7 +287,7 @@ public final class ImaAdsLoader
   private final @Nullable String adsResponse;
   private final int vastLoadTimeoutMs;
   private final int mediaLoadTimeoutMs;
-  private final int mediaBitrateKbps;
+  private final int mediaBitrate;
   private final @Nullable Set<UiElement> adUiElements;
   private final @Nullable AdEventListener adEventListener;
   private final ImaFactory imaFactory;
@@ -375,7 +375,7 @@ public final class ImaAdsLoader
         /* adsResponse= */ null,
         /* vastLoadTimeoutMs= */ TIMEOUT_UNSET,
         /* mediaLoadTimeoutMs= */ TIMEOUT_UNSET,
-        /* mediaBitrateKpbs= */ BITRATE_UNSET,
+        /* mediaBitrate= */ BITRATE_UNSET,
         /* adUiElements= */ null,
         /* adEventListener= */ null,
         /* imaFactory= */ new DefaultImaFactory());
@@ -401,7 +401,7 @@ public final class ImaAdsLoader
         /* adsResponse= */ null,
         /* vastLoadTimeoutMs= */ TIMEOUT_UNSET,
         /* mediaLoadTimeoutMs= */ TIMEOUT_UNSET,
-        /* mediaBitrateKbps= */ BITRATE_UNSET,
+        /* mediaBitrate= */ BITRATE_UNSET,
         /* adUiElements= */ null,
         /* adEventListener= */ null,
         /* imaFactory= */ new DefaultImaFactory());
@@ -414,7 +414,7 @@ public final class ImaAdsLoader
       @Nullable String adsResponse,
       int vastLoadTimeoutMs,
       int mediaLoadTimeoutMs,
-      int mediaBitrateKbps,
+      int mediaBitrate,
       @Nullable Set<UiElement> adUiElements,
       @Nullable AdEventListener adEventListener,
       ImaFactory imaFactory) {
@@ -423,7 +423,7 @@ public final class ImaAdsLoader
     this.adsResponse = adsResponse;
     this.vastLoadTimeoutMs = vastLoadTimeoutMs;
     this.mediaLoadTimeoutMs = mediaLoadTimeoutMs;
-    this.mediaBitrateKbps = mediaBitrateKbps;
+    this.mediaBitrate = mediaBitrate;
     this.adUiElements = adUiElements;
     this.adEventListener = adEventListener;
     this.imaFactory = imaFactory;
@@ -971,8 +971,8 @@ public final class ImaAdsLoader
     if (mediaLoadTimeoutMs != TIMEOUT_UNSET) {
       adsRenderingSettings.setLoadVideoTimeout(mediaLoadTimeoutMs);
     }
-    if (mediaBitrateKbps != BITRATE_UNSET) {
-      adsRenderingSettings.setBitrateKbps(mediaBitrateKbps);
+    if (mediaBitrate != BITRATE_UNSET) {
+      adsRenderingSettings.setBitrateKbps(mediaBitrate / 1000);
     }
     if (adUiElements != null) {
       adsRenderingSettings.setUiElements(adUiElements);


### PR DESCRIPTION
This adds support more for ads rendering settings

https://github.com/google/ExoPlayer/commit/861b81694de78b4eaba324121fec4bd997e99f73

Allow setting the ad media bitrate in ImaAdsLoader

```
e.g. 
adsLoader = new ImaAdsLoader.Builder(context)
    .setMediaBitrateKbps(700)
    .buildForAdTag(Uri.parse(adTag));
```

When VAST with multiple bit rates set is returned, 
If nothing is set, the IMASDK selects the highest bit rate.

I tried it with the following VAST data.
```
https://vast-ads.netlify.com/vast_10s_multi_bitrate.xml

test1: Default(not set) -> ad_1080.mp4
test2: Sets 700 Kbps -> ad_240.mp4
```

https://github.com/google/ExoPlayer/commit/cfcbd2114ba43a7a906577981e383a264d437929

Allow setting the ad UI elements to be rendered in ImaAdsLoader

```
e.g. 
adsLoader = new ImaAdsLoader.Builder(context)
    .setAdUiElements(Collections.emptySet())
    .buildForAdTag(Uri.parse(adTag));
```

It is useful when you want to create ad UI element in the application.

| Default(not set) | Empty |
|----|----|
| <img src="https://user-images.githubusercontent.com/1496485/47263618-c46e0280-d53f-11e8-878d-4b26cd009736.png" width="240"/> | <img src="https://user-images.githubusercontent.com/1496485/47263596-8f61b000-d53f-11e8-93f5-bbd2c23970f9.png" width="240"/> |