### PR TITLE
Checking directory exist before create

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/util/AtomicFile.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/AtomicFile.java
@@ -107,7 +107,7 @@ public final class AtomicFile {
       str = new AtomicFileOutputStream(baseName);
     } catch (FileNotFoundException e) {
       File parent = baseName.getParentFile();
-      if (parent == null || !parent.mkdirs()) {
+      if (parent == null || (!parent.exists() && !parent.mkdirs())) {
         throw new IOException("Couldn't create directory " + baseName, e);
       }
       try {


### PR DESCRIPTION
It should check if the parent directory exists before creating it. Otherwise, the directory creation fails and a wrong exception message is thrown.