### PR TITLE
Add tag and Factory to SilenceMediaSource

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/source/SilenceMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/SilenceMediaSource.java
@@ -33,6 +33,46 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
 /** Media source with a single period consisting of silent raw audio of a given duration. */
 public final class SilenceMediaSource extends BaseMediaSource {
 
+  /** Factory for {@link SilenceMediaSource}s. */
+  public static final class Factory {
+
+    private long durationUs;
+    @Nullable private Object tag;
+
+    /**
+     * Sets the duration of the silent audio.
+     *
+     * @param durationUs The duration of silent audio to output, in microseconds.
+     * @return This factory, for convenience.
+     */
+    public Factory setDuration(long durationUs) {
+      this.durationUs = durationUs;
+      return this;
+    }
+
+    /**
+     * Sets a tag for the media source which will be published in the {@link
+     * com.google.android.exoplayer2.Timeline} of the source as {@link
+     * com.google.android.exoplayer2.Timeline.Window#tag}.
+     *
+     * @param tag A tag for the media source.
+     * @return This factory, for convenience.
+     */
+    public Factory setTag(@Nullable Object tag) {
+      this.tag = tag;
+      return this;
+    }
+
+    /**
+     * Returns a new {@link SilenceMediaSource}.
+     *
+     * @return The new {@link SilenceMediaSource}.
+     */
+    public SilenceMediaSource createMediaSource() {
+      return new SilenceMediaSource(durationUs, tag);
+    }
+  }
+
   private static final int SAMPLE_RATE_HZ = 44100;
   @C.PcmEncoding private static final int PCM_ENCODING = C.ENCODING_PCM_16BIT;
   private static final int CHANNEL_COUNT = 2;
@@ -47,6 +87,7 @@ public final class SilenceMediaSource extends BaseMediaSource {
       new byte[Util.getPcmFrameSize(PCM_ENCODING, CHANNEL_COUNT) * 1024];
 
   private final long durationUs;
+  @Nullable private final Object tag;
 
   /**
    * Creates a new media source providing silent audio of the given duration.
@@ -56,13 +97,20 @@ public final class SilenceMediaSource extends BaseMediaSource {
   public SilenceMediaSource(long durationUs) {
     Assertions.checkArgument(durationUs >= 0);
     this.durationUs = durationUs;
+    this.tag = null;
+  }
+
+  private SilenceMediaSource(long durationUs, @Nullable Object tag) {
+    Assertions.checkArgument(durationUs >= 0);
+    this.durationUs = durationUs;
+    this.tag = tag;
   }
 
   @Override
   protected void prepareSourceInternal(@Nullable TransferListener mediaTransferListener) {
     refreshSourceInfo(
         new SinglePeriodTimeline(
-            durationUs, /* isSeekable= */ true, /* isDynamic= */ false, /* isLive= */ false));
+            durationUs, /* isSeekable= */ true, /* isDynamic= */ false, /* isLive= */ false, null, tag));
   }
 
   @Override


### PR DESCRIPTION
## What

Added a Factory to SilenceMediaSource to be able to create it like the other MediaSource. Also added a tag in the class so that users can get more information on this object.

## Why

The idea comes from the following issue. In the use case, the user would like to create a transition between two medias in a playlist. To do that we could use a SilenceMediaSource with a tag in order to know more about the media in the onPositionDiscontinuity() method. The user would only have to call player.getCurrentTag().