### PR TITLE
Support signalling of last segment number via supplemental descriptor in mpd.

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
@@ -42,7 +42,6 @@ import com.google.android.exoplayer2.source.chunk.SingleSampleMediaChunk;
 import com.google.android.exoplayer2.source.dash.PlayerEmsgHandler.PlayerTrackEmsgHandler;
 import com.google.android.exoplayer2.source.dash.manifest.AdaptationSet;
 import com.google.android.exoplayer2.source.dash.manifest.DashManifest;
-import com.google.android.exoplayer2.source.dash.manifest.Descriptor;
 import com.google.android.exoplayer2.source.dash.manifest.RangedUri;
 import com.google.android.exoplayer2.source.dash.manifest.Representation;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
@@ -326,35 +325,10 @@ public class DefaultDashChunkSource implements DashChunkSource {
       return;
     }
 
-    List<Descriptor> listDescriptors;
-    Integer lastSegmentNumberSchemeIdUri = Integer.MAX_VALUE;
-    String sampleMimeType = trackSelection.getFormat(periodIndex).sampleMimeType;
-
-    if (sampleMimeType.contains("video") || sampleMimeType.contains("audio")) {
-
-      int track_type = sampleMimeType.contains("video")? C.TRACK_TYPE_VIDEO : C.TRACK_TYPE_AUDIO;
-
-      if (!manifest.getPeriod(periodIndex).adaptationSets.get(manifest.getPeriod(periodIndex)
-          .getAdaptationSetIndex(track_type)).supplementalProperties.isEmpty()) {
-        listDescriptors = manifest.getPeriod(periodIndex).adaptationSets
-            .get(manifest.getPeriod(periodIndex).getAdaptationSetIndex(track_type))
-            .supplementalProperties;
-        for ( Descriptor descriptor: listDescriptors ) {
-          if (descriptor.schemeIdUri.equalsIgnoreCase
-              ("http://dashif.org/guidelines/last-segment-number")) {
-            lastSegmentNumberSchemeIdUri = Integer.valueOf(descriptor.value);
-          }
-        }
-      }
-    }
-
     long firstAvailableSegmentNum =
         representationHolder.getFirstAvailableSegmentNum(manifest, periodIndex, nowUnixTimeUs);
     long lastAvailableSegmentNum =
-        Math.min(representationHolder.
-                getLastAvailableSegmentNum(manifest, periodIndex, nowUnixTimeUs),
-                lastSegmentNumberSchemeIdUri);
-
+        representationHolder.getLastAvailableSegmentNum(manifest, periodIndex, nowUnixTimeUs);
     updateLiveEdgeTimeUs(representationHolder, lastAvailableSegmentNum);
 
     long segmentNum =

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
@@ -42,6 +42,7 @@ import com.google.android.exoplayer2.source.chunk.SingleSampleMediaChunk;
 import com.google.android.exoplayer2.source.dash.PlayerEmsgHandler.PlayerTrackEmsgHandler;
 import com.google.android.exoplayer2.source.dash.manifest.AdaptationSet;
 import com.google.android.exoplayer2.source.dash.manifest.DashManifest;
+import com.google.android.exoplayer2.source.dash.manifest.Descriptor;
 import com.google.android.exoplayer2.source.dash.manifest.RangedUri;
 import com.google.android.exoplayer2.source.dash.manifest.Representation;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
@@ -325,10 +326,34 @@ public class DefaultDashChunkSource implements DashChunkSource {
       return;
     }
 
+    List<Descriptor> listDescriptors;
+    Integer lastSegmentNumberSchemeIdUri = Integer.MAX_VALUE;
+    String sampleMimeType = trackSelection.getFormat(periodIndex).sampleMimeType;
+
+    if (sampleMimeType.contains("video") || sampleMimeType.contains("audio")) {
+
+      int track_type = sampleMimeType.contains("video")? C.TRACK_TYPE_VIDEO : C.TRACK_TYPE_AUDIO;
+
+      if (!manifest.getPeriod(periodIndex).adaptationSets.get(manifest.getPeriod(periodIndex)
+          .getAdaptationSetIndex(track_type)).supplementalProperties.isEmpty()) {
+        listDescriptors = manifest.getPeriod(periodIndex).adaptationSets
+            .get(manifest.getPeriod(periodIndex).getAdaptationSetIndex(track_type))
+            .supplementalProperties;
+        for ( Descriptor descriptor: listDescriptors ) {
+          if (descriptor.schemeIdUri.equalsIgnoreCase
+              ("http://dashif.org/guidelines/last-segment-number")) {
+            lastSegmentNumberSchemeIdUri = Integer.valueOf(descriptor.value);
+          }
+        }
+      }
+    }
+
     long firstAvailableSegmentNum =
         representationHolder.getFirstAvailableSegmentNum(manifest, periodIndex, nowUnixTimeUs);
     long lastAvailableSegmentNum =
