### PR TITLE
Update com.squareup.okhttp3 to 4.1.0 and update deprecated

### DIFF
--- a/extensions/okhttp/build.gradle
+++ b/extensions/okhttp/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation project(modulePrefix + 'library-core')
     implementation 'androidx.annotation:annotation:1.1.0'
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
-    api 'com.squareup.okhttp3:okhttp:3.12.1'
+    api 'com.squareup.okhttp3:okhttp:4.1.0'
 }
 
 ext {

--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
@@ -351,10 +351,10 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
     }
     RequestBody requestBody = null;
     if (dataSpec.httpBody != null) {
-      requestBody = RequestBody.create(null, dataSpec.httpBody);
+      requestBody = RequestBody.create(dataSpec.httpBody, null);
     } else if (dataSpec.httpMethod == DataSpec.HTTP_METHOD_POST) {
       // OkHttp requires a non-null body for POST requests.
-      requestBody = RequestBody.create(null, Util.EMPTY_BYTE_ARRAY);
+      requestBody = RequestBody.create(Util.EMPTY_BYTE_ARRAY, null);
     }
     builder.method(dataSpec.getHttpMethodString(), requestBody);
     return builder.build();


### PR DESCRIPTION
There is others out of date dependencies..

**Dependencies that need update:**

 - androidx.test:core [1.1.0 -> 1.2.0]
 - androidx.test:runner [1.1.0 -> 1.2.0]
 - androidx.test.ext:junit [1.1.0 -> 1.1.1]
 - androidx.work:work-runtime [2.1.0 -> 2.2.0]
 - com.android.tools.lint:lint-gradle [26.4.2 -> 26.5.0]
 - com.firebase:firebase-jobdispatcher [0.8.5 -> 0.8.6]
 - com.google.android.gms:play-services-ads-identifier [16.0.0 -> 17.0.0]
 - com.google.auto.value:auto-value [1.6 -> 1.6.6]
 - com.google.auto.value:auto-value-annotations [1.6 -> 1.6.6]
 - com.google.truth:truth [0.44 -> 1.0]
 - com.linkedin.dexmaker:dexmaker [2.21.0 -> 2.25.0]
 - com.linkedin.dexmaker:dexmaker-mockito [2.21.0 -> 2.25.0]
 - net.butterflytv.utils:rtmp-client [3.0.1 -> 3.1.0]
 - org.checkerframework:checker-compat-qual [2.5.0 -> 2.5.5]
 - org.checkerframework:checker-qual [2.5.0 -> 2.10.0]
 - org.chromium.net:cronet-embedded [75.3770.101 -> 76.3809.111]
 - org.mockito:mockito-core [2.25.0 -> 3.0.0]

**net.butterflytv.utils:rtmp-client** has a open pr https://github.com/google/ExoPlayer/pull/6303