### PR TITLE
Support for HLS EXT-X-IFRAME-ONLY playlists

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/C.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/C.java
@@ -1065,6 +1065,10 @@ public final class C {
   /** Indicates the track contains a text that has been edited for ease of reading. */
   public static final int ROLE_FLAG_EASY_TO_READ = 1 << 13;
 
+  // TODO - not a 'role' in the sense it is parsed from the CHARACTERISTICS attribute... forced if iFrame only
+  /** Indicates the track is an IDR (IFrame) only track for trick play */
+  public static final int ROLE_FLAG_TRICK_PLAY = 1 << 14;
+
   /**
    * Converts a time in microseconds to the corresponding time in milliseconds, preserving
    * {@link #TIME_UNSET} and {@link #TIME_END_OF_SOURCE} values.

--- a/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
@@ -541,16 +541,10 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
   protected boolean canSelectFormat(
       Format format, int trackBitrate, float playbackSpeed, long effectiveBitrate) {
 
-    boolean isIframeOnly = (format.roleFlags & C.ROLE_FLAG_TRICK_PLAY) != 0;
+    boolean isNonIframeOnly = (format.roleFlags & C.ROLE_FLAG_TRICK_PLAY) == 0;
     boolean canSelect = Math.round(trackBitrate * playbackSpeed) <= effectiveBitrate;
 
-    if (Math.abs(playbackSpeed) > 6.0f) {
-      canSelect = isIframeOnly;   // TODO factor in playback speed...
-    } else {
-      canSelect = ! isIframeOnly && canSelect;
-    }
-    return canSelect;
-
+    return canSelect && isNonIframeOnly;    // Default is not to use the IDR only tracks in selection
   }
 
   /**

--- a/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
@@ -541,10 +541,10 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
   protected boolean canSelectFormat(
       Format format, int trackBitrate, float playbackSpeed, long effectiveBitrate) {
 
-    boolean isNonIframeOnly = (format.roleFlags & C.ROLE_FLAG_TRICK_PLAY) == 0;
+    boolean isIframeOnlyFormat = (format.roleFlags & C.ROLE_FLAG_TRICK_PLAY) != 0;
     boolean canSelect = Math.round(trackBitrate * playbackSpeed) <= effectiveBitrate;
 
-    return canSelect && isNonIframeOnly;    // Default is not to use the IDR only tracks in selection
+    return canSelect && !isIframeOnlyFormat;    // Default is not to use the IDR only tracks in selection
   }
 
   /**

--- a/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
@@ -540,7 +540,17 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
   @SuppressWarnings("unused")
   protected boolean canSelectFormat(
       Format format, int trackBitrate, float playbackSpeed, long effectiveBitrate) {
-    return Math.round(trackBitrate * playbackSpeed) <= effectiveBitrate;
+
+    boolean isIframeOnly = (format.roleFlags & C.ROLE_FLAG_TRICK_PLAY) != 0;
+    boolean canSelect = Math.round(trackBitrate * playbackSpeed) <= effectiveBitrate;
+
+    if (Math.abs(playbackSpeed) > 6.0f) {
+      canSelect = isIframeOnly;   // TODO factor in playback speed...
+    } else {
+      canSelect = ! isIframeOnly && canSelect;
+    }
+    return canSelect;
+
   }
 
   /**

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaPeriod.java
@@ -470,7 +470,6 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsSampleStreamWrapper
             : Collections.emptyMap();
 
     boolean hasVariants = !masterPlaylist.variants.isEmpty();
-    boolean hasIFrameVariants = !masterPlaylist.iFrameVariants.isEmpty();
     List<Rendition> audioRenditions = masterPlaylist.audios;
     List<Rendition> subtitleRenditions = masterPlaylist.subtitles;
 
@@ -564,7 +563,8 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsSampleStreamWrapper
       long positionUs,
       List<HlsSampleStreamWrapper> sampleStreamWrappers,
       List<int[]> manifestUrlIndicesPerWrapper,
-      Map<String, DrmInitData> overridingDrmInitData, List<Variant> variants) {
+      Map<String, DrmInitData> overridingDrmInitData,
+      List<Variant> variants) {
     int[] variantTypes = new int[variants.size()];
     int videoVariantCount = 0;
     int audioVariantCount = 0;
@@ -627,8 +627,8 @@ public final class HlsMediaPeriod implements MediaPeriod, HlsSampleStreamWrapper
       List<TrackGroup> muxedTrackGroups = new ArrayList<>();
       if (variantsContainVideoCodecs) {
         Format[] videoFormats = new Format[selectedVariantsCount];
-        for (int i1 = 0; i1 < videoFormats.length; i1++) {
-          videoFormats[i1] = deriveVideoFormat(selectedPlaylistFormats[i1]);
+        for (int i = 0; i < videoFormats.length; i++) {
+          videoFormats[i] = deriveVideoFormat(selectedPlaylistFormats[i]);
         }
         muxedTrackGroups.add(new TrackGroup(videoFormats));
 

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylist.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylist.java
@@ -35,6 +35,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
           /* baseUri= */ "",
           /* tags= */ Collections.emptyList(),
           /* variants= */ Collections.emptyList(),
+          /* iframes= */ Collections.emptyList(),
           /* videos= */ Collections.emptyList(),
           /* audios= */ Collections.emptyList(),
           /* subtitles= */ Collections.emptyList(),
@@ -95,6 +96,28 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
     }
 
     /**
+     * Construct a Variant with only an (optional) video Rendition (for example, EXT-X-I-FRAME-STREAM-INF
+     * only allows alternate VIDEO Renditions, these are suggested if the non-Iframe Variant includes
+     * alternate video Rendition but not required)
+     *
+     * @param url See {@link #url}.
+     * @param format See {@link #format}.
+     * @param videoGroupId See {@link #videoGroupId}.
+     */
+    public Variant(
+        Uri url,
+        Format format,
+        @Nullable String videoGroupId) {
+      this(
+          url,
+          format,
+          videoGroupId,
+          /* audioGroupId */null,
+          /* subtitleGroupId */null,
+          /* captionGroupId */null);
+    }
+
+    /**
      * Creates a variant for a given media playlist url.
      *
      * @param url The media playlist url.
@@ -152,6 +175,8 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
   public final List<Uri> mediaPlaylistUrls;
   /** The variants declared by the playlist. */
   public final List<Variant> variants;
