### PR TITLE
Requeue MSG_DOWNLOAD_UPDATE when received before the service is started.

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadManager.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadManager.java
@@ -484,6 +484,13 @@ public final class DownloadManager {
     }
   }
 
+  void resendDownloadUpdate(Download download, boolean isRemove) {
+    Assertions.checkNotNull(download);
+    DownloadUpdate update =
+            new DownloadUpdate(download, isRemove, Collections.singletonList(download));
+    mainHandler.obtainMessage(MSG_DOWNLOAD_UPDATE, update).sendToTarget();
+  }
+
   private void onRequirementsStateChanged(
       RequirementsWatcher requirementsWatcher,
       @Requirements.RequirementFlags int notMetRequirements) {


### PR DESCRIPTION
This fixes the case where downloads get stuck when network requirements are met after previously not being met. It resends the update messages once the service is attached to the helper. Also added logging when this occurs:
```
2020-01-05 11:55:45.391 3204-3204/com.google.android.exoplayer2.demo D/DownloadService: onDownloadChanged with null service. Queuing to resend message later.
2020-01-05 11:55:45.415 3204-3204/com.google.android.exoplayer2.demo D/DownloadService: 1 messages to resend.
```

Fixes https://github.com/google/ExoPlayer/issues/6798