### PR TITLE
Update media timestamp regex to allow negative values

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/WebvttExtractor.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/WebvttExtractor.java
@@ -49,7 +49,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 public final class WebvttExtractor implements Extractor {
 
   private static final Pattern LOCAL_TIMESTAMP = Pattern.compile("LOCAL:([^,]+)");
-  private static final Pattern MEDIA_TIMESTAMP = Pattern.compile("MPEGTS:(\\d+)");
+  private static final Pattern MEDIA_TIMESTAMP = Pattern.compile("MPEGTS:(-?\\d+)");
   private static final int HEADER_MIN_LENGTH = 6 /* "WEBVTT" */;
   private static final int HEADER_MAX_LENGTH = 3 /* optional Byte Order Mark */ + HEADER_MIN_LENGTH;
 


### PR DESCRIPTION
The RegEx for matching the `MPEGTS` in an `X-TIMESTAMP-MAP` header of a WebVtt file is extended to allow negative values.


### Reference
- The 2017 [spec](https://tools.ietf.org/html/rfc8216#section-3.5) 
- The 2019 edition of the [spec](https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-05#section-3.5) (still a draft, but Apple calls it 2nd Edition already)