### PR TITLE
fix checkIdleRequirement

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/scheduler/Requirements.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/scheduler/Requirements.java
@@ -187,7 +187,7 @@ public final class Requirements {
     }
     PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
     return Util.SDK_INT >= 23
-        ? !powerManager.isDeviceIdleMode()
+        ? powerManager.isDeviceIdleMode()
         : Util.SDK_INT >= 20 ? !powerManager.isInteractive() : !powerManager.isScreenOn();
   }
 


### PR DESCRIPTION
I think that the conditional expression is reversed if you want to download it in the IDLE state.

https://developer.android.com/reference/android/os/PowerManager#isDeviceIdleMode()