### PR TITLE
Saving subtitle track name

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/Format.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/Format.java
@@ -626,6 +626,28 @@ public final class Format implements Parcelable {
       @Nullable DrmInitData drmInitData) {
     return createTextSampleFormat(
         id,
+        /* label= */ null,
+        sampleMimeType,
+        /* codecs= */ null,
+        /* bitrate= */ NO_VALUE,
+        selectionFlags,
+        language,
+        NO_VALUE,
+        drmInitData,
+        OFFSET_SAMPLE_RELATIVE,
+        Collections.emptyList());
+  }
+
+  public static Format createTextSampleFormat(
+      @Nullable String id,
+      @Nullable String label,
+      @Nullable String sampleMimeType,
+      @C.SelectionFlags int selectionFlags,
+      @Nullable String language,
+      @Nullable DrmInitData drmInitData) {
+    return createTextSampleFormat(
+        id,
+        label,
         sampleMimeType,
         /* codecs= */ null,
         /* bitrate= */ NO_VALUE,
@@ -648,6 +670,7 @@ public final class Format implements Parcelable {
       @Nullable DrmInitData drmInitData) {
     return createTextSampleFormat(
         id,
+        /* label= */ null,
         sampleMimeType,
         codecs,
         bitrate,
@@ -670,6 +693,7 @@ public final class Format implements Parcelable {
       long subsampleOffsetUs) {
     return createTextSampleFormat(
         id,
+        /* label= */ null,
         sampleMimeType,
         codecs,
         bitrate,
@@ -683,6 +707,7 @@ public final class Format implements Parcelable {
 
   public static Format createTextSampleFormat(
       @Nullable String id,
+      @Nullable String label,
       @Nullable String sampleMimeType,
       @Nullable String codecs,
       int bitrate,
@@ -694,7 +719,7 @@ public final class Format implements Parcelable {
       @Nullable List<byte[]> initializationData) {
     return new Format(
         id,
-        /* label= */ null,
+        /* label= */ label,
         selectionFlags,
         /* roleFlags= */ 0,
         bitrate,

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/mkv/MatroskaExtractor.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/mkv/MatroskaExtractor.java
@@ -2133,14 +2133,14 @@ public class MatroskaExtractor implements Extractor {
                 drmInitData);
       } else if (MimeTypes.APPLICATION_SUBRIP.equals(mimeType)) {
         type = C.TRACK_TYPE_TEXT;
-        format = Format.createTextSampleFormat(Integer.toString(trackId), mimeType, selectionFlags,
+        format = Format.createTextSampleFormat(Integer.toString(trackId), name, mimeType, selectionFlags,
             language, drmInitData);
       } else if (MimeTypes.TEXT_SSA.equals(mimeType)) {
         type = C.TRACK_TYPE_TEXT;
         initializationData = new ArrayList<>(2);
         initializationData.add(SSA_DIALOGUE_FORMAT);
         initializationData.add(codecPrivate);
-        format = Format.createTextSampleFormat(Integer.toString(trackId), mimeType, null,
+        format = Format.createTextSampleFormat(Integer.toString(trackId), name, mimeType, null,
             Format.NO_VALUE, selectionFlags, language, Format.NO_VALUE, drmInitData,
             Format.OFFSET_SAMPLE_RELATIVE, initializationData);
       } else if (MimeTypes.APPLICATION_VOBSUB.equals(mimeType)

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -841,6 +841,7 @@ import java.util.List;
     out.format =
         Format.createTextSampleFormat(
             Integer.toString(trackId),
+            /* label= */ null,
             mimeType,
             /* codecs= */ null,
             /* bitrate= */ Format.NO_VALUE,

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/ts/DefaultTsPayloadReaderFactory.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/ts/DefaultTsPayloadReaderFactory.java
@@ -257,6 +257,7 @@ public final class DefaultTsPayloadReaderFactory implements TsPayloadReader.Fact
           closedCaptionFormats.add(
               Format.createTextSampleFormat(
                   /* id= */ null,
+                  /* label= */ null,
                   mimeType,
                   /* codecs= */ null,
                   /* bitrate= */ Format.NO_VALUE,

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/ts/SeiReader.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/ts/SeiReader.java
@@ -53,6 +53,7 @@ public final class SeiReader {
       output.format(
           Format.createTextSampleFormat(
               formatId,
+              /* label= */ null,
               channelMimeType,
               /* codecs= */ null,
               /* bitrate= */ Format.NO_VALUE,

--- a/library/core/src/main/java/com/google/android/exoplayer2/extractor/ts/UserDataReader.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/extractor/ts/UserDataReader.java
@@ -52,6 +52,7 @@ import java.util.List;
       output.format(
           Format.createTextSampleFormat(
               idGenerator.getFormatId(),
+              /* label= */ null,
               channelMimeType,
               /* codecs= */ null,
               /* bitrate= */ Format.NO_VALUE,

--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaPeriod.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaPeriod.java
@@ -807,6 +807,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
         adaptationSetId
             + ":cea608"
             + (accessibilityChannel != Format.NO_VALUE ? ":" + accessibilityChannel : ""),
+        /* label= */ null,
         MimeTypes.APPLICATION_CEA608,
         /* codecs= */ null,
         /* bitrate= */ Format.NO_VALUE,

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/DefaultTrackNameProvider.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/DefaultTrackNameProvider.java
@@ -48,6 +48,11 @@ public class DefaultTrackNameProvider implements TrackNameProvider {
               buildLanguageOrLabelString(format),
               buildAudioChannelString(format),
               buildBitrateString(format));
+    } else if (trackType == C.TRACK_TYPE_TEXT) {
+      trackName =
+          joinWithSeparator(
+              buildLabelString(format),
+              buildLanguageString(format));
     } else {
       trackName = buildLanguageOrLabelString(format);
     }


### PR DESCRIPTION
Some files have several subtitles in the same language, such as forced and regular subtitles. In this case, a name is added for the subtitle track.
This code allows to save the name of the subtitle track.
The subtitle name and language name can also be seen in the VLC player.
Sample video with name subtitle track: https://drive.google.com/file/d/1WoWcL9B4cVd1fsDEAtYpXDmG0cMF0F_3/view?usp=sharing