### PR TITLE
Added load error handling policy to OfflineLicenseHelper.

### DIFF
--- a/library/core/src/test/java/com/google/android/exoplayer2/drm/OfflineLicenseHelperTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/drm/OfflineLicenseHelperTest.java
@@ -25,6 +25,7 @@ import android.util.Pair;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.drm.DrmInitData.SchemeData;
+import com.google.android.exoplayer2.upstream.DefaultLoadErrorHandlingPolicy;
 import java.util.HashMap;
 import org.junit.After;
 import org.junit.Before;
@@ -55,6 +56,7 @@ public class OfflineLicenseHelperTest {
             C.WIDEVINE_UUID,
             new ExoMediaDrm.AppManagedProvider<>(mediaDrm),
             mediaDrmCallback,
+            new DefaultLoadErrorHandlingPolicy(),
             null);
   }
 


### PR DESCRIPTION
This change is in reference to:
#7078

Adds the ability to use a load error handling policy to OfflineLicenseHelper. Since the DRM session is being built within the OfflineLicenseHelper, I've exposed the policy to the end user, similar to that of the KeyRequestParameters.

Added the NonNull annotation since there is an assertion within setLoadErrorHandlingPolicy.

Please let me know if there is anything else.

Thanks!