### PR TITLE
Make DefaultRenderersFactory subclass-friendly

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/DefaultRenderersFactory.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/DefaultRenderersFactory.java
@@ -85,12 +85,12 @@ public class DefaultRenderersFactory implements RenderersFactory {
 
   protected static final int MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY = 50;
 
-  private final Context context;
-  @Nullable private DrmSessionManager<FrameworkMediaCrypto> drmSessionManager;
-  @ExtensionRendererMode private int extensionRendererMode;
-  private long allowedVideoJoiningTimeMs;
-  private boolean playClearSamplesWithoutKeys;
-  private MediaCodecSelector mediaCodecSelector;
+  protected final Context context;
+  @Nullable protected DrmSessionManager<FrameworkMediaCrypto> drmSessionManager;
+  @ExtensionRendererMode protected int extensionRendererMode;
+  protected long allowedVideoJoiningTimeMs;
+  protected boolean playClearSamplesWithoutKeys;
+  protected MediaCodecSelector mediaCodecSelector;
 
   /** @param context A {@link Context}. */
   public DefaultRenderersFactory(Context context) {


### PR DESCRIPTION
Change the `private` fields to `protected` so that subclasses can use them. 

An alternative might can be adding protected/public getters, but that seems to be an overkill.

Currently our workaround is having our own copies of private allowedVideoJoiningTimeMs and playClearSamplesWithoutKeys.