### PR TITLE
Fix ImaAdsLoader handling of first midroll ad without preroll #5928

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -1055,7 +1055,13 @@ public final class ImaAdsLoader
     int adGroupIndexForPosition =
         adPlaybackState.getAdGroupIndexForPositionUs(C.msToUs(contentPositionMs));
     if (adGroupIndexForPosition == 0) {
-      podIndexOffset = 0;
+      if (adGroupTimesUs[0] == 0) {
+        // starting playback from start or just after preroll
+        podIndexOffset = 0;
+      } else {
+        // starting playback from after first midroll in a no-preroll setup, handle as midroll
+        podIndexOffset = -1;
+      }
     } else if (adGroupIndexForPosition == C.INDEX_UNSET) {
       // There is no preroll and midroll pod indices start at 1.
       podIndexOffset = -1;


### PR DESCRIPTION
In situation where we have a IMA tag setup of no preroll but have midrolls,
and when we start playback directly after first midroll, we can get into a
stuck state after ad finishes playing. This patch fixes this issue.

For more details about the issue see #5928 