### PR TITLE
#5731 Add license information to generated POM files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ allprojects {
         }
         buildDir = "${externalBuildDir}/${project.name}"
     }
+    group = 'com.google.android.exoplayer'
 }
 
 apply from: 'javadoc_combined.gradle'

--- a/publish.gradle
+++ b/publish.gradle
@@ -23,10 +23,42 @@ if (project.ext.has("exoplayerPublishEnabled")
         groupId = 'com.google.android.exoplayer'
         website = 'https://github.com/google/ExoPlayer'
     }
+
+    gradle.taskGraph.whenReady { taskGraph ->
+        project.tasks
+                .findAll { task -> task.name.contains("generatePomFileFor") }
+                .forEach { task ->
+                    task.doLast {
+                        task.outputs.files
+                                .filter { File file ->
+                                    file.path.contains("publications") && file.name.matches("^pom-.+\\.xml\$") 
+                                }
+                                .forEach { File file -> addLicense(file) }
+                    }
+                }
+    }
 }
 
 def getBintrayRepo() {
     boolean publicRepo = hasProperty('publicRepo') &&
         property('publicRepo').toBoolean()
     return publicRepo ? 'exoplayer' : 'exoplayer-test'
+}
+
+static void addLicense(File pom) {
+    def licenseNode = new Node(null, "license")
+    licenseNode.append(new Node(null, "name", "The Apache Software License, Version 2.0"))
+    licenseNode.append(new Node(null, "url", "http://www.apache.org/licenses/LICENSE-2.0.txt"))
+    licenseNode.append(new Node(null, "distribution", "repo"))
+    def licensesNode = new Node(null, "licenses")
+    licensesNode.append(licenseNode)
+
+    def xml = new XmlParser().parse(pom)
+    xml.append(licensesNode)
+
+    def writer = new PrintWriter(new FileWriter(pom))
+    def printer = new XmlNodePrinter(writer)
+    printer.preserveWhitespace = true
+    printer.print(xml)
+    writer.close()
 }


### PR DESCRIPTION
Resolves #5731 by adding license information to each generated POM file.