### PR TITLE
Use previous TtmlRegion when no origin and extent are present on current TtmlRegion

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlDecoder.java
@@ -91,6 +91,7 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
       new CellResolution(/* columns= */ 32, /* rows= */ 15);
 
   private final XmlPullParserFactory xmlParserFactory;
+  private TtmlRegion previousTtmlRegion = null;
 
   public TtmlDecoder() {
     super("TtmlDecoder");
@@ -352,12 +353,19 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
       }
     } else {
       Log.w(TAG, "Ignoring region without an origin");
-      return null;
+      // return null;
       // TODO: Should default to top left as below in this case, but need to fix
       // https://github.com/google/ExoPlayer/issues/2953 first.
       // Origin is omitted. Default to top left.
       // position = 0;
       // line = 0;
+      if (previousTtmlRegion != null) {
+        position = previousTtmlRegion.position;
+        line = previousTtmlRegion.line;
+      } else {
+        position = 0;
+        line = 0;
+      }
     }
 
     float width;
@@ -395,12 +403,19 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
       }
     } else {
       Log.w(TAG, "Ignoring region without an extent");
-      return null;
+      // return null;
       // TODO: Should default to extent of parent as below in this case, but need to fix
       // https://github.com/google/ExoPlayer/issues/2953 first.
       // Extent is omitted. Default to extent of parent.
       // width = 1;
       // height = 1;
+      if (previousTtmlRegion != null) {
+        width = previousTtmlRegion.width;
+        height = previousTtmlRegion.height;
+      } else {
+        width = 1;
+        height = 1;
+      }
     }
 
     @Cue.AnchorType int lineAnchor = Cue.ANCHOR_TYPE_START;
@@ -423,6 +438,17 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
     }
 
     float regionTextHeight = 1.0f / cellResolution.rows;
+    previousTtmlRegion = new TtmlRegion(
+        regionId,
+        position,
+        line,
+        /* lineType= */ Cue.LINE_TYPE_FRACTION,
+        lineAnchor,
+        width,
+        height,
+        /* textSizeType= */ Cue.TEXT_SIZE_TYPE_FRACTIONAL_IGNORE_PADDING,
+        /* textSize= */ regionTextHeight
+    );
     return new TtmlRegion(
         regionId,
         position,

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlDecoder.java
@@ -353,7 +353,6 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
       }
     } else {
       Log.w(TAG, "Ignoring region without an origin");
-      // return null;
       // TODO: Should default to top left as below in this case, but need to fix
       // https://github.com/google/ExoPlayer/issues/2953 first.
       // Origin is omitted. Default to top left.
@@ -363,8 +362,7 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
         position = previousTtmlRegion.position;
         line = previousTtmlRegion.line;
       } else {
-        position = 0;
-        line = 0;
+        return null;
       }
     }
 
@@ -403,7 +401,6 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
       }
     } else {
       Log.w(TAG, "Ignoring region without an extent");
-      // return null;
       // TODO: Should default to extent of parent as below in this case, but need to fix
       // https://github.com/google/ExoPlayer/issues/2953 first.
       // Extent is omitted. Default to extent of parent.
@@ -413,8 +410,7 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
         width = previousTtmlRegion.width;
         height = previousTtmlRegion.height;
       } else {
-        width = 1;
-        height = 1;
+        return null;
       }
     }
 


### PR DESCRIPTION
I have some DASH streams containing ttml subtitles with image bitmap where it's sometime flickering one the screen:
The subtitle appears shortly for a very short time, then disappear, and then appear again before being replaced by the next subtitle.
Each time I see this behaviour, I see the following logs into logcat:
`Ignoring region without an extent`
`Ignoring region without an origin`

I had a look into the code and saw that it's related to this opened issue:
https://github.com/google/ExoPlayer/issues/2953

I tried to uncomment the "TODO" in order to default line/position/width/height as already present in dev-v2 but it is leading to image subtitles being stretched on the whole screen.

I tried to reuse previously decoded TtmlRegion origin and extent and I get the image subtitle rendered on screen as expected.

Not sure this is the right way to fix the issue I'm experiencing.