### PR TITLE
Parse TFRF for continuous SmoothStreaming segments refresh

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/FragmentedMp4Extractor.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/FragmentedMp4Extractor.java
@@ -65,6 +65,10 @@ public class FragmentedMp4Extractor implements Extractor {
   public static final ExtractorsFactory FACTORY =
       () -> new Extractor[] {new FragmentedMp4Extractor()};
 
+  public interface SsAtomCallback {
+    void onTfrfAtom(long startTime, long duration);
+  }
+
   /**
    * Flags controlling the behavior of the extractor. Possible flag values are {@link
    * #FLAG_WORKAROUND_EVERY_VIDEO_FRAME_IS_SYNC_FRAME}, {@link #FLAG_WORKAROUND_IGNORE_TFDT_BOX},
@@ -115,6 +119,8 @@ public class FragmentedMp4Extractor implements Extractor {
       new byte[] {-94, 57, 79, 82, 90, -101, 79, 20, -94, 68, 108, 66, 124, 100, -115, -12};
   private static final Format EMSG_FORMAT =
       Format.createSampleFormat(null, MimeTypes.APPLICATION_EMSG);
+  private static final byte[] TFRF_UUID =
+      new byte[] { -44, -128, 126, -14, -54, 57, 70, -107, -114, 84, 38, -53, -98, 70, -89, -97 };
 
   // Parser states.
   private static final int STATE_READING_ATOM_HEADER = 0;
@@ -150,6 +156,8 @@ public class FragmentedMp4Extractor implements Extractor {
   private final ArrayDeque<ContainerAtom> containerAtoms;
   private final ArrayDeque<MetadataSampleInfo> pendingMetadataSampleInfos;
   @Nullable private final TrackOutput additionalEmsgTrackOutput;
+
+  private SsAtomCallback ssAtomCallback;
 
   private int parserState;
   private int atomType;
@@ -265,6 +273,10 @@ public class FragmentedMp4Extractor implements Extractor {
     pendingSeekTimeUs = C.TIME_UNSET;
     segmentIndexEarliestPresentationTimeUs = C.TIME_UNSET;
     enterReadingAtomHeaderState();
+  }
+
+  public void setSsAtomCallback(SsAtomCallback cb) {
+    ssAtomCallback = cb;
   }
 
   @Override
@@ -685,7 +697,7 @@ public class FragmentedMp4Extractor implements Extractor {
     return version == 0 ? mehd.readUnsignedInt() : mehd.readUnsignedLongToLong();
   }
 
-  private static void parseMoof(ContainerAtom moof, SparseArray<TrackBundle> trackBundleArray,
+  private void parseMoof(ContainerAtom moof, SparseArray<TrackBundle> trackBundleArray,
       @Flags int flags, byte[] extendedTypeScratch) throws ParserException {
     int moofContainerChildrenSize = moof.containerChildren.size();
     for (int i = 0; i < moofContainerChildrenSize; i++) {
@@ -700,7 +712,7 @@ public class FragmentedMp4Extractor implements Extractor {
   /**
    * Parses a traf atom (defined in 14496-12).
    */
-  private static void parseTraf(ContainerAtom traf, SparseArray<TrackBundle> trackBundleArray,
+  private void parseTraf(ContainerAtom traf, SparseArray<TrackBundle> trackBundleArray,
       @Flags int flags, byte[] extendedTypeScratch) throws ParserException {
     LeafAtom tfhd = traf.getLeafAtomOfType(Atom.TYPE_tfhd);
     @Nullable TrackBundle trackBundle = parseTfhd(tfhd.data, trackBundleArray);
@@ -1004,20 +1016,41 @@ public class FragmentedMp4Extractor implements Extractor {
     return trackRunEnd;
   }
 
-  private static void parseUuid(ParsableByteArray uuid, TrackFragment out,
+  private void parseUuid(ParsableByteArray uuid, TrackFragment out,
       byte[] extendedTypeScratch) throws ParserException {
     uuid.setPosition(Atom.HEADER_SIZE);
     uuid.readBytes(extendedTypeScratch, 0, 16);
 
-    // Currently this parser only supports Microsoft's PIFF SampleEncryptionBox.
-    if (!Arrays.equals(extendedTypeScratch, PIFF_SAMPLE_ENCRYPTION_BOX_EXTENDED_TYPE)) {
-      return;
+    if (Arrays.equals(extendedTypeScratch, PIFF_SAMPLE_ENCRYPTION_BOX_EXTENDED_TYPE)) {
+        // Except for the extended type, this box is identical to a SENC box. See "Portable encoding of
+        // audio-video objects: The Protected Interoperable File Format (PIFF), John A. Bocharov et al,
+        // Section 5.3.2.1."
+        parseSenc(uuid, 16, out);
+        return;
     }
 
-    // Except for the extended type, this box is identical to a SENC box. See "Portable encoding of
-    // audio-video objects: The Protected Interoperable File Format (PIFF), John A. Bocharov et al,
-    // Section 5.3.2.1."
-    parseSenc(uuid, 16, out);
+    if (Arrays.equals(extendedTypeScratch, TFRF_UUID)) {
+        ParsableByteArray data = uuid;
+        data.setPosition(Atom.HEADER_SIZE+16);
+        int fullAtom = data.readInt();
+        int version = Atom.parseFullAtomVersion(fullAtom);
+
+        int fragmentCount = data.readUnsignedByte();
+        for(int i=0; i<fragmentCount; i++) {
+            long absTime = 0, duration = 0;
+            if(version == 0) {
+                absTime = data.readInt();
+                duration = data.readInt();
+            } else if(version == 1) {
+                absTime = data.readLong();
+                duration = data.readLong();
+            }
+            if(ssAtomCallback != null) {
+                ssAtomCallback.onTfrfAtom(absTime, duration);
+            }
+        }
+        return;
+    }
   }
 
   private static void parseSenc(ParsableByteArray senc, TrackFragment out) throws ParserException {

--- a/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsChunkSource.java
+++ b/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsChunkSource.java
@@ -46,7 +46,8 @@ public interface SsChunkSource extends ChunkSource {
         SsManifest manifest,
         int streamElementIndex,
         TrackSelection trackSelection,
-        @Nullable TransferListener transferListener);
+        @Nullable TransferListener transferListener,
+        SsMediaSource mediaSource);
   }
 
   /**

--- a/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaPeriod.java
+++ b/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaPeriod.java
@@ -23,6 +23,7 @@ import com.google.android.exoplayer2.drm.DrmSessionManager;
 import com.google.android.exoplayer2.offline.StreamKey;
 import com.google.android.exoplayer2.source.CompositeSequenceableLoaderFactory;
 import com.google.android.exoplayer2.source.MediaPeriod;
+import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSourceEventListener.EventDispatcher;
 import com.google.android.exoplayer2.source.SampleStream;
 import com.google.android.exoplayer2.source.SequenceableLoader;
@@ -59,6 +60,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
   private ChunkSampleStream<SsChunkSource>[] sampleStreams;
   private SequenceableLoader compositeSequenceableLoader;
   private boolean notifiedReadingStarted;
+  private SsMediaSource mediaSource;
 
   public SsMediaPeriod(
       SsManifest manifest,
@@ -69,7 +71,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
       LoadErrorHandlingPolicy loadErrorHandlingPolicy,
       EventDispatcher eventDispatcher,
       LoaderErrorThrower manifestLoaderErrorThrower,
-      Allocator allocator) {
+      Allocator allocator,
+      SsMediaSource mediaSource) {
     this.manifest = manifest;
     this.chunkSourceFactory = chunkSourceFactory;
     this.transferListener = transferListener;
@@ -84,6 +87,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
     compositeSequenceableLoader =
         compositeSequenceableLoaderFactory.createCompositeSequenceableLoader(sampleStreams);
     eventDispatcher.mediaPeriodCreated();
+    this.mediaSource = mediaSource;
   }
 
   public void updateManifest(SsManifest manifest) {
@@ -244,7 +248,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
             manifest,
             streamElementIndex,
             selection,
-            transferListener);
+            transferListener,
+	    mediaSource);
     return new ChunkSampleStream<>(
         manifest.streamElements[streamElementIndex].type,
         null,

--- a/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaSource.java
+++ b/library/smoothstreaming/src/main/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaSource.java
@@ -567,7 +567,8 @@ public final class SsMediaSource extends BaseMediaSource
             loadErrorHandlingPolicy,
             eventDispatcher,
             manifestLoaderErrorThrower,
-            allocator);
+            allocator,
+	    this);
     mediaPeriods.add(period);
     return period;
   }
@@ -725,13 +726,19 @@ public final class SsMediaSource extends BaseMediaSource
     refreshSourceInfo(timeline);
   }
 
+  public void sourceInfoRefreshed(Timeline timeline) {
+    refreshSourceInfo(timeline);
+  }
+
   private void scheduleManifestRefresh() {
     if (!manifest.isLive) {
       return;
     }
+    /*
     long nextLoadTimestamp = manifestLoadStartTimestamp + MINIMUM_MANIFEST_REFRESH_PERIOD_MS;
     long delayUntilNextLoad = Math.max(0, nextLoadTimestamp - SystemClock.elapsedRealtime());
     manifestRefreshHandler.postDelayed(this::startLoadingManifest, delayUntilNextLoad);
+    */
   }
 
   private void startLoadingManifest() {

--- a/library/smoothstreaming/src/test/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaPeriodTest.java
+++ b/library/smoothstreaming/src/test/java/com/google/android/exoplayer2/source/smoothstreaming/SsMediaPeriodTest.java
@@ -75,7 +75,8 @@ public class SsMediaPeriodTest {
                         /* mediaPeriodId= */ new MediaPeriodId(/* periodUid= */ new Object()),
                         /* mediaTimeOffsetMs= */ 0),
                 mock(LoaderErrorThrower.class),
-                mock(Allocator.class));
+                mock(Allocator.class),
+                null);
 
     MediaPeriodAsserts.assertGetStreamKeysAndManifestFilterIntegration(
         mediaPeriodFactory, testManifest);


### PR DESCRIPTION
This fixes issues #855

This is needed in our use-case because we have a backend for which the access to the manifest requires a token that is valid only for one minute.

I have tested this with http://essdrmproducts-dev.insidesecure.com:9090/live/clear.isml/manifest
I added logs in HttpDataSource to log every access to manifest and confirmed it is now only accessed once, while it was recurrent before.

Points that are unclear to me:
- When testing on http://essdrmproducts-dev.insidesecure.com:9090/live/clear.isml/manifest I can see that Exoplayer tries to download chunks ahead of their time, so the server returns few 412 before the chunks are actually available. This doesn't happen prior to the patch. Since I don't change the chunk download algorithm I'm not sure why this happen.
- I'm using System.currentTimeMillis() to expire old chunks. I think this is the sane way to do, but i'm not totally convinced