### PR TITLE
Provide http status message to InvalidResponseCodeException

### DIFF
--- a/extensions/cronet/src/main/java/com/google/android/exoplayer2/ext/cronet/CronetDataSource.java
+++ b/extensions/cronet/src/main/java/com/google/android/exoplayer2/ext/cronet/CronetDataSource.java
@@ -327,7 +327,7 @@ public class CronetDataSource extends BaseDataSource implements HttpDataSource {
     int responseCode = responseInfo.getHttpStatusCode();
     if (responseCode < 200 || responseCode > 299) {
       InvalidResponseCodeException exception = new InvalidResponseCodeException(responseCode,
-          responseInfo.getAllHeaders(), currentDataSpec);
+          responseInfo.getHttpStatusText(), responseInfo.getAllHeaders(), currentDataSpec);
       if (responseCode == 416) {
         exception.initCause(new DataSourceException(DataSourceException.POSITION_OUT_OF_RANGE));
       }
@@ -611,7 +611,8 @@ public class CronetDataSource extends BaseDataSource implements HttpDataSource {
         // The industry standard is to disregard POST redirects when the status code is 307 or 308.
         if (responseCode == 307 || responseCode == 308) {
           exception =
-              new InvalidResponseCodeException(responseCode, info.getAllHeaders(), currentDataSpec);
+              new InvalidResponseCodeException(responseCode, info.getHttpStatusText(),
+                      info.getAllHeaders(), currentDataSpec);
           operation.open();
           return;
         }

--- a/extensions/cronet/src/main/java/com/google/android/exoplayer2/ext/cronet/CronetDataSource.java
+++ b/extensions/cronet/src/main/java/com/google/android/exoplayer2/ext/cronet/CronetDataSource.java
@@ -326,8 +326,12 @@ public class CronetDataSource extends BaseDataSource implements HttpDataSource {
     // Check for a valid response code.
     int responseCode = responseInfo.getHttpStatusCode();
     if (responseCode < 200 || responseCode > 299) {
-      InvalidResponseCodeException exception = new InvalidResponseCodeException(responseCode,
-          responseInfo.getHttpStatusText(), responseInfo.getAllHeaders(), currentDataSpec);
+      InvalidResponseCodeException exception =
+          new InvalidResponseCodeException(
+              responseCode,
+              responseInfo.getHttpStatusText(),
+              responseInfo.getAllHeaders(),
+              currentDataSpec);
       if (responseCode == 416) {
         exception.initCause(new DataSourceException(DataSourceException.POSITION_OUT_OF_RANGE));
       }
@@ -611,8 +615,11 @@ public class CronetDataSource extends BaseDataSource implements HttpDataSource {
         // The industry standard is to disregard POST redirects when the status code is 307 or 308.
         if (responseCode == 307 || responseCode == 308) {
           exception =
-              new InvalidResponseCodeException(responseCode, info.getHttpStatusText(),
-                      info.getAllHeaders(), currentDataSpec);
+              new InvalidResponseCodeException(
+                  responseCode,
+                  info.getHttpStatusText(),
+                  info.getAllHeaders(),
+                  currentDataSpec);
           operation.open();
           return;
         }

--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
@@ -172,8 +172,8 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
     if (!response.isSuccessful()) {
       Map<String, List<String>> headers = response.headers().toMultimap();
       closeConnectionQuietly();
-      InvalidResponseCodeException exception = new InvalidResponseCodeException(
-          responseCode, response.message(), headers, dataSpec);
+      InvalidResponseCodeException exception =
+          new InvalidResponseCodeException(responseCode, response.message(), headers, dataSpec);
       if (responseCode == 416) {
         exception.initCause(new DataSourceException(DataSourceException.POSITION_OUT_OF_RANGE));
       }

--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
@@ -173,7 +173,7 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
       Map<String, List<String>> headers = response.headers().toMultimap();
       closeConnectionQuietly();
       InvalidResponseCodeException exception = new InvalidResponseCodeException(
-          responseCode, headers, dataSpec);
+          responseCode, response.message(), headers, dataSpec);
       if (responseCode == 416) {
         exception.initCause(new DataSourceException(DataSourceException.POSITION_OUT_OF_RANGE));
       }

--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
@@ -283,8 +283,10 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
     }
 
     int responseCode;
+    String responseMessage;
     try {
       responseCode = connection.getResponseCode();
+      responseMessage = connection.getResponseMessage();
     } catch (IOException e) {
       closeConnectionQuietly();
       throw new HttpDataSourceException("Unable to connect to " + dataSpec.uri.toString(), e,
@@ -296,7 +298,7 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
       Map<String, List<String>> headers = connection.getHeaderFields();
       closeConnectionQuietly();
       InvalidResponseCodeException exception =
-          new InvalidResponseCodeException(responseCode, headers, dataSpec);
+          new InvalidResponseCodeException(responseCode, responseMessage, headers, dataSpec);
       if (responseCode == 416) {
         exception.initCause(new DataSourceException(DataSourceException.POSITION_OUT_OF_RANGE));
       }

--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java
@@ -16,6 +16,7 @@
 package com.google.android.exoplayer2.upstream;
 
 import android.support.annotation.IntDef;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import com.google.android.exoplayer2.util.Predicate;
 import com.google.android.exoplayer2.util.Util;
@@ -295,14 +296,21 @@ public interface HttpDataSource extends DataSource {
     public final int responseCode;
 
     /**
+     * The HTTP status message.
+     */
+    public final @Nullable String responseMessage;
+
+    /**
      * An unmodifiable map of the response header fields and values.
      */
     public final Map<String, List<String>> headerFields;
 
-    public InvalidResponseCodeException(int responseCode, Map<String, List<String>> headerFields,
+    public InvalidResponseCodeException(int responseCode, @Nullable String responseMessage,
+                                        Map<String, List<String>> headerFields,
         DataSpec dataSpec) {
       super("Response code: " + responseCode, dataSpec, TYPE_OPEN);
       this.responseCode = responseCode;
+      this.responseMessage = responseMessage;
       this.headerFields = headerFields;
     }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java
@@ -298,15 +298,17 @@ public interface HttpDataSource extends DataSource {
     /**
      * The HTTP status message.
      */
-    public final @Nullable String responseMessage;
+    @Nullable public final String responseMessage;
 
     /**
      * An unmodifiable map of the response header fields and values.
      */
     public final Map<String, List<String>> headerFields;
 
-    public InvalidResponseCodeException(int responseCode, @Nullable String responseMessage,
-                                        Map<String, List<String>> headerFields,
+    public InvalidResponseCodeException(
+        int responseCode,
+        @Nullable String responseMessage,
+        Map<String, List<String>> headerFields,
         DataSpec dataSpec) {
       super("Response code: " + responseCode, dataSpec, TYPE_OPEN);
       this.responseCode = responseCode;

--- a/library/core/src/test/java/com/google/android/exoplayer2/upstream/DefaultLoadErrorHandlingPolicyTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/upstream/DefaultLoadErrorHandlingPolicyTest.java
@@ -34,7 +34,7 @@ public final class DefaultLoadErrorHandlingPolicyTest {
   @Test
   public void getBlacklistDurationMsFor_blacklist404() {
     InvalidResponseCodeException exception =
-        new InvalidResponseCodeException(404, Collections.emptyMap(), new DataSpec(Uri.EMPTY));
+        new InvalidResponseCodeException(404, "Not Found", Collections.emptyMap(), new DataSpec(Uri.EMPTY));
     assertThat(getDefaultPolicyBlacklistOutputFor(exception))
         .isEqualTo(DefaultLoadErrorHandlingPolicy.DEFAULT_TRACK_BLACKLIST_MS);
   }
@@ -42,7 +42,7 @@ public final class DefaultLoadErrorHandlingPolicyTest {
   @Test
   public void getBlacklistDurationMsFor_blacklist410() {
     InvalidResponseCodeException exception =
-        new InvalidResponseCodeException(410, Collections.emptyMap(), new DataSpec(Uri.EMPTY));
+        new InvalidResponseCodeException(410, "Gone", Collections.emptyMap(), new DataSpec(Uri.EMPTY));
     assertThat(getDefaultPolicyBlacklistOutputFor(exception))
         .isEqualTo(DefaultLoadErrorHandlingPolicy.DEFAULT_TRACK_BLACKLIST_MS);
   }
@@ -50,7 +50,7 @@ public final class DefaultLoadErrorHandlingPolicyTest {
   @Test
   public void getBlacklistDurationMsFor_dontBlacklistUnexpectedHttpCodes() {
     InvalidResponseCodeException exception =
-        new InvalidResponseCodeException(500, Collections.emptyMap(), new DataSpec(Uri.EMPTY));
+        new InvalidResponseCodeException(500, "Internal Server Error", Collections.emptyMap(), new DataSpec(Uri.EMPTY));
     assertThat(getDefaultPolicyBlacklistOutputFor(exception)).isEqualTo(C.TIME_UNSET);
   }
 

--- a/library/core/src/test/java/com/google/android/exoplayer2/upstream/DefaultLoadErrorHandlingPolicyTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/upstream/DefaultLoadErrorHandlingPolicyTest.java
@@ -50,7 +50,8 @@ public final class DefaultLoadErrorHandlingPolicyTest {
   @Test
   public void getBlacklistDurationMsFor_dontBlacklistUnexpectedHttpCodes() {
     InvalidResponseCodeException exception =
-        new InvalidResponseCodeException(500, "Internal Server Error", Collections.emptyMap(), new DataSpec(Uri.EMPTY));
+        new InvalidResponseCodeException(
+            500, "Internal Server Error", Collections.emptyMap(), new DataSpec(Uri.EMPTY));
     assertThat(getDefaultPolicyBlacklistOutputFor(exception)).isEqualTo(C.TIME_UNSET);
   }
 


### PR DESCRIPTION
When response code alone is not enough to distinguish error responses, the http status message is helpful.