### PR TITLE
Check if exoplayerModulePrefix is set

### DIFF
--- a/library/core/build.gradle
+++ b/library/core/build.gradle
@@ -61,8 +61,12 @@ dependencies {
     androidTestImplementation 'com.google.guava:guava:' + guavaVersion
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker:' + dexmakerVersion
     androidTestImplementation 'com.linkedin.dexmaker:dexmaker-mockito:' + dexmakerVersion
-    androidTestImplementation(project(modulePrefix + 'testutils')) {
-        exclude module: gradle.ext.exoplayerModulePrefix + 'library-core'
+    if (gradle.ext.has('exoplayerModulePrefix')) {
+        androidTestImplementation(project(modulePrefix + 'testutils')) {
+            exclude module: gradle.ext.exoplayerModulePrefix + 'library-core'
+        }
+    } else {
+        androidTestImplementation project(modulePrefix + 'testutils')
     }
     testImplementation 'com.google.guava:guava:' + guavaVersion
     testImplementation 'org.robolectric:robolectric:' + robolectricVersion


### PR DESCRIPTION
Check if `exoplayerModulePrefix` is defined before accessing it.

Similar checks can be seen [here](https://github.com/google/ExoPlayer/blob/release-v2/core_settings.gradle#L16) and [here](https://github.com/google/ExoPlayer/blob/release-v2/settings.gradle#L17). 

Fixes #7147