### PR TITLE
Made seekTo not final

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/BasePlayer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/BasePlayer.java
@@ -38,7 +38,7 @@ public abstract class BasePlayer implements Player {
   }
 
   @Override
-  public final void seekTo(long positionMs) {
+  public void seekTo(long positionMs) {
     seekTo(getCurrentWindowIndex(), positionMs);
   }
 


### PR DESCRIPTION
In this commit (https://github.com/google/ExoPlayer/commit/bbd82cf5da8072a0c67f5a422c426ef2d71e315e) you add a `BasePlayer` with `public **final** void seekTo()`, but in #535 (first issue I've found with this question) you advised to override `seekTo` in own instance. Now it's impossible (if you want to intercept `positionMs` too).

Or maybe there are another way to intercept seek event and result position?