### PR TITLE
Update gradle to 3.3.0, remove buildToolsVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath 'com.novoda:bintray-release:0.8.1'
-        classpath 'com.google.android.gms:strict-version-matcher-plugin:1.0.3'
+        classpath 'com.google.android.gms:strict-version-matcher-plugin:1.1.0'
     }
     // Workaround for the following test coverage issue. Remove when fixed:
     // https://code.google.com/p/android/issues/detail?id=226070
@@ -38,12 +38,12 @@ allprojects {
     project.ext {
         exoplayerPublishEnabled = true
     }
-    if (it.hasProperty('externalBuildDir')) {
-        if (!new File(externalBuildDir).isAbsolute()) {
-            externalBuildDir = new File(rootDir, externalBuildDir)
-        }
-        buildDir = "${externalBuildDir}/${project.name}"
-    }
+//    if (it.hasProperty('externalBuildDir')) {
+//        if (!new File(externalBuildDir).isAbsolute()) {
+//            externalBuildDir = new File(rootDir, externalBuildDir)
+//        }
+//        buildDir = "${externalBuildDir}/${project.name}"
+//    }
 }
 
 apply from: 'javadoc_combined.gradle'

--- a/demos/cast/build.gradle
+++ b/demos/cast/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/demos/cast/src/main/java/com/google/android/exoplayer2/castdemo/PlayerManager.java
+++ b/demos/cast/src/main/java/com/google/android/exoplayer2/castdemo/PlayerManager.java
@@ -19,6 +19,7 @@ import android.view.KeyEvent;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ext.cast.MediaItem;
 
+
 /** Manages the players in the Cast demo app. */
 interface PlayerManager {
 

--- a/demos/ima/build.gradle
+++ b/demos/ima/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/demos/ima/src/main/java/com/google/android/exoplayer2/imademo/PlayerManager.java
+++ b/demos/ima/src/main/java/com/google/android/exoplayer2/imademo/PlayerManager.java
@@ -79,6 +79,7 @@ import com.google.android.exoplayer2.util.Util;
             playerView.getOverlayFrameLayout());
 
     // Prepare the player with the source.
+    adsLoader.setPlayer(player);
     player.seekTo(contentPosition);
     player.prepare(mediaSourceWithAds);
     player.setPlayWhenReady(true);

--- a/demos/main/build.gradle
+++ b/demos/main/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/cast/build.gradle
+++ b/extensions/cast/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/cronet/build.gradle
+++ b/extensions/cronet/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion 16

--- a/extensions/ffmpeg/build.gradle
+++ b/extensions/ffmpeg/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/flac/build.gradle
+++ b/extensions/flac/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/gvr/build.gradle
+++ b/extensions/gvr/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/ima/build.gradle
+++ b/extensions/ima/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/jobdispatcher/build.gradle
+++ b/extensions/jobdispatcher/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/leanback/build.gradle
+++ b/extensions/leanback/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/mediasession/build.gradle
+++ b/extensions/mediasession/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/okhttp/build.gradle
+++ b/extensions/okhttp/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/opus/build.gradle
+++ b/extensions/opus/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/rtmp/build.gradle
+++ b/extensions/rtmp/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/extensions/vp9/build.gradle
+++ b/extensions/vp9/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 05 13:43:42 BST 2017
+#Fri Jan 25 12:48:30 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/library/all/build.gradle
+++ b/library/all/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion project.ext.minSdkVersion