-        representationHolder.getLastAvailableSegmentNum(manifest, periodIndex, nowUnixTimeUs);
+        Math.min(representationHolder.
+                getLastAvailableSegmentNum(manifest, periodIndex, nowUnixTimeUs),
+                lastSegmentNumberSchemeIdUri);
 
     updateLiveEdgeTimeUs(representationHolder, lastAvailableSegmentNum);
 

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/SegmentBase.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/SegmentBase.java
@@ -140,7 +140,7 @@ public abstract class SegmentBase {
      *     division of this value and {@code timescale}.
      * @param startNumber The sequence number of the first segment.
      * @param endNumber The sequence number of the last segment specified by SupplementalProperty
-     *           schemeIdUri="http://dashif.org/guidelines/last-segment-number"
+     *     schemeIdUri="http://dashif.org/guidelines/last-segment-number"
      * @param duration The duration of each segment in the case of fixed duration segments. The
      *     value in seconds is the division of this value and {@code timescale}. If {@code
      *     segmentTimeline} is non-null then this parameter is ignored.
@@ -408,10 +408,10 @@ public abstract class SegmentBase {
 
     @Override
     public int getSegmentCount(long periodDurationUs) {
-      if( endNumber != C.INDEX_UNSET) {
-        return endNumber;
-      } else if (segmentTimeline != null) {
+      if (segmentTimeline != null) {
         return segmentTimeline.size();
+      } else if (endNumber != C.INDEX_UNSET) {
+        return endNumber - (int) startNumber + 1;
       } else if (periodDurationUs != C.TIME_UNSET) {
         long durationUs = (duration * C.MICROS_PER_SECOND) / timescale;
         return (int) Util.ceilDivide(periodDurationUs, durationUs);
@@ -419,7 +419,6 @@ public abstract class SegmentBase {
         return DashSegmentIndex.INDEX_UNBOUNDED;
       }
     }
-
   }
 
   /**

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/SegmentBase.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/SegmentBase.java
@@ -102,7 +102,6 @@ public abstract class SegmentBase {
     /* package */ final long startNumber;
     /* package */ final long duration;
     /* package */ final List<SegmentTimelineElement> segmentTimeline;
-    /* package */ final int endNumber;
 
     /**
      * @param initialization A {@link RangedUri} corresponding to initialization data, if such data
@@ -129,38 +128,6 @@ public abstract class SegmentBase {
       this.startNumber = startNumber;
       this.duration = duration;
       this.segmentTimeline = segmentTimeline;
-      this.endNumber = C.INDEX_UNSET;
-    }
-
-    /**
-     * @param initialization A {@link RangedUri} corresponding to initialization data, if such data
-     *     exists.
-     * @param timescale The timescale in units per second.
-     * @param presentationTimeOffset The presentation time offset. The value in seconds is the
-     *     division of this value and {@code timescale}.
-     * @param startNumber The sequence number of the first segment.
-     * @param endNumber The sequence number of the last segment specified by SupplementalProperty
-     *     schemeIdUri="http://dashif.org/guidelines/last-segment-number"
-     * @param duration The duration of each segment in the case of fixed duration segments. The
-     *     value in seconds is the division of this value and {@code timescale}. If {@code
-     *     segmentTimeline} is non-null then this parameter is ignored.
-     * @param segmentTimeline A segment timeline corresponding to the segments. If null, then
-     *     segments are assumed to be of fixed duration as specified by the {@code duration}
-     *     parameter.
-     */
-    public MultiSegmentBase(
-        RangedUri initialization,
-        long timescale,
-        long presentationTimeOffset,
-        long startNumber,
-        int endNumber,
-        long duration,
-        List<SegmentTimelineElement> segmentTimeline) {
-      super(initialization, timescale, presentationTimeOffset);
-      this.startNumber = startNumber;
-      this.duration = duration;
-      this.segmentTimeline = segmentTimeline;
-      this.endNumber = endNumber;
     }
 
     /** @see DashSegmentIndex#getSegmentNum(long, long) */
@@ -310,6 +277,7 @@ public abstract class SegmentBase {
 
     /* package */ final UrlTemplate initializationTemplate;
     /* package */ final UrlTemplate mediaTemplate;
+    /* package */ final long endNumber;
 
     /**
      * @param initialization A {@link RangedUri} corresponding to initialization data, if such data
@@ -343,6 +311,7 @@ public abstract class SegmentBase {
           duration, segmentTimeline);
       this.initializationTemplate = initializationTemplate;
       this.mediaTemplate = mediaTemplate;
+      this.endNumber = C.INDEX_UNSET;
     }
 
     /**
@@ -371,15 +340,16 @@ public abstract class SegmentBase {
         long timescale,
         long presentationTimeOffset,
         long startNumber,
-        int endNumber,
+        long endNumber,
         long duration,
         List<SegmentTimelineElement> segmentTimeline,
         UrlTemplate initializationTemplate,
         UrlTemplate mediaTemplate) {
-      super(initialization, timescale, presentationTimeOffset, startNumber,endNumber,
-          duration, segmentTimeline);
+      super(initialization, timescale, presentationTimeOffset, startNumber, duration,
+          segmentTimeline);
       this.initializationTemplate = initializationTemplate;
       this.mediaTemplate = mediaTemplate;
+      this.endNumber = endNumber;
     }
 
     @Override
@@ -411,7 +381,7 @@ public abstract class SegmentBase {
       if (segmentTimeline != null) {
         return segmentTimeline.size();
       } else if (endNumber != C.INDEX_UNSET) {
-        return endNumber - (int) startNumber + 1;
+        return (int) (endNumber - startNumber + 1);
       } else if (periodDurationUs != C.TIME_UNSET) {
         long durationUs = (duration * C.MICROS_PER_SECOND) / timescale;
         return (int) Util.ceilDivide(periodDurationUs, durationUs);


### PR DESCRIPTION
Last segment indicated Supplemental Property by mpd is parsed but not taken into consideration by the player.

This patch supports Supplemental Descriptor with @schemeIdUri set to "http://dashif.org/guide-
lines/last-segment-number" with the @value set to the last segment number.

Example stream: http://dash.akamaized.net/dash264/TestCasesIOP41/LastSegmentNumber/1/manifest_last_segment_num.mpd
