### PR TITLE
Support for UDP data source

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultDataSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultDataSource.java
@@ -55,6 +55,7 @@ public final class DefaultDataSource implements DataSource {
   private static final String SCHEME_ASSET = "asset";
   private static final String SCHEME_CONTENT = "content";
   private static final String SCHEME_RTMP = "rtmp";
+  private static final String SCHEME_UDP = "udp";
   private static final String SCHEME_RAW = RawResourceDataSource.RAW_RESOURCE_SCHEME;
 
   private final Context context;
@@ -66,6 +67,7 @@ public final class DefaultDataSource implements DataSource {
   @Nullable private DataSource assetDataSource;
   @Nullable private DataSource contentDataSource;
   @Nullable private DataSource rtmpDataSource;
+  @Nullable private DataSource udpDataSource;
   @Nullable private DataSource dataSchemeDataSource;
   @Nullable private DataSource rawResourceDataSource;
 
@@ -139,6 +141,7 @@ public final class DefaultDataSource implements DataSource {
     maybeAddListenerToDataSource(assetDataSource, transferListener);
     maybeAddListenerToDataSource(contentDataSource, transferListener);
     maybeAddListenerToDataSource(rtmpDataSource, transferListener);
+    maybeAddListenerToDataSource(udpDataSource, transferListener);
     maybeAddListenerToDataSource(dataSchemeDataSource, transferListener);
     maybeAddListenerToDataSource(rawResourceDataSource, transferListener);
   }
@@ -161,6 +164,8 @@ public final class DefaultDataSource implements DataSource {
       dataSource = getContentDataSource();
     } else if (SCHEME_RTMP.equals(scheme)) {
       dataSource = getRtmpDataSource();
+    } else if(SCHEME_UDP.equals(scheme)){
+      dataSource = getUdpDataSource();
     } else if (DataSchemeDataSource.SCHEME_DATA.equals(scheme)) {
       dataSource = getDataSchemeDataSource();
     } else if (SCHEME_RAW.equals(scheme)) {
@@ -197,6 +202,14 @@ public final class DefaultDataSource implements DataSource {
         dataSource = null;
       }
     }
+  }
+
+  private DataSource getUdpDataSource(){
+    if (udpDataSource == null) {
+      udpDataSource = new UdpDataSource();
+      addListenersToDataSource(udpDataSource);
+    }
+    return udpDataSource;
   }
 
   private DataSource getFileDataSource() {


### PR DESCRIPTION
In the current release, there is no support to reproduce videos throughout UDP. As a result, I wanted to modify just this single class to add the functionality. I have tested it with an UDP video and it worked like a charm. Just a few changes were needed. 

In order to test and make sure that these changes can be applied to next release, it's only necessary to put an UDP video in the demo and ensure that it works correctly.

I saw some people asking for this feature in ExoPlayer's issues. So I think it would be very useful to add this functionality in future releases. It would keep us aside of having to instantiate your whole project locally in our repositories.