### PR TITLE
Fix for CloudFront malformed manifest

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/UrlTemplate.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/UrlTemplate.java
@@ -115,6 +115,7 @@ public final class UrlTemplate {
    */
   private static int parseTemplate(String template, String[] urlPieces, int[] identifiers,
       String[] identifierFormatTags) {
+    template = template.replace("%00","%0");
     urlPieces[0] = "";
     int templateIndex = 0;
     int identifierCount = 0;

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/UrlTemplate.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/UrlTemplate.java
@@ -115,7 +115,7 @@ public final class UrlTemplate {
    */
   private static int parseTemplate(String template, String[] urlPieces, int[] identifiers,
       String[] identifierFormatTags) {
-    template = template.replace("%00","%0");
+    template = template.replace("%00d","");
     urlPieces[0] = "";
     int templateIndex = 0;
     int identifierCount = 0;


### PR DESCRIPTION
CloudFront uses malformed manifests in their mpd files, eg:
<SegmentTemplate duration="4000000" initialization="../video/360/stream_2-init.mp4" media="../video/360/stream_2-seg_$Number%00d$.mp4" startNumber="1" timescale="1000000"></SegmentTemplate>

%00d does not format well when passed to formatter and throws exception