### PR TITLE
Stuck buffering while tunneling.

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -34,6 +34,7 @@ import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.FormatHolder;
+import com.google.android.exoplayer2.Renderer;
 import com.google.android.exoplayer2.decoder.CryptoInfo;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
 import com.google.android.exoplayer2.decoder.DecoderInputBuffer;
@@ -1144,6 +1145,19 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     return outputIndex >= 0;
   }
 
+  /**
+   * Check if the renderer has one or more output frames queued to render.  For non-tunneled
+   * mode MediaCodecRenderer's this is true if the codec has returned a frame ready to render
+   * (that is {@see #hasOutputBuffer() is true}.
+   *
+   * This factors into the ready {@link Renderer#isReady()} decision
+   *
+   * @return
+   */
+  protected boolean hasOutputReady() {
+    return hasOutputBuffer();
+  }
+
   private void resetInputBuffer() {
     inputIndex = C.INDEX_UNSET;
     buffer.data = null;
@@ -1528,7 +1542,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     return inputFormat != null
         && !waitingForKeys
         && (isSourceReady()
-            || hasOutputBuffer()
+            || hasOutputReady()
             || (codecHotswapDeadlineMs != C.TIME_UNSET
                 && SystemClock.elapsedRealtime() < codecHotswapDeadlineMs));
   }

--- a/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -400,6 +400,18 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
     }
   }
 
+  /**
+   * Override, to handle tunneling.  In the tunneled case we must assume there is
+   * output ready to render whenever we have queued any sample buffers to the codec that
+   * it has not reported as rendered.
+   *
+   * @return
+   */
+  @Override
+  protected boolean hasOutputReady() {
+    return tunneling && buffersInCodecCount > 0 || super.hasOutputReady();
+  }
+
   @Override
   protected void onStarted() {
     super.onStarted();


### PR DESCRIPTION
This pull fixes the issue where the video render does not correctly report ready in tunneled mode.  The specific bug is #6366 

I can remove the manifest and network security changes (these allow local http testing on my workstation).  I've provided a stream that reproduces this on streaming devices with Broadcom SOC chips. 

The issue is largely timing related, streams that have very low video frame rate compared to the audio will cause the issue to manifest strait away.
