### PR TITLE
use swresample instead of avresample

### DIFF
--- a/extensions/ffmpeg/src/main/jni/ffmpeg_jni.cc
+++ b/extensions/ffmpeg/src/main/jni/ffmpeg_jni.cc
@@ -26,7 +26,7 @@ extern "C" {
 #include <stdint.h>
 #endif
 #include <libavcodec/avcodec.h>
-#include <libavresample/avresample.h>
+#include <libswresample/swresample.h>
 #include <libavutil/channel_layout.h>
 #include <libavutil/error.h>
 #include <libavutil/opt.h>
@@ -289,11 +289,11 @@ int decodePacket(AVCodecContext *context, AVPacket *packet,
     int sampleCount = frame->nb_samples;
     int dataSize = av_samples_get_buffer_size(NULL, channelCount, sampleCount,
                                               sampleFormat, 1);
-    AVAudioResampleContext *resampleContext;
+    SwrContext *resampleContext;
     if (context->opaque) {
-      resampleContext = (AVAudioResampleContext *) context->opaque;
+      resampleContext = (SwrContext *) context->opaque;
     } else {
-      resampleContext = avresample_alloc_context();
+      resampleContext = swr_alloc();
       av_opt_set_int(resampleContext, "in_channel_layout",  channelLayout, 0);
       av_opt_set_int(resampleContext, "out_channel_layout", channelLayout, 0);
       av_opt_set_int(resampleContext, "in_sample_rate", sampleRate, 0);
@@ -302,7 +302,7 @@ int decodePacket(AVCodecContext *context, AVPacket *packet,
       // The output format is always the requested format.
       av_opt_set_int(resampleContext, "out_sample_fmt",
           context->request_sample_fmt, 0);
-      result = avresample_open(resampleContext);
+      result = swr_init(resampleContext);
       if (result < 0) {
         logError("avresample_open", result);
         av_frame_free(&frame);
@@ -312,7 +312,7 @@ int decodePacket(AVCodecContext *context, AVPacket *packet,
     }
     int inSampleSize = av_get_bytes_per_sample(sampleFormat);
     int outSampleSize = av_get_bytes_per_sample(context->request_sample_fmt);
-    int outSamples = avresample_get_out_samples(resampleContext, sampleCount);
+    int outSamples = swr_get_out_samples(resampleContext, sampleCount);
     int bufferOutSize = outSampleSize * channelCount * outSamples;
     if (outSize + bufferOutSize > outputSize) {
       LOGE("Output buffer size (%d) too small for output data (%d).",
@@ -320,15 +320,15 @@ int decodePacket(AVCodecContext *context, AVPacket *packet,
       av_frame_free(&frame);
       return -1;
     }
-    result = avresample_convert(resampleContext, &outputBuffer, bufferOutSize,
-                                outSamples, frame->data, frame->linesize[0],
-                                sampleCount);
+    result = swr_convert(resampleContext,
+                                &outputBuffer, bufferOutSize,
+                                (const uint8_t **)frame->data, frame->nb_samples);
     av_frame_free(&frame);
     if (result < 0) {
       logError("avresample_convert", result);
       return result;
     }
-    int available = avresample_available(resampleContext);
+    int available = swr_get_out_samples(resampleContext, 0);
     if (available != 0) {
       LOGE("Expected no samples remaining after resampling, but found %d.",
            available);
@@ -351,10 +351,10 @@ void releaseContext(AVCodecContext *context) {
   if (!context) {
     return;
   }
-  AVAudioResampleContext *resampleContext;
-  if ((resampleContext = (AVAudioResampleContext *) context->opaque)) {
-    avresample_free(&resampleContext);
-    context->opaque = NULL;
+  SwrContext *swrContext;
+  if ((swrContext = (SwrContext *) context->opaque)) {
+      swr_free(&swrContext);
+      context->opaque = NULL;
   }
   avcodec_free_context(&context);
 }


### PR DESCRIPTION
Hello, ExoPlayer developers. I found that avresample module of FFmpeg has deprecated. Therefore, this commit is using swresample instead of avresample, and we could reduce the library size of avresample.