### PR TITLE
Parse SmoothStreaming text track subtype into Format.roleflags.

### DIFF
--- a/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/manifest/SsManifestParser.java
+++ b/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/manifest/SsManifestParser.java
@@ -586,6 +586,7 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
       } else {
         subType = parser.getAttributeValue(null, KEY_SUB_TYPE);
       }
+      putNormalizedAttribute(KEY_SUB_TYPE, subType);
       name = parser.getAttributeValue(null, KEY_NAME);
       url = parseRequiredString(parser, KEY_URL);
       maxWidth = parseInt(parser, KEY_MAX_WIDTH, Format.NO_VALUE);
@@ -645,6 +646,7 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
     private static final String KEY_CHANNELS = "Channels";
     private static final String KEY_FOUR_CC = "FourCC";
     private static final String KEY_TYPE = "Type";
+    private static final String KEY_SUB_TYPE = "Subtype";
     private static final String KEY_LANGUAGE = "Language";
     private static final String KEY_NAME = "Name";
     private static final String KEY_MAX_WIDTH = "MaxWidth";
@@ -710,6 +712,18 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
                 language);
       } else if (type == C.TRACK_TYPE_TEXT) {
         String language = (String) getNormalizedAttribute(KEY_LANGUAGE);
+        String subType = (String) getNormalizedAttribute(KEY_SUB_TYPE);
+        int roleFlags = 0;
+        switch (subType) {
+          case "CAPT":
+            roleFlags |= C.ROLE_FLAG_CAPTION;
+            break;
+          case "DESC":
+            roleFlags |= C.ROLE_FLAG_DESCRIBES_MUSIC_AND_SOUND;
+            break;
+          case "SUBT":
+            break;
+        }
         format =
             Format.createTextContainerFormat(
                 id,
@@ -719,7 +733,7 @@ public class SsManifestParser implements ParsingLoadable.Parser<SsManifest> {
                 /* codecs= */ null,
                 bitrate,
                 /* selectionFlags= */ 0,
-                /* roleFlags= */ 0,
+                /* roleFlags= */ roleFlags,
                 language);
       } else {
         format =


### PR DESCRIPTION
According to the SmoothStreaming specification available here https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-sstr/8383f27f-7efe-4c60-832a-387274457251 "Subtype" can describe the role of a text track like _"Closed captions for people who are deaf."_