### PR TITLE
Feature discard upstream HLS

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -451,6 +451,13 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     return chunkIterators;
   }
 
+  public int getPreferredQueueSize(long playbackPositionUs, List<? extends MediaChunk> queue) {
+    if (fatalError != null || trackSelection.length() < 2) {
+      return queue.size();
+    }
+    return trackSelection.evaluateQueueSize(playbackPositionUs, queue);
+  }
+
   // Private methods.
 
   /**

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
@@ -27,6 +27,7 @@ import com.google.android.exoplayer2.extractor.PositionHolder;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.metadata.id3.Id3Decoder;
 import com.google.android.exoplayer2.metadata.id3.PrivFrame;
+import com.google.android.exoplayer2.source.SampleQueue;
 import com.google.android.exoplayer2.source.chunk.MediaChunk;
 import com.google.android.exoplayer2.source.hls.playlist.HlsMediaPlaylist;
 import com.google.android.exoplayer2.upstream.DataSource;
@@ -222,6 +223,12 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
   private volatile boolean loadCanceled;
   private boolean loadCompleted;
 
+  /**
+   * Index of first sample written to the SampleQueue for the primary track from
+   * this segment.
+   */
+  private int firstSampleIndex = C.INDEX_UNSET;
+
   private HlsMediaChunk(
       HlsExtractorFactory extractorFactory,
       DataSource mediaDataSource,
@@ -291,6 +298,15 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
     return loadCompleted;
   }
 
+  /**
+   * Return the index of the first sample from the primary sample stream for this media chunk
+   *
+   * @return sample index {@link SampleQueue#getWriteIndex()}
+   */
+  public int getFirstPrimarySampleIndex() {
+    return firstSampleIndex;
+  }
+
   // Loadable implementation
 
   @Override
@@ -308,6 +324,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
       initDataLoadRequired = false;
       output.init(uid, shouldSpliceIn, /* reusingExtractor= */ true);
     }
+    firstSampleIndex = output.getPrimaryTrackWritePosition();
     maybeLoadInitData();
     if (!loadCanceled) {
       if (!hasGapTag) {

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
@@ -300,7 +300,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
   }
 
   /**
-   * Return the index of the first sample from the primary sample stream for this media chunk
+   * Return the indexes of the first samples from each sample queue for this media chunk
    *
    * @return sample index {@link SampleQueue#getWriteIndex()}
    */
@@ -308,6 +308,13 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
     return firstSampleIndexes;
   }
 
+  /**
+   * Set the index of the first sample written to a sample queue from this media chunk,
+   * indexed by the caller's stream index for the sample queue
+   *
+   * @param streamIndex - caller's index for the {@link SampleQueue}
+   * @param firstSampleIndex - index value to store
+   */
   void setFirstSampleIndex(int streamIndex, int firstSampleIndex) {
     firstSampleIndexes = Arrays.copyOf(firstSampleIndexes, streamIndex + 1);
     firstSampleIndexes[streamIndex] = firstSampleIndex;
@@ -330,7 +337,6 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
       initDataLoadRequired = false;
       output.init(uid, shouldSpliceIn, /* reusingExtractor= */ true);
     }
-    firstSampleIndexes = output.getTrackWritePositions();
     maybeLoadInitData();
     if (!loadCanceled) {
       if (!hasGapTag) {

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
@@ -40,6 +40,7 @@ import com.google.android.exoplayer2.util.Util;
 import java.io.EOFException;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
@@ -224,10 +225,10 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
   private boolean loadCompleted;
 
   /**
-   * Index of first sample written to the SampleQueue for the primary track from
-   * this segment.
+   * Index of first sample written for each SampleQueue created from the extraction of this
+   * media chunk
    */
-  private int firstSampleIndex = C.INDEX_UNSET;
+  private int [] firstSampleIndexes = new int[0];
 
   private HlsMediaChunk(
       HlsExtractorFactory extractorFactory,
@@ -303,8 +304,13 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
    *
    * @return sample index {@link SampleQueue#getWriteIndex()}
    */
-  public int getFirstPrimarySampleIndex() {
-    return firstSampleIndex;
+  int [] getFirstSampleIndexes() {
+    return firstSampleIndexes;
+  }
+
+  void setFirstSampleIndex(int streamIndex, int firstSampleIndex) {
+    firstSampleIndexes = Arrays.copyOf(firstSampleIndexes, streamIndex + 1);
+    firstSampleIndexes[streamIndex] = firstSampleIndex;
   }
 
   // Loadable implementation
@@ -324,7 +330,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
       initDataLoadRequired = false;
       output.init(uid, shouldSpliceIn, /* reusingExtractor= */ true);
     }
-    firstSampleIndex = output.getPrimaryTrackWritePosition();
+    firstSampleIndexes = output.getTrackWritePositions();
     maybeLoadInitData();
     if (!loadCanceled) {
       if (!hasGapTag) {

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsSampleStreamWrapper.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsSampleStreamWrapper.java
@@ -1049,23 +1049,6 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
     }
   }
 
-  /**
-   * Get the SampleQueue write position indexes.  Used to associate group of
-   * samples with a MediaChunk.
-   *
-   * @return array of write positions {@link SampleQueue#getWriteIndex()}, by sample queue index
-   */
-  int [] getTrackWritePositions() {
-    int [] writePositions;
-
-    writePositions = new int[sampleQueues.length];
-    for (int i=0; i < sampleQueues.length; i++) {
-      writePositions[i] = sampleQueues[i].getWriteIndex();
-    }
-
-    return writePositions;
-  }
-
   // Internal methods.
 
   private HlsMediaChunk findChunkMatching(int chunkUid) {


### PR DESCRIPTION
Pull request is not ready to merge.  The HLS libraries `HlsSampleStreamWrapper` needs a way to manage the queued samples matching up with the `HlsMediaChunk` that will be discarded.  See notes in the diffs below.