### PR TITLE
Add convenience constructors for notification channel descriptions

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadService.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadService.java
@@ -174,6 +174,7 @@ public abstract class DownloadService extends Service {
   @Nullable private final ForegroundNotificationUpdater foregroundNotificationUpdater;
   @Nullable private final String channelId;
   @StringRes private final int channelNameResourceId;
+  @StringRes private final int channelDescriptionResourceId;
 
   private DownloadManager downloadManager;
   private int lastStartId;
@@ -239,16 +240,53 @@ public abstract class DownloadService extends Service {
       long foregroundNotificationUpdateInterval,
       @Nullable String channelId,
       @StringRes int channelNameResourceId) {
+    this(
+        foregroundNotificationId,
+        foregroundNotificationUpdateInterval,
+        channelId,
+        channelNameResourceId,
+        /* channelDescriptionResourceId= */ 0
+    );
+  }
+
+  /**
+   * Creates a DownloadService.
+   *
+   * @param foregroundNotificationId The notification id for the foreground notification, or {@link
+   *     #FOREGROUND_NOTIFICATION_ID_NONE} if the service should only ever run in the background.
+   * @param foregroundNotificationUpdateInterval The maximum interval between updates to the
+   *     foreground notification, in milliseconds. Ignored if {@code foregroundNotificationId} is
+   *     {@link #FOREGROUND_NOTIFICATION_ID_NONE}.
+   * @param channelId An id for a low priority notification channel to create, or {@code null} if
+   *     the app will take care of creating a notification channel if needed. If specified, must be
+   *     unique per package. The value may be truncated if it's too long. Ignored if {@code
+   *     foregroundNotificationId} is {@link #FOREGROUND_NOTIFICATION_ID_NONE}.
+   * @param channelNameResourceId A string resource identifier for the user visible name of the
+   *     channel, if {@code channelId} is specified. The recommended maximum length is 40
+   *     characters. The value may be truncated if it is too long. Ignored if {@code
+   *     foregroundNotificationId} is {@link #FOREGROUND_NOTIFICATION_ID_NONE}.
+   * @param channelDescriptionResourceId A string resource identifier for the user visible
+   *     description. Ignored if {@code foregroundNotificationId} is
+   *     {@link #FOREGROUND_NOTIFICATION_ID_NONE}.
+   */
+  protected DownloadService(
+      int foregroundNotificationId,
+      long foregroundNotificationUpdateInterval,
+      @Nullable String channelId,
+      @StringRes int channelNameResourceId,
+      @StringRes int channelDescriptionResourceId) {
     if (foregroundNotificationId == FOREGROUND_NOTIFICATION_ID_NONE) {
       this.foregroundNotificationUpdater = null;
       this.channelId = null;
       this.channelNameResourceId = 0;
+      this.channelDescriptionResourceId = 0;
     } else {
       this.foregroundNotificationUpdater =
           new ForegroundNotificationUpdater(
               foregroundNotificationId, foregroundNotificationUpdateInterval);
       this.channelId = channelId;
       this.channelNameResourceId = channelNameResourceId;
+      this.channelDescriptionResourceId = channelDescriptionResourceId;
     }
   }
 
@@ -543,7 +581,11 @@ public abstract class DownloadService extends Service {
   public void onCreate() {
     if (channelId != null) {
       NotificationUtil.createNotificationChannel(
-          this, channelId, channelNameResourceId, NotificationUtil.IMPORTANCE_LOW);
+          this,
+          channelId,
+          channelNameResourceId,
+          channelDescriptionResourceId,
+          NotificationUtil.IMPORTANCE_LOW);
     }
     Class<? extends DownloadService> clazz = getClass();
     DownloadManagerHelper downloadManagerHelper = downloadManagerListeners.get(clazz);

--- a/library/core/src/main/java/com/google/android/exoplayer2/util/NotificationUtil.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/NotificationUtil.java
@@ -80,11 +80,48 @@ public final class NotificationUtil {
    */
   public static void createNotificationChannel(
       Context context, String id, @StringRes int nameResourceId, @Importance int importance) {
+    createNotificationChannel(
+        context,
+        id,
+        nameResourceId,
+        importance,
+        /* descriptionResourceId= */ 0);
+  }
+
+  /**
+   * Creates a notification channel that notifications can be posted to. See {@link
+   * NotificationChannel} and {@link
+   * NotificationManager#createNotificationChannel(NotificationChannel)} for details.
+   *
+   * @param context A {@link Context}.
+   * @param id The id of the channel. Must be unique per package. The value may be truncated if it's
+   *     too long.
+   * @param nameResourceId A string resource identifier for the user visible name of the channel.
+   *     You can rename this channel when the system locale changes by listening for the {@link
+   *     Intent#ACTION_LOCALE_CHANGED} broadcast. The recommended maximum length is 40 characters.
+   *     The value may be truncated if it is too long.
+   * @param importance The importance of the channel. This controls how interruptive notifications
+   *     posted to this channel are. One of {@link #IMPORTANCE_UNSPECIFIED}, {@link
+   *     #IMPORTANCE_NONE}, {@link #IMPORTANCE_MIN}, {@link #IMPORTANCE_LOW}, {@link
+   *     #IMPORTANCE_DEFAULT} and {@link #IMPORTANCE_HIGH}.
+   * @param descriptionResourceId A String resource identifier for the user visible description of
+   *     the channel. You can change the description of this channel when the system locale changes
+   *     by listening for the {@link Intent#ACTION_LOCALE_CHANGED} broadcast. Ignored if set to 0.
+   */
+  public static void createNotificationChannel(
+      Context context,
+      String id,
+      @StringRes int nameResourceId,
+      @Importance int importance,
+      @StringRes int descriptionResourceId) {
     if (Util.SDK_INT >= 26) {
       NotificationManager notificationManager =
           (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
       NotificationChannel channel =
           new NotificationChannel(id, context.getString(nameResourceId), importance);
+      if(descriptionResourceId != 0) {
+        channel.setDescription(context.getString(descriptionResourceId));
+      }
       notificationManager.createNotificationChannel(channel);
     }
   }

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerNotificationManager.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/PlayerNotificationManager.java
@@ -416,6 +416,38 @@ public class PlayerNotificationManager {
 
   /**
    * Creates a notification manager and a low-priority notification channel with the specified
+   * {@code channelId} and {@code channelName}.
+   *
+   * <p>If the player notification manager is intended to be used within a foreground service,
+   * {@link #createWithNotificationChannel(Context, String, int, int, MediaDescriptionAdapter,
+   * NotificationListener)} should be used to which a {@link NotificationListener} can be passed.
+   * This way you'll receive the notification to put the service into the foreground by calling
+   * {@link android.app.Service#startForeground(int, Notification)}.
+   *
+   * @param context The {@link Context}.
+   * @param channelId The id of the notification channel.
+   * @param channelName A string resource identifier for the user visible name of the channel. The
+   *     recommended maximum length is 40 characters; the value may be truncated if it is too long.
+   * @param channelDescription A String resource identifier for the user visible description of the
+   *     channel.
+   * @param notificationId The id of the notification.
+   * @param mediaDescriptionAdapter The {@link MediaDescriptionAdapter}.
+   */
+  public static PlayerNotificationManager createWithNotificationChannel(
+      Context context,
+      String channelId,
+      @StringRes int channelName,
+      @StringRes int channelDescription,
+      int notificationId,
+      MediaDescriptionAdapter mediaDescriptionAdapter) {
+    NotificationUtil.createNotificationChannel(
+        context, channelId, channelName, channelDescription, NotificationUtil.IMPORTANCE_LOW);
+    return new PlayerNotificationManager(
+        context, channelId, notificationId, mediaDescriptionAdapter);
+  }
+
+  /**
+   * Creates a notification manager and a low-priority notification channel with the specified
    * {@code channelId} and {@code channelName}. The {@link NotificationListener} passed as the last
    * parameter will be notified when the notification is created and cancelled.
    *
@@ -436,6 +468,35 @@ public class PlayerNotificationManager {
       @Nullable NotificationListener notificationListener) {
     NotificationUtil.createNotificationChannel(
         context, channelId, channelName, NotificationUtil.IMPORTANCE_LOW);
+    return new PlayerNotificationManager(
+        context, channelId, notificationId, mediaDescriptionAdapter, notificationListener);
+  }
+
+  /**
+   * Creates a notification manager and a low-priority notification channel with the specified
+   * {@code channelId} and {@code channelName}. The {@link NotificationListener} passed as the last
+   * parameter will be notified when the notification is created and cancelled.
+   *
+   * @param context The {@link Context}.
+   * @param channelId The id of the notification channel.
+   * @param channelName A string resource identifier for the user visible name of the channel. The
+   *     recommended maximum length is 40 characters; the value may be truncated if it is too long.
+   * @param channelDescription A String resource identifier for the user visible description of the
+   *     channel.
+   * @param notificationId The id of the notification.
+   * @param mediaDescriptionAdapter The {@link MediaDescriptionAdapter}.
+   * @param notificationListener The {@link NotificationListener}.
+   */
+  public static PlayerNotificationManager createWithNotificationChannel(
+      Context context,
+      String channelId,
+      @StringRes int channelName,
+      @StringRes int channelDescription,
+      int notificationId,
+      MediaDescriptionAdapter mediaDescriptionAdapter,
+      @Nullable NotificationListener notificationListener) {
+    NotificationUtil.createNotificationChannel(
+        context, channelId, channelName, channelDescription, NotificationUtil.IMPORTANCE_LOW);
     return new PlayerNotificationManager(
         context, channelId, notificationId, mediaDescriptionAdapter, notificationListener);
   }


### PR DESCRIPTION
Currently only the channel name can be supplied when using the convenience constructors for `PlayerNotificationManager` and `DownloadService` to create notification channels.

With this PR it is possible to also conveniently change the description of the notification channel.