### PR TITLE
Noop fix to WebvttDecoder

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/webvtt/WebvttDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/webvtt/WebvttDecoder.java
@@ -110,7 +110,7 @@ public final class WebvttDecoder extends SimpleSubtitleDecoder {
         foundEvent = EVENT_END_OF_FILE;
       } else if (STYLE_START.equals(line)) {
         foundEvent = EVENT_STYLE_BLOCK;
-      } else if (COMMENT_START.startsWith(line)) {
+      } else if (line.startsWith(COMMENT_START)) {
         foundEvent = EVENT_COMMENT;
       } else {
         foundEvent = EVENT_CUE;


### PR DESCRIPTION
We already have tests for comment blocks, and they already
pass because we discard the comment when we fail to parse it
as a cue. We should just skip it directly, however.