### PR TITLE
Add protected method to override the AspectRatioFrameLayout aspect ratio

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerView.java
@@ -1031,6 +1031,19 @@ public class PlayerView extends FrameLayout {
     return subtitleView;
   }
 
+  /**
+   * Called to notify the {@link AspectRatioFrameLayout} of the new video aspect ratio.
+   * The default implementation will simply forward the aspect ratio to
+   * {@link AspectRatioFrameLayout#setAspectRatio(float)}. Subclasses can override this
+   * method, for example, to apply aspect ratio constraints.
+   *
+   * @param aspectRatioFrameLayout the video surface view container
+   * @param widthHeightRatio the computed aspect ratio
+   */
+  protected void onDispatchVideoAspectRatio(@NonNull AspectRatioFrameLayout aspectRatioFrameLayout, float widthHeightRatio) {
+    aspectRatioFrameLayout.setAspectRatio(widthHeightRatio);
+  }
+
   @Override
   public boolean onTouchEvent(MotionEvent ev) {
     if (ev.getActionMasked() != MotionEvent.ACTION_DOWN) {
@@ -1355,7 +1368,7 @@ public class PlayerView extends FrameLayout {
         videoAspectRatio = 0;
       }
 
-      contentFrame.setAspectRatio(videoAspectRatio);
+      onDispatchVideoAspectRatio(contentFrame, videoAspectRatio);
     }
 
     @Override


### PR DESCRIPTION
This fixes #5221 : adds a protected method so that `PlayerView` subclasses can change the surface aspect ratio before it is forwarded to the `AspectRatioFrameLayout`.

I personally think that `AspectRatioFrameLayout` could **also** be made non-final, will do if you want.

I have intentionally left aside the drawable artwork case, and named the method with the "video" word, so this does not intercept all `setAspectRatio` calls but has a clearer meaning / usage.