+  /** The IFrame only playlist declared by the playlist, if any. */
+  public final List<Variant> iFrameVariants;
   /** The video renditions declared by the playlist. */
   public final List<Rendition> videos;
   /** The audio renditions declared by the playlist. */
@@ -181,6 +206,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
    * @param baseUri See {@link #baseUri}.
    * @param tags See {@link #tags}.
    * @param variants See {@link #variants}.
+   * @param iFrameVariants
    * @param videos See {@link #videos}.
    * @param audios See {@link #audios}.
    * @param subtitles See {@link #subtitles}.
@@ -195,6 +221,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
       String baseUri,
       List<String> tags,
       List<Variant> variants,
+      List<Variant> iFrameVariants,
       List<Rendition> videos,
       List<Rendition> audios,
       List<Rendition> subtitles,
@@ -209,6 +236,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
         Collections.unmodifiableList(
             getMediaPlaylistUrls(variants, iFrameVariants, videos, audios, subtitles, closedCaptions));
     this.variants = Collections.unmodifiableList(variants);
+    this.iFrameVariants = Collections.unmodifiableList(iFrameVariants);
     this.videos = Collections.unmodifiableList(videos);
     this.audios = Collections.unmodifiableList(audios);
     this.subtitles = Collections.unmodifiableList(subtitles);
@@ -226,6 +254,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
         baseUri,
         tags,
         copyStreams(variants, GROUP_INDEX_VARIANT, streamKeys),
+        /* iframes */ Collections.emptyList(),
         // TODO: Allow stream keys to specify video renditions to be retained.
         /* videos= */ Collections.emptyList(),
         copyStreams(audios, GROUP_INDEX_AUDIO, streamKeys),
@@ -252,6 +281,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
         /* baseUri= */ "",
         /* tags= */ Collections.emptyList(),
         variant,
+        /* iframes= */ Collections.emptyList(),
         /* videos= */ Collections.emptyList(),
         /* audios= */ Collections.emptyList(),
         /* subtitles= */ Collections.emptyList(),
@@ -265,7 +295,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
 
   private static List<Uri> getMediaPlaylistUrls(
       List<Variant> variants,
-      List<IFrameVariant> iFrameVariants,
+      List<Variant> iFrameVariants,
       List<Rendition> videos,
       List<Rendition> audios,
       List<Rendition> subtitles,
@@ -277,7 +307,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
         mediaPlaylistUrls.add(uri);
       }
     }
-    for (IFrameVariant iFrameVariant : iFrameVariants) {
+    for (Variant iFrameVariant : iFrameVariants) {
       mediaPlaylistUrls.add(iFrameVariant.url);
     }
     addMediaPlaylistUrls(videos, mediaPlaylistUrls);

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylist.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylist.java
@@ -207,7 +207,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
     super(baseUri, tags, hasIndependentSegments);
     this.mediaPlaylistUrls =
         Collections.unmodifiableList(
-            getMediaPlaylistUrls(variants, videos, audios, subtitles, closedCaptions));
+            getMediaPlaylistUrls(variants, iFrameVariants, videos, audios, subtitles, closedCaptions));
     this.variants = Collections.unmodifiableList(variants);
     this.videos = Collections.unmodifiableList(videos);
     this.audios = Collections.unmodifiableList(audios);
@@ -265,6 +265,7 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
 
   private static List<Uri> getMediaPlaylistUrls(
       List<Variant> variants,
+      List<IFrameVariant> iFrameVariants,
       List<Rendition> videos,
       List<Rendition> audios,
       List<Rendition> subtitles,
@@ -275,6 +276,9 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
       if (!mediaPlaylistUrls.contains(uri)) {
         mediaPlaylistUrls.add(uri);
       }
+    }
+    for (IFrameVariant iFrameVariant : iFrameVariants) {
+      mediaPlaylistUrls.add(iFrameVariant.url);
     }
     addMediaPlaylistUrls(videos, mediaPlaylistUrls);
     addMediaPlaylistUrls(audios, mediaPlaylistUrls);

--- a/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylistParserTest.java
+++ b/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/playlist/HlsMasterPlaylistParserTest.java
@@ -24,6 +24,7 @@ import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.ParserException;
 import com.google.android.exoplayer2.metadata.Metadata;
+import com.google.android.exoplayer2.source.hls.HlsMediaSource;
 import com.google.android.exoplayer2.source.hls.HlsTrackMetadataEntry;
 import com.google.android.exoplayer2.util.MimeTypes;
 import java.io.ByteArrayInputStream;
@@ -193,6 +194,22 @@ public class HlsMasterPlaylistParserTest {
           + "\n"
           + "#EXT-X-MEDIA:TYPE=SUBTITLES,"
           + "GROUP-ID=\"sub1\",NAME=\"English\",URI=\"s1/en/prog_index.m3u8\"\n";
+
+  private static final String PLAYLIST_WITH_IFRAME_VARIANTS =
+      "#EXTM3U\n"
+          + "#EXT-X-VERSION:5\n"
+          + "#EXT-X-MEDIA:URI=\"AUDIO_English/index.m3u8\",TYPE=AUDIO,GROUP-ID=\"audio-aac\",LANGUAGE=\"en\",NAME=\"English\",AUTOSELECT=YES\n"
+          + "#EXT-X-MEDIA:URI=\"AUDIO_Spanish/index.m3u8\",TYPE=AUDIO,GROUP-ID=\"audio-aac\",LANGUAGE=\"es\",NAME=\"Spanish\",AUTOSELECT=YES\n"
+          + "#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID=\"cc1\",LANGUAGE=\"en\",NAME=\"English\",AUTOSELECT=YES,DEFAULT=YES,INSTREAM-ID=\"CC1\"\n"
+          + "#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=400000,RESOLUTION=480x320,CODECS=\"mp4a.40.2,avc1.640015\",AUDIO=\"audio-aac\",CLOSED-CAPTIONS=\"cc1\"\n"
+          + "400000/index.m3u8\n"
+          + "#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1000000,RESOLUTION=848x480,CODECS=\"mp4a.40.2,avc1.64001f\",AUDIO=\"audio-aac\",CLOSED-CAPTIONS=\"cc1\"\n"
+          + "1000000/index.m3u8\n"
+          + "#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=3220000,RESOLUTION=1280x720,CODECS=\"mp4a.40.2,avc1.64001f\",AUDIO=\"audio-aac\",CLOSED-CAPTIONS=\"cc1\"\n"
+          + "3220000/index.m3u8\n"
+          + "#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=8940000,RESOLUTION=1920x1080,CODECS=\"mp4a.40.2,avc1.640028\",AUDIO=\"audio-aac\",CLOSED-CAPTIONS=\"cc1\"\n"
+          + "8940000/index.m3u8\n"
+          + "#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=1313400,RESOLUTION=1920x1080,CODECS=\"avc1.640028\",URI=\"iframe_1313400/index.m3u8\"\n";
 
   @Test
   public void parseMasterPlaylist_withSimple_success() throws IOException {
@@ -379,6 +396,15 @@ public class HlsMasterPlaylistParserTest {
         .isEqualTo(createExtXMediaMetadata(/* groupId= */ "aud2", /* name= */ "English"));
     assertThat(playlist.audios.get(2).format.metadata)
         .isEqualTo(createExtXMediaMetadata(/* groupId= */ "aud3", /* name= */ "English"));
+  }
+
+  @Test
+  public void testIFrameVariant() throws IOException {
+    HlsMasterPlaylist playlist = parseMasterPlaylist(PLAYLIST_URI, PLAYLIST_WITH_IFRAME_VARIANTS);
+    assertThat(playlist.variants).hasSize(4);
+    assertThat(playlist.iFrameVariants).hasSize(1);
+    assertThat(playlist.iFrameVariants.get(0).format.bitrate).isEqualTo(1313400);
+    assertThat(playlist.iFrameVariants.get(0).format.roleFlags & C.ROLE_FLAG_TRICK_PLAY).isEqualTo(C.ROLE_FLAG_TRICK_PLAY);
   }
 
   private static Metadata createExtXStreamInfMetadata(HlsTrackMetadataEntry.VariantInfo... infos) {


### PR DESCRIPTION
This branch adds support for parsing HLS I-Frame only playlists and adding them as a selectable `Format` in an `TrackGroup`.

All existing unit test cases pass, the branch includes one test case for iFrame specifically.   I modified `AdaptiveTrackSelection` to not include these IDR only `Formats`, so they will not affect current ExoPlayer playback for existing master playlists that already contain iFrame only variants. The expectation is a subclass of same would do this intelligently based on desired playback speed.

I can provide (privately) sample broadcast and VOD streams that have IDR streams you can manually select to see the behavior.  The existing apple streams all parse and present their iFrame only tracks (bipbop), however playback of these is not very interesting ;-).

See my notes in the code in the individual commits for more thoughts on direction.

PS, our CLA is signed and in Google's hands for approval.
