### PR TITLE
Extend FrameworkMediaDrm to support PSSHv1 on Amazon FireTV devices

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
@@ -358,13 +358,15 @@ public final class FrameworkMediaDrm implements ExoMediaDrm<FrameworkMediaCrypto
     }
 
     // Prior to L the Widevine CDM required data to be extracted from the PSSH atom. Some Amazon
-    // devices also required data to be extracted from the PSSH atom for PlayReady.
+    // devices also required data to be extracted from the PSSH atom for PlayReady and Widevine
+    // with PSSHv1 boxes.
     if ((Util.SDK_INT < 21 && C.WIDEVINE_UUID.equals(uuid))
-        || (C.PLAYREADY_UUID.equals(uuid)
+        || ((C.PLAYREADY_UUID.equals(uuid) || C.WIDEVINE_UUID.equals(uuid))
             && "Amazon".equals(Util.MANUFACTURER)
             && ("AFTB".equals(Util.MODEL) // Fire TV Gen 1
                 || "AFTS".equals(Util.MODEL) // Fire TV Gen 2
-                || "AFTM".equals(Util.MODEL)))) { // Fire TV Stick Gen 1
+                || "AFTM".equals(Util.MODEL) // Fire TV Stick Gen 1
+                || "AFTT".equals(Util.MODEL)))) { // Fire TV Stick Gen 2
       byte[] psshData = PsshAtomUtil.parseSchemeSpecificData(initData, uuid);
       if (psshData != null) {
         // Extraction succeeded, so return the extracted data.


### PR DESCRIPTION
Extend `FrameworkMediaDrm` to support PSSHv1 on Amazon FireTV Gen1, FireTV Gen2 as well as Fire Stick Gen1 and Fire Stick Gen2.

There exists already a workaround for Amazon devices in `FrameworkMediaDrm` regarding PlayReady DRM data. This workaround is extended to also cover Widevine DRM and the issue with PSSHv1 data.


Without this PR the initial key request fails on named devices 
```
E/MediaDrm-JNI( 9635): Illegal state exception: Failed to get key request: DRM vendor-defined error: -2998 (-2998)\
E/ExoPlayerImplInternal( 9635): Playback error.\
E/ExoPlayerImplInternal( 9635): com.google.android.exoplayer2.ExoPlaybackException: com.google.android.exoplayer2.drm.DrmSession$DrmSessionException: android.media.MediaDrm$MediaDrmStateException: Failed to get key request: DRM vendor-defined error: -2998\
E/ExoPlayerImplInternal( 9635): 	at com.google.android.exoplayer2.mediacodec.MediaCodecRenderer.maybeInitCodec(MediaCodecRenderer.java:465)\
E/ExoPlayerImplInternal( 9635): 	at com.google.android.exoplayer2.mediacodec.MediaCodecRenderer.reinitializeCodec(MediaCodecRenderer.java:1261)\
E/ExoPlayerImplInternal( 9635): 	at com.google.android.exoplayer2.mediacodec.MediaCodecRenderer.onInputFormatChanged(MediaCodecRenderer.java:1111)\
E/ExoPlayerImplInternal( 9635): 	at com.google.android.exoplayer2.audio.MediaCodecAudioRenderer.onInputFormatChanged(MediaCodecAudioRenderer.java:412)\
E/ExoPlayerImplInternal( 9635): 	at com.google.android.exoplayer2.mediacodec.MediaCodecRenderer.render(MediaCodecRenderer.java:647)\
E/ExoPlayerImplInternal( 9635): 	at com.google.android.exoplayer2.ExoPlayerImplInternal.doSomeWork(ExoPlayerImplInternal.java:529)\
E/ExoPlayerImplInternal( 9635): 	at com.google.android.exoplayer2.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:300)\
E/ExoPlayerImplInternal( 9635): 	at android.os.Handler.dispatchMessage(Handler.java:98)\
E/ExoPlayerImplInternal( 9635): 	at android.os.Looper.loop(Looper.java:135)\
E/ExoPlayerImplInternal( 9635): 	at android.os.HandlerThread.run(HandlerThread.java:61)\
```

## Notes
The change will result in parsing the `initData` independent of the actual used PSSH version. Let me know if you would prefer an explicit version check.
But PSSHv0 streams still play back as expected.