### PR TITLE
Avoid ArithmeticException when sampleRate equals zero

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -1024,10 +1024,12 @@ public final class Util {
    * @return The scaled timestamp.
    */
   public static long scaleLargeTimestamp(long timestamp, long multiplier, long divisor) {
-    if (divisor >= multiplier && (divisor % multiplier) == 0) {
+    if (multiplier == 0 && divisor == 0) {
+      return timestamp;
+    } else if (divisor >= multiplier && multiplier != 0 && (divisor % multiplier) == 0) {
       long divisionFactor = divisor / multiplier;
       return timestamp / divisionFactor;
-    } else if (divisor < multiplier && (multiplier % divisor) == 0) {
+    } else if (divisor < multiplier && divisor != 0 && (multiplier % divisor) == 0) {
       long multiplicationFactor = multiplier / divisor;
       return timestamp * multiplicationFactor;
     } else {


### PR DESCRIPTION
Hi guys, 

the pull request fixes Arithmetical exception for missed sampleRate. In my investigation, some specific tracks, and more specifically their format doesn't contain sampleRate. The sampleRate field is set only once during parsing the Sample Description Table (STSD).  And in my case, it had 0 value.

Stacktrace of thrown Exception.
```
java.lang.ArithmeticException: divide by zero
        at com.google.android.exoplayer2.util.Util.scaleLargeTimestamp(Util.java:968)
        at com.google.android.exoplayer2.extractor.mp4.AtomParsers.parseStbl(AtomParsers.java:374)
        at com.google.android.exoplayer2.extractor.mp4.Mp4Extractor.getTrackSampleTables(Mp4Extractor.java:472)
        at com.google.android.exoplayer2.extractor.mp4.Mp4Extractor.processMoovAtom(Mp4Extractor.java:407)
        at com.google.android.exoplayer2.extractor.mp4.Mp4Extractor.processAtomEnded(Mp4Extractor.java:369)
        at com.google.android.exoplayer2.extractor.mp4.Mp4Extractor.readAtomPayload(Mp4Extractor.java:360)
        at com.google.android.exoplayer2.extractor.mp4.Mp4Extractor.read(Mp4Extractor.java:188)
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:971)
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:381)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:764)
```

Actually, I don't know it is the correct fix or not. Perhaps sampleRate hasn't to be as 0 value and this fix breaks logic. What do you think about it? 
