### PR TITLE
Allow hex format tags when parsing URL templates

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/UrlTemplate.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/UrlTemplate.java
@@ -139,7 +139,7 @@ public final class UrlTemplate {
           String formatTag = DEFAULT_FORMAT_TAG;
           if (formatTagIndex != -1) {
             formatTag = identifier.substring(formatTagIndex);
-            if (!formatTag.endsWith("d")) {
+            if (!formatTag.endsWith("d") && !formatTag.endsWith("x")) {
               formatTag += "d";
             }
             identifier = identifier.substring(0, formatTagIndex);


### PR DESCRIPTION
Currently the method that parses the URL templates, only recognizes decimal format. However, if it does not find the decimal identifier `d`, it places it in the template.
Streams with other formats are therefore corrupted (they might skip over parts of the video).

So far I only encountered streams with either decimal or hex format. Therefore a simple extension of the `if` adding the "missing" `d` is sufficient.