### PR TITLE
Issue: #6501 Wrong segmentNumShift calculated in copyWithNewRepresentation

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
@@ -702,12 +702,14 @@ public class DefaultDashChunkSource implements DashChunkSource {
         // There's a gap between the old index and the new one which means we've slipped behind the
         // live window and can't proceed.
         throw new BehindLiveWindowException();
-      } else if (oldIndexStartTimeUs >= newIndexStartTimeUs) {
+      } else if (newIndexStartTimeUs < oldIndexStartTimeUs) {
         // The new index overlaps with (but does not have a start position contained within) the old
         // index. This can only happen if extra segments have been added to the start of the index.
-        // Continue process the next segment as is.
+        newSegmentNumShift -=
+            newIndex.getSegmentNum(oldIndexStartTimeUs, newPeriodDurationUs)
+                - oldIndexFirstSegmentNum;
       } else {
-        // The new index overlaps with the old one.
+        // The new index overlaps with (and has a start position contained within) the old index.
         newSegmentNumShift +=
             oldIndex.getSegmentNum(newIndexStartTimeUs, newPeriodDurationUs)
                 - newIndexFirstSegmentNum;

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
@@ -686,6 +686,8 @@ public class DefaultDashChunkSource implements DashChunkSource {
             newPeriodDurationUs, newRepresentation, extractorWrapper, segmentNumShift, newIndex);
       }
 
+      long oldIndexFirstSegmentNum = oldIndex.getFirstSegmentNum();
+      long oldIndexStartTimeUs = oldIndex.getTimeUs(oldIndexFirstSegmentNum);
       long oldIndexLastSegmentNum = oldIndex.getFirstSegmentNum() + oldIndexSegmentCount - 1;
       long oldIndexEndTimeUs =
           oldIndex.getTimeUs(oldIndexLastSegmentNum)
@@ -700,8 +702,10 @@ public class DefaultDashChunkSource implements DashChunkSource {
         // There's a gap between the old index and the new one which means we've slipped behind the
         // live window and can't proceed.
         throw new BehindLiveWindowException();
-      } else if (oldIndex.getFirstSegmentNum() >= newIndexFirstSegmentNum) {
-        // The new index contains the old one, continue process the next segment
+      } else if (oldIndexStartTimeUs >= newIndexStartTimeUs) {
+        // The new index overlaps with (but does not have a start position contained within) the old
+        // index. This can only happen if extra segments have been added to the start of the index.
+        // Continue process the next segment as is.
       } else {
         // The new index overlaps with the old one.
         newSegmentNumShift +=

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
@@ -700,6 +700,8 @@ public class DefaultDashChunkSource implements DashChunkSource {
         // There's a gap between the old index and the new one which means we've slipped behind the
         // live window and can't proceed.
         throw new BehindLiveWindowException();
+      } else if (oldIndex.getFirstSegmentNum() >= newIndexFirstSegmentNum) {
+        // The new index contains the old one, continue process the next segment
       } else {
         // The new index overlaps with the old one.
         newSegmentNumShift +=


### PR DESCRIPTION
In DefaultDashChunkSource.copyWithNewRepresentation, it will handle the logic that
new MPD manifest file is updated and calculate a newSegmentNumShift for furthermore
segNum index calculation in getSegmentUrl, when a shorter window MPD updated and then
back to a longer window MPD, copyWithNewRepresentation will go into the overlap case
but the new index actually contains the old index.
Fix: https://github.com/google/ExoPlayer/issues/6501