### PR TITLE
Detect Dolby Vision profile 7

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/video/DolbyVisionConfig.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/DolbyVisionConfig.java
@@ -36,7 +36,7 @@ public final class DolbyVisionConfig {
     int dvProfile = (profileData >> 1);
     int dvLevel = ((profileData & 0x1) << 5) | ((data.readUnsignedByte() >> 3) & 0x1F);
     String codecsPrefix;
-    if (dvProfile == 4 || dvProfile == 5) {
+    if (dvProfile == 4 || dvProfile == 5 || dvProfile == 7) {
       codecsPrefix = "dvhe";
     } else if (dvProfile == 8) {
       codecsPrefix = "hev1";


### PR DESCRIPTION
In official documentation dvProfile 7 uses dvhe as the codec type.

