### PR TITLE
Fix incorrect anamorphic handling in Leanback extension.

### DIFF
--- a/extensions/leanback/src/main/java/com/google/android/exoplayer2/ext/leanback/LeanbackPlayerAdapter.java
+++ b/extensions/leanback/src/main/java/com/google/android/exoplayer2/ext/leanback/LeanbackPlayerAdapter.java
@@ -308,7 +308,8 @@ public final class LeanbackPlayerAdapter extends PlayerAdapter implements Runnab
     @Override
     public void onVideoSizeChanged(
         int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
-      getCallback().onVideoSizeChanged(LeanbackPlayerAdapter.this, width, height);
+      int playbackwidth = (int)((float)width * pixelWidthHeightRatio);
+      getCallback().onVideoSizeChanged(LeanbackPlayerAdapter.this, playbackwidth, height);
     }
 
     @Override


### PR DESCRIPTION
Anamorphic videos were being displayed with incorrect aspect ratio as pixel shape
was not taken into account. This fix adjusts the video size based on pixel shape.

The problem can be seen and reproduced using the sample at https://github.com/android/tv-samples/tree/master/Leanback , adjusting the URLS to point to an anamorphic video. I used a 16x9 video that had 720x480 resolution (standard DVD resolution).