### PR TITLE
Do not update with empty metadata when metadata provider is set to null

### DIFF
--- a/extensions/mediasession/src/main/java/com/google/android/exoplayer2/ext/mediasession/MediaSessionConnector.java
+++ b/extensions/mediasession/src/main/java/com/google/android/exoplayer2/ext/mediasession/MediaSessionConnector.java
@@ -662,11 +662,12 @@ public final class MediaSessionConnector {
    * {@link MediaMetadataProvider#getMetadata(Player)}.
    */
   public final void invalidateMediaSessionMetadata() {
-    MediaMetadataCompat metadata =
-        mediaMetadataProvider != null && player != null
-            ? mediaMetadataProvider.getMetadata(player)
-            : METADATA_EMPTY;
-    mediaSession.setMetadata(metadata != null ? metadata : METADATA_EMPTY);
+    if (mediaMetadataProvider != null) {
+      MediaMetadataCompat metadata = player != null
+          ? mediaMetadataProvider.getMetadata(player)
+          : METADATA_EMPTY;
+      mediaSession.setMetadata(metadata != null ? metadata : METADATA_EMPTY);
+    }
   }
 
   /**


### PR DESCRIPTION
When `MediaSessionConnector.setMediaMetadataProvider` is called with `null`, I'd expect `MediaSessionConnector` to no longer update the media session metadata, even with an empty placeholder (`METADATA_EMPTY`).
This brings more flexibility to how metadata can be updated: the current `MediaMetadataProvider` interface does not support setting metadata retrieved from a callback/asynchronous API (RxJava, Kotlin Coroutines, etc.)