### PR TITLE
Add saving subtitle track name for MatroskaExtractor

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mkv/MatroskaExtractor.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mkv/MatroskaExtractor.java
@@ -2139,6 +2139,7 @@ public class MatroskaExtractor implements Extractor {
       Format format =
           formatBuilder
               .setId(trackId)
+              .setLabel(name)
               .setSampleMimeType(mimeType)
               .setMaxInputSize(maxInputSize)
               .setLanguage(language)

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/DefaultTrackNameProvider.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/DefaultTrackNameProvider.java
@@ -48,6 +48,11 @@ public class DefaultTrackNameProvider implements TrackNameProvider {
               buildLanguageOrLabelString(format),
               buildAudioChannelString(format),
               buildBitrateString(format));
+    } else if (trackType == C.TRACK_TYPE_TEXT) {
+      trackName =
+          joinWithSeparator(
+              buildLabelString(format),
+              buildLanguageString(format));
     } else {
       trackName = buildLanguageOrLabelString(format);
     }


### PR DESCRIPTION
Some files have several subtitles in the same language, such as forced and regular subtitles. In this case, a name is added for the subtitle track.
This code allows to save the name of the subtitle track. DefaultTrackNameProvider consider the name for TRACK_TYPE_TEXT track type.   
The subtitle name and language name in the pair can also be seen in VLC player.
Sample video with subtitle track name: https://drive.google.com/file/d/1WoWcL9B4cVd1fsDEAtYpXDmG0cMF0F_3/view?usp=sharing