### PR TITLE
keep hls chunk source from getting redundant playlists

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -431,7 +431,8 @@ import java.util.List;
     for (int i = 0; i < chunkIterators.length; i++) {
       int variantIndex = trackSelection.getIndexInTrackGroup(i);
       HlsUrl variantUrl = variants[variantIndex];
-      if (!playlistTracker.isSnapshotValid(variantUrl)) {
+      if (!playlistTracker.isSnapshotValid(variantUrl)
+          || trackSelection.getSelectedIndexInTrackGroup() != variantIndex) {
         chunkIterators[i] = MediaChunkIterator.EMPTY;
         continue;
       }


### PR DESCRIPTION
### Overview

when playing **live** hls stream, ExoPlayer periodically getting all playlists which has been loaded at least once. Because of this, ExoPlayer keeps sending network requests more than necessary.

### Environment

#### since version 2.9.0

[This](https://abclive1-lh.akamaihd.net/i/abc_live10@420897/master.m3u8) is the url that I tested, and it is reproducible on ExoPlayer demo. 

You will see ExoPlayer keeps fetching all variants of mediaPlaylist which ExoPlayer has loaded during the playback.

### Cause 

Inside the HlsChunkSource, HlsChunkSource#createMediaChunkIterators() provides MediaChunkIterator[] that contains information for upcoming media chunks. However, in `createMediaChunkIterators()`, playlistTracker.getPlaylistSnapshot(variantUrl) is called and it sends an network request to fetch an MediaPlaylist. It's called for every variant that has `playlistSnapshot`. 

I think unselected playlists should no be loaded through network calls from the viewpoint of reducing network requests.  






