### PR TITLE
Change mime type of AV1 from video/av01 to video/av1

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
@@ -37,7 +37,7 @@ public final class MimeTypes {
   public static final String VIDEO_H265 = BASE_TYPE_VIDEO + "/hevc";
   public static final String VIDEO_VP8 = BASE_TYPE_VIDEO + "/x-vnd.on2.vp8";
   public static final String VIDEO_VP9 = BASE_TYPE_VIDEO + "/x-vnd.on2.vp9";
-  public static final String VIDEO_AV1 = BASE_TYPE_VIDEO + "/av01";
+  public static final String VIDEO_AV1 = BASE_TYPE_VIDEO + "/av1";
   public static final String VIDEO_MP4V = BASE_TYPE_VIDEO + "/mp4v-es";
   public static final String VIDEO_MPEG = BASE_TYPE_VIDEO + "/mpeg";
   public static final String VIDEO_MPEG2 = BASE_TYPE_VIDEO + "/mpeg2";


### PR DESCRIPTION
The AV1 test vectors provided by Netflix can not be played
due to incorrect mime type. Fix this issue by changing mime type
from video/av01 to video/av1.
The test vectors link:
http://download.opencontent.netflix.com/?prefix=AV1/Chimera/