### PR TITLE
Add responseBody field to InvalidResponseCodeException

### DIFF
--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
@@ -230,10 +230,19 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
 
     // Check for a valid response code.
     if (!response.isSuccessful()) {
+      byte[] errorResponseBody;
+      try {
+        errorResponseBody = Util.toByteArray(responseByteStream);
+      } catch (IOException e) {
+        throw new HttpDataSourceException(
+            "Error reading response body of unsuccessful response " + dataSpec.uri,
+            e, dataSpec, HttpDataSourceException.TYPE_OPEN);
+      }
       Map<String, List<String>> headers = response.headers().toMultimap();
       closeConnectionQuietly();
       InvalidResponseCodeException exception =
-          new InvalidResponseCodeException(responseCode, response.message(), headers, dataSpec);
+          new InvalidResponseCodeException(responseCode, response.message(), headers, dataSpec,
+              errorResponseBody);
       if (responseCode == 416) {
         exception.initCause(new DataSourceException(DataSourceException.POSITION_OUT_OF_RANGE));
       }

--- a/library/common/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java
@@ -315,10 +315,10 @@ public interface HttpDataSource extends DataSource {
     @Deprecated
     public InvalidResponseCodeException(
         int responseCode, Map<String, List<String>> headerFields, DataSpec dataSpec) {
-      this(responseCode, /* responseMessage= */ null, headerFields, dataSpec);
+      this(responseCode, /* responseMessage= */ null, headerFields, dataSpec, null);
     }
 
-    /** @deprecated Use {@link #InvalidResponseCodeException(int, String, Map, DataSpec byte[])}. */
+    /** @deprecated Use {@link #InvalidResponseCodeException(int, String, Map, DataSpec, byte[])}. */
     @Deprecated
     public InvalidResponseCodeException(
         int responseCode,

--- a/library/common/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/upstream/HttpDataSource.java
@@ -306,6 +306,11 @@ public interface HttpDataSource extends DataSource {
      */
     public final Map<String, List<String>> headerFields;
 
+    /**
+     * The response body, if one was provided.
+     */
+    @Nullable public final byte[] responseBody;
+
     /** @deprecated Use {@link #InvalidResponseCodeException(int, String, Map, DataSpec)}. */
     @Deprecated
     public InvalidResponseCodeException(
@@ -313,15 +318,27 @@ public interface HttpDataSource extends DataSource {
       this(responseCode, /* responseMessage= */ null, headerFields, dataSpec);
     }
 
+    /** @deprecated Use {@link #InvalidResponseCodeException(int, String, Map, DataSpec byte[])}. */
+    @Deprecated
     public InvalidResponseCodeException(
         int responseCode,
         @Nullable String responseMessage,
         Map<String, List<String>> headerFields,
         DataSpec dataSpec) {
+      this(responseCode, responseMessage, headerFields, dataSpec, /* responseBody= */ null);
+    }
+
+    public InvalidResponseCodeException(
+        int responseCode,
+        @Nullable String responseMessage,
+        Map<String, List<String>> headerFields,
+        DataSpec dataSpec,
+        @Nullable byte[] responseBody) {
       super("Response code: " + responseCode, dataSpec, TYPE_OPEN);
       this.responseCode = responseCode;
       this.responseMessage = responseMessage;
       this.headerFields = headerFields;
+      this.responseBody = responseBody;
     }
 
   }


### PR DESCRIPTION
Issue #6853

Previously the body of an HTTP response was not included in an
InvalidResponseCodeException. This change adds a field to store
the response body, and updates DefaultHttpDataSource to populate
this value.