### PR TITLE
Add missing @Nullable annotations

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadHelper.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadHelper.java
@@ -459,7 +459,7 @@ public final class DownloadHelper {
   public static MediaSource createMediaSource(
       DownloadRequest downloadRequest,
       DataSource.Factory dataSourceFactory,
-      DrmSessionManager<?> drmSessionManager) {
+      @Nullable DrmSessionManager<?> drmSessionManager) {
     @Nullable Constructor<? extends MediaSourceFactory> constructor;
     switch (downloadRequest.type) {
       case DownloadRequest.TYPE_DASH:

--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadService.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadService.java
@@ -595,7 +595,7 @@ public abstract class DownloadService extends Service {
   }
 
   @Override
-  public int onStartCommand(Intent intent, int flags, int startId) {
+  public int onStartCommand(@Nullable Intent intent, int flags, int startId) {
     lastStartId = startId;
     taskRemoved = false;
     @Nullable String intentAction = null;


### PR DESCRIPTION
This adds a couple of missing `@Nullable` annotations. Most notably `DownloadService.onStartCommand(Intent...)`, as this hit us with a crash in production as `Intent` can be nullable during normal operation. Kotlin gets upset with non nullable things being called with null. We ended up having to wrap the service in a Java implementation converting it to nullable.

I've also added `@Nullable` in a separate commit to `DownloadHelper.createMediaSource(...DrmSessionManager)` at it is unused in this function, and passed into a function with a `@Nullable` annotation on `DrmSessionManager`. Saves the caller needing to put a conditional on the existence of `DrmSessionManager` to decide if it should call `DownloadHelper.createMediaSource(request, factory)` or `""drmSessionManager)`. This one is less important but figured while I was here, feel free to throw away that commit.