### PR TITLE
Split a few assertThat(a && b).isTrue() calls into separate assertions

### DIFF
--- a/library/core/src/test/java/com/google/android/exoplayer2/source/ShuffleOrderTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/source/ShuffleOrderTest.java
@@ -123,7 +123,8 @@ public final class ShuffleOrderTest {
       assertThat(shuffleOrder.getLastIndex()).isEqualTo(indices[length - 1]);
       assertThat(shuffleOrder.getNextIndex(indices[length - 1])).isEqualTo(INDEX_UNSET);
       for (int i = 0; i < length; i++) {
-        assertThat(indices[i] >= 0 && indices[i] < length).isTrue();
+        assertThat(indices[i] >= 0).isTrue();
+        assertThat(indices[i] < length).isTrue();
       }
     }
   }

--- a/library/core/src/test/java/com/google/android/exoplayer2/upstream/DataSourceInputStreamTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/upstream/DataSourceInputStreamTest.java
@@ -40,7 +40,8 @@ public final class DataSourceInputStreamTest {
     // Read bytes.
     for (int i = 0; i < TEST_DATA.length; i++) {
       int readByte = inputStream.read();
-      assertThat(0 <= readByte && readByte < 256).isTrue();
+      assertThat(0 <= readByte).isTrue();
+      assertThat(readByte < 256).isTrue();
       assertThat(readByte).isEqualTo(TEST_DATA[i] & 0xFF);
       assertThat(inputStream.bytesRead()).isEqualTo(i + 1);
     }

--- a/testutils/src/main/java/com/google/android/exoplayer2/testutil/FakeExtractorInput.java
+++ b/testutils/src/main/java/com/google/android/exoplayer2/testutil/FakeExtractorInput.java
@@ -86,7 +86,8 @@ public final class FakeExtractorInput implements ExtractorInput {
    * @param position The position to set.
    */
   public void setPosition(int position) {
-    assertThat(0 <= position && position <= data.length).isTrue();
+    assertThat(0 <= position).isTrue();
+    assertThat(position <= data.length).isTrue();
     readPosition = position;
     peekPosition = position;
   }


### PR DESCRIPTION
This patch just separates some statements of the form "assertThat(a && b).isTrue()" into separate assertions, for more precise diagnostics.

This is an untested (but pretty trivial) patch for something that is not a bug from someone is not currently an ExoPlayer developer.  I completely understand if you choose not merge this patch, although I hope you do if you determine that it's OK.  I was just visiting this source tree to look for bigger problems, which I did not find, but noticed the conjunction assertions and got the itch to split them and then felt it was something like my civic duty to pass the patch along.  I already signed the Google contributor license agreement, by the way.

In case you're wondering about the case for splitting "assert(a && b)" statements, here is a file that I have put together advocating it.  I include this screed only here in the pull message, not the commit message, which is just a line or two.

1. Assertion failures are often sporadic, and users who report them may
   not be in a position to efficiently narrow them down further, so it
   is important to get as much precision from each assertion failure as
   possible.

2. It is a more efficient use of developers time when a bug report
   arrives if the problem has been narrowed down that much more.  A
   new bug report may initially attract more interest, so, if the
   problem has been narrowed down that much more, it may increase the
   chance that developers may invest the time to try to resolve the
   problem, and also reduce unnecessary traffic on the developer mailing
   list about possible causes of the bug that separating the assertion
   was able to rule out.
   
3. When using a debugger to step over an assertion failure in the
   first part of the statement, the second part is still tested.

4. Providing separate likelihood hints to the compiler in the form
   of separate assert statements does not require the compiler to
   be quite as smart to recognize that it should optimize both branches,
   although I do not know if that makes a difference for any compiler
   commonly used to compile X (that is, I suspect that they are all
   smart enough to realize is that "a && b" is likely true, then "a"
   is likely true and "b" is likely true).

5. In my humble opinion, separated assertions are almost always more
   readable, sometimes eliminating parentheses, often making
   references to the same values line up on the same columns, which
   can make range checks more obvious, and sometimes changing
   multi-line conditions to separate single line conditions, which can
   be recognized separately.

   Consider, for example, how columnization in this makes this range
   check more recongizable and makes it easier to recognize in a glance
   that it is a bounds check and what the bounds are:

                assert(reg.vstride >= 0 && reg.vstride < ARRAY_SIZE(vstride_for_reg));
                        ... vs. ...

                assert(reg.vstride >= 0);
                assert(reg.vstride < ARRAY_SIZE(vstride_for_reg));

   A possible counter-argument to this might be that, in a sequence of
   assertions, can be informative to group related assertions together,
   which I think is true, but it is possible to get this other means, such
   as by using blank lines to separate express such grouping.



Anyhow, thanks in advance for considering this patch.