### PR TITLE
create release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,22 @@
+name-template: Release v$NEXT_MINOR_VERSION 🌈
+tag-template: v$NEXT_MINOR_VERSION
+categories:
+  - title: 🚀 Features
+    label: feature
+  - title: 🐛 Bug Fixes
+    label: fix
+  - title: 🧰 Maintenance
+    label: chore
+  - title: 🕮 Documentation
+    label: docs
+  - title: ⚙ Dependencies and Libraries
+    label: dependencies
+change-template: '- $TITLE (#$NUMBER) - @$AUTHOR'
+template: |
+  ## Changes
+  $CHANGES
+  
+  ## Contributors
+  
+  Thanks a lot to our contributors for making this release possible:
+  $CONTRIBUTORS


### PR DESCRIPTION
Fixes #6829 

* **What changes have you introduced?**
Added `release-drafter.yml` file inside the `.github` folder  which is very useful to keep track of a project. As pull requests are merged, a draft release is kept up-to-date listing the changes, ready to publish when you’re ready.

Right Configuration can categorises the changes into headings, and automatically suggests the next version number as well.