### PR TITLE
Accept setting null override to setSelectionOverride

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelector.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/trackselection/DefaultTrackSelector.java
@@ -646,7 +646,7 @@ public class DefaultTrackSelector extends MappingTrackSelector {
      * @return This builder.
      */
     public final ParametersBuilder setSelectionOverride(
-        int rendererIndex, TrackGroupArray groups, SelectionOverride override) {
+        int rendererIndex, TrackGroupArray groups, @Nullable SelectionOverride override) {
       Map<TrackGroupArray, SelectionOverride> overrides = selectionOverrides.get(rendererIndex);
       if (overrides == null) {
         overrides = new HashMap<>();


### PR DESCRIPTION
In-code documentation say this is allowed, and is the expected way to
disable renderer.