### PR TITLE
keep indices from offsetting when playing from a midroll

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -1059,15 +1059,12 @@ public final class ImaAdsLoader
 
     // IMA indexes any remaining midroll ad pods from 1. A preroll (if present) has index 0.
     // Store an index offset as we want to index all ads (including skipped ones) from 0.
-    if (adGroupIndexForPosition == 0 && adGroupTimesUs[0] == 0) {
-      // We are playing a preroll.
-      podIndexOffset = 0;
-    } else if (adGroupIndexForPosition == C.INDEX_UNSET) {
+    if (adGroupIndexForPosition == C.INDEX_UNSET) {
       // There's no ad to play which means there's no preroll.
       podIndexOffset = -1;
     } else {
-      // We are playing a midroll and any ads before it were skipped.
-      podIndexOffset = adGroupIndexForPosition - 1;
+      // There's a preroll, so no need to offset indices.
+      podIndexOffset = 0;
     }
 
     if (adGroupIndexForPosition != C.INDEX_UNSET && hasMidrollAdGroups(adGroupTimesUs)) {


### PR DESCRIPTION
## Overview

When playing a second mid-roll or any mid-roll after the second mid-roll with an initial seek position, ExoPlayer gets stuck.
The reason is that I think ImaAdsLoader calculate `adGroupIndex` from `podIndex + podIndexOffset` but podIndex always return the correct pod index (even when playback starts over multiple mid points) so no need to shift indicies by podIndexOffset.

https://github.com/google/ExoPlayer/blob/release-v2/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java#L1120

You can reproduce the stuck just playing `VMAP pre-roll single ad, mid-roll standard pods with 5 ads every 10 seconds for 1:40, post-roll single ad` on demo app with an initial seek position 25 * 1000L ms. (which should play the second mid-roll and play content subsequently)

```java
  private void initializePlayer() {
    ...
    player.prepare();
    player.seekTo(25 * 1000);
    ...
}
```

After applying my changes, the stuck will be gone and the ad will be played correctly.
