### PR TITLE
Name logged fields in EventLogger

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/util/EventLogger.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/EventLogger.java
@@ -489,8 +489,8 @@ public class EventLogger implements AnalyticsListener {
         windowPeriodString += ", ad=" + eventTime.mediaPeriodId.adIndexInAdGroup;
       }
     }
-    return getTimeString(eventTime.realtimeMs - startTimeMs)
-        + ", "
+    return "eventDuration= " + getTimeString(eventTime.realtimeMs - startTimeMs)
+        + ", playbackPosition="
         + getTimeString(eventTime.currentPlaybackPositionMs)
         + ", "
         + windowPeriodString;


### PR DESCRIPTION
Low-hanging fruit of the `EventLogger` class.
Without specifying what these numeric values are, it can be a bit cryptic to read:
```
I/ExoPlayerEngine: decoderDisabled [41.34, 0.00, window=0, period=0, audio]
```