### PR TITLE
DUMMY drm manager overrides default methods.

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/DrmSessionManager.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/DrmSessionManager.java
@@ -53,6 +53,22 @@ public interface DrmSessionManager<T extends ExoMediaCrypto> {
         public Class<ExoMediaCrypto> getExoMediaCryptoType(DrmInitData drmInitData) {
           return null;
         }
+
+        @Override
+        public DrmSession<ExoMediaCrypto> acquirePlaceholderSession(Looper playbackLooper, int trackType) {
+          // Intentionally overriden to make sure that build toolchain without desugaring support don't crash
+          return null;
+        }
+
+        @Override
+        public void prepare() {
+          // Intentionally overriden to make sure that build toolchain without desugaring support don't crash
+        }
+      
+        @Override
+        public void release() {
+          // Intentionally overriden to make sure that build toolchain without desugaring support don't crash
+        }
       };
 
   /**


### PR DESCRIPTION
DUMMY drm manager is internal class which is created for every HLS/DASH session.

It addresses this issue: https://github.com/google/ExoPlayer/issues/7119.

It is impossible to work-around AbstractMethodError issue in toolchains without java 8 de-sugaring support.

It could be addressed in many different ways, pick the one which suits the ExoPlayer the best.

Out of blue:
- Allow passing the implementation to Builder constructor, so external developer will be able to override the methods
- Remove the defaults from this particular interface
- Implement all methods for DUMMY

It would be wonderful if you could publish 2.11.4 with one of this fixes applied.