### PR TITLE
Fix for ANR on release (at least one case)

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -563,7 +563,7 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
     clearReportedVideoSize();
     clearRenderedFirstFrame();
     frameReleaseTimeHelper.disable();
-    if (tunnelingOnFrameRenderedListener != null && getCodec() != null) {
+    if (tunnelingOnFrameRenderedListener != null) {
       tunnelingOnFrameRenderedListener.destroyHandler(getCodec());
     }
     tunnelingOnFrameRenderedListener = null;


### PR DESCRIPTION
This fixes an ANR we are seeing on Player.release().  The problem is the `MediaCodec` listener callbacks hold a lock that blocks any other message to `MediaCodec`'s handler.  This can cause a call into `MediaCodec` to not complete

The bug number is: https://github.com/google/ExoPlayer/issues/4352