--- a/library/core/build.gradle
+++ b/library/core/build.gradle
@@ -16,7 +16,6 @@ apply from: '../../constants.gradle'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/library/core/src/main/java/com/google/android/exoplayer2/C.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/C.java
@@ -807,6 +807,12 @@ public final class C {
    */
   public static final int MSG_CUSTOM_BASE = 10000;
 
+
+  /**
+   * Flag to set preferred audio output based on AudioDeviceInfo
+   */
+  public static final int MSG_SET_PREFERRED_AUDIO_OUTPUT = 10001;
+
   /**
    * The stereo mode for 360/3D/VR videos. One of {@link Format#NO_VALUE}, {@link
    * #STEREO_MODE_MONO}, {@link #STEREO_MODE_TOP_BOTTOM}, {@link #STEREO_MODE_LEFT_RIGHT} or {@link

--- a/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
@@ -19,6 +19,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.SurfaceTexture;
+import android.media.AudioDeviceInfo;
 import android.media.MediaCodec;
 import android.media.PlaybackParams;
 import android.os.Handler;
@@ -108,6 +109,7 @@ public class SimpleExoPlayer extends BasePlayer
   @Nullable private DecoderCounters audioDecoderCounters;
   private int audioSessionId;
   private AudioAttributes audioAttributes;
+  private AudioDeviceInfo preferredAudioDevice;
   private float audioVolume;
   @Nullable private MediaSource mediaSource;
   private List<Cue> currentCues;
@@ -731,6 +733,29 @@ public class SimpleExoPlayer extends BasePlayer
   public void removeMetadataOutput(MetadataOutput listener) {
     metadataOutputs.remove(listener);
   }
+
+  /**
+   * Sets the preferred audio output.
+   *
+   * @param audioDeviceInfo The preferred audio output or null to use the default output.
+   */
+  public void setAudioOutput(@Nullable AudioDeviceInfo audioDeviceInfo) {
+    this.preferredAudioDevice = audioDeviceInfo;
+    for (Renderer renderer : renderers) {
+      if (renderer.getTrackType() == C.TRACK_TYPE_AUDIO) {
+        PlayerMessage message = player.createMessage(renderer);
+        message.setType(C.MSG_SET_PREFERRED_AUDIO_OUTPUT);
+        message.setPayload(preferredAudioDevice);
+      }
+    }
+  }
+
+  @Nullable
+  @TargetApi(23)
+  public AudioDeviceInfo getAudioOutput() {
+    return preferredAudioDevice;
+  }
+
 
   /**
    * Sets an output to receive metadata events, removing all existing outputs.

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioSink.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioSink.java
@@ -15,6 +15,7 @@
  */
 package com.google.android.exoplayer2.audio;
 
+import android.media.AudioDeviceInfo;
 import android.media.AudioTrack;
 import android.support.annotation.Nullable;
 import com.google.android.exoplayer2.C;
@@ -289,6 +290,12 @@ public interface AudioSink {
 
   /** Sets the auxiliary effect. */
   void setAuxEffectInfo(AuxEffectInfo auxEffectInfo);
+
+  /** Getter and setter for Preferred Output Device */
+  AudioDeviceInfo getPreferredOutputDevice();
+
+  void setPreferredOutputDevice(AudioDeviceInfo deviceInfo);
+
 
   /**
    * Enables tunneling, if possible. The sink is reset if tunneling was previously disabled or if

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java
@@ -17,13 +17,17 @@ package com.google.android.exoplayer2.audio;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.media.AudioDeviceInfo;
 import android.media.AudioFormat;
 import android.media.AudioManager;
+import android.media.AudioRouting;
 import android.media.AudioTrack;
+import android.os.Build;
 import android.os.ConditionVariable;
 import android.os.SystemClock;
 import android.support.annotation.IntDef;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.PlaybackParameters;
@@ -287,6 +291,7 @@ public final class DefaultAudioSink implements AudioSink {
   private AuxEffectInfo auxEffectInfo;
   private boolean tunneling;
   private long lastFeedElapsedRealtimeMs;
+  private AudioDeviceInfoHolder preferredOutputDevice;
 
   /**
    * Creates a new default audio sink.
@@ -371,7 +376,7 @@ public final class DefaultAudioSink implements AudioSink {
   // AudioSink implementation.
 
   @Override
-  public void setListener(Listener listener) {
+  public void setListener(@Nullable Listener listener) {
     this.listener = listener;
   }
 
@@ -529,6 +534,7 @@ public final class DefaultAudioSink implements AudioSink {
     releasingConditionVariable.block();
 
     audioTrack = initializeAudioTrack();
+    applyPreferredOutputDevice();
     int audioSessionId = audioTrack.getAudioSessionId();
     if (enablePreV21AudioSessionWorkaround) {
       if (Util.SDK_INT < 21) {
@@ -565,6 +571,70 @@ public final class DefaultAudioSink implements AudioSink {
       audioTrack.setAuxEffectSendLevel(auxEffectInfo.sendLevel);
     }
   }
+
+  @TargetApi(23)
+  @Nullable
+  @Override
+  public AudioDeviceInfo getPreferredOutputDevice() {
+    return preferredOutputDevice == null ? null : preferredOutputDevice.audioDeviceInfo;
+  }
+
+  @TargetApi(23)
+  @Override
+  public void setPreferredOutputDevice(@Nullable AudioDeviceInfo preferredOutputDevice) {
+    this.preferredOutputDevice = new AudioDeviceInfoHolder(preferredOutputDevice);
+    applyPreferredOutputDevice();
+  }
+
+  private void applyPreferredOutputDevice() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && audioTrack != null) {
+      AudioDeviceInfo preferredOutputDevice = getPreferredOutputDevice();
+      Log.d(TAG, "applyPreferredOutputDevice: "
+          + (preferredOutputDevice == null ? "null" : preferredOutputDevice.getId()));
+      if (!audioTrack.setPreferredDevice(preferredOutputDevice)) {
+        Log.w(TAG, "applyPreferredOutputDevice: setPreferredDevice failed");
+      }
+      addListener();
+    }
+  }
+
+  @TargetApi(Build.VERSION_CODES.N)
+  private static class RoutingListener implements AudioRouting.OnRoutingChangedListener, android
+      .media.AudioTrack.OnRoutingChangedListener {
+
+    @Override
+    public void onRoutingChanged(@Nullable android.media.AudioTrack audioTrack) {
+      Log.d(TAG, "onRoutingChanged() called with: audioTrack = [" + audioTrack + "]");
+    }
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.N)
+    public void onRoutingChanged(AudioRouting router) {
+      if (router instanceof android.media.AudioTrack) {
+        onRoutingChanged((android.media.AudioTrack) router);
+      } else {
+        onRoutingChanged(null);
+      }
+    }
+  }
+
+  private final RoutingListener routingListener = new RoutingListener();
+
+  @RequiresApi(23)
+  private void addListener() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      audioTrack.removeOnRoutingChangedListener(
+          (AudioRouting.OnRoutingChangedListener) routingListener);
+      audioTrack.addOnRoutingChangedListener(
+          ((AudioRouting.OnRoutingChangedListener) routingListener), null);
+    } else {
+      //noinspection deprecation
+      audioTrack.removeOnRoutingChangedListener(routingListener);
+      //noinspection deprecation
+      audioTrack.addOnRoutingChangedListener(routingListener, null);
+    }
+  }
+
 
   @Override
   public void play() {
@@ -1149,6 +1219,18 @@ public final class DefaultAudioSink implements AudioSink {
             .build();
     int audioSessionId = this.audioSessionId != C.AUDIO_SESSION_ID_UNSET ? this.audioSessionId
         : AudioManager.AUDIO_SESSION_ID_GENERATE;
+    if (Util.SDK_INT >= 23) {
+      AudioTrack.Builder builder = new AudioTrack.Builder()
+          .setAudioAttributes(attributes)
+          .setAudioFormat(format)
+          .setBufferSizeInBytes(bufferSize)
+          .setTransferMode(android.media.AudioTrack.MODE_STREAM)
+          .setSessionId(audioSessionId);
+      if (Util.SDK_INT >= 26) {
+        builder.setPerformanceMode(android.media.AudioTrack.PERFORMANCE_MODE_POWER_SAVING);
+      }
+      return builder.build();
+    }
     return new AudioTrack(attributes, format, bufferSize, MODE_STREAM, audioSessionId);
   }
 
@@ -1371,4 +1453,14 @@ public final class DefaultAudioSink implements AudioSink {
       }
     }
   }
+
+  @TargetApi(23)
+  private static class AudioDeviceInfoHolder {
+    public final AudioDeviceInfo audioDeviceInfo;
+
+    public AudioDeviceInfoHolder(@Nullable AudioDeviceInfo audioDeviceInfo) {
+      this.audioDeviceInfo = audioDeviceInfo;
+    }
+  }
+
 }

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java
@@ -18,10 +18,12 @@ package com.google.android.exoplayer2.audio;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.media.AudioDeviceInfo;
 import android.media.MediaCodec;
 import android.media.MediaCrypto;
 import android.media.MediaFormat;
 import android.media.audiofx.Virtualizer;
+import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.CallSuper;
 import android.support.annotation.Nullable;
@@ -259,6 +261,16 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
     pendingStreamChangeTimesUs = new long[MAX_PENDING_STREAM_CHANGE_COUNT];
     eventDispatcher = new EventDispatcher(eventHandler, eventListener);
     audioSink.setListener(new AudioSinkListener());
+  }
+
+  @TargetApi(23)
+  public void setPreferredAudioOutput(@Nullable AudioDeviceInfo audioDeviceInfo) {
+    audioSink.setPreferredOutputDevice(audioDeviceInfo);
+  }
+
+  @TargetApi(23)
+  public @Nullable AudioDeviceInfo getPreferredAudioOutput() {
+    return audioSink.getPreferredOutputDevice();
   }
 
   @Override
@@ -685,6 +697,12 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       case C.MSG_SET_AUX_EFFECT_INFO:
         AuxEffectInfo auxEffectInfo = (AuxEffectInfo) message;
         audioSink.setAuxEffectInfo(auxEffectInfo);
+        break;
+      case C.MSG_SET_PREFERRED_AUDIO_OUTPUT:
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+          AudioDeviceInfo deviceInfo = (AudioDeviceInfo) message;
+          audioSink.setPreferredOutputDevice(deviceInfo);
+        }
         break;
       default:
         super.handleMessage(messageType, message);

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/SimpleDecoderAudioRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/SimpleDecoderAudioRenderer.java
@@ -15,7 +15,9 @@
  */
 package com.google.android.exoplayer2.audio;
 
+import android.media.AudioDeviceInfo;
 import android.media.audiofx.Virtualizer;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
@@ -589,6 +591,12 @@ public abstract class SimpleDecoderAudioRenderer extends BaseRenderer implements
       case C.MSG_SET_AUX_EFFECT_INFO:
         AuxEffectInfo auxEffectInfo = (AuxEffectInfo) message;
         audioSink.setAuxEffectInfo(auxEffectInfo);
+        break;
+      case C.MSG_SET_PREFERRED_AUDIO_OUTPUT:
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+          AudioDeviceInfo deviceInfo = (AudioDeviceInfo) message;
+          audioSink.setPreferredOutputDevice(deviceInfo);
+        }
         break;
       default:
         super.handleMessage(messageType, message);

--- a/library/dash/build.gradle
+++ b/library/dash/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/library/hls/build.gradle
+++ b/library/hls/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/library/smoothstreaming/build.gradle
+++ b/library/smoothstreaming/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/library/ui/build.gradle
+++ b/library/ui/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/playbacktests/build.gradle
+++ b/playbacktests/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/testutils_robolectric/build.gradle
+++ b/testutils_robolectric/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.ext.compileSdkVersion
-    buildToolsVersion project.ext.buildToolsVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Gradle was simply not syncing on Android Studio 3.3 until I updated the Gradle Version, the Android Plugin Version and refactored the modules to remove old buildToolsVersions. This pull requests updates the above mentioned components.

I also had to comment out/remove the externalBuildDir code (lines 41 - 46 in the project level build.gradle file) in order for Android Studio to run the project, however, I am not able to debug that at this time.