### PR TITLE
Change needed to prevent bandwidth based adaptation from selecting iFrame only

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/trackselection/AdaptiveTrackSelection.java
@@ -540,7 +540,17 @@ public class AdaptiveTrackSelection extends BaseTrackSelection {
   @SuppressWarnings("unused")
   protected boolean canSelectFormat(
       Format format, int trackBitrate, float playbackSpeed, long effectiveBitrate) {
-    return Math.round(trackBitrate * playbackSpeed) <= effectiveBitrate;
+
+    boolean isIframeOnly = (format.roleFlags & C.ROLE_FLAG_TRICK_PLAY) != 0;
+    boolean canSelect = Math.round(trackBitrate * playbackSpeed) <= effectiveBitrate;
+
+    if (Math.abs(playbackSpeed) > 6.0f) {
+      canSelect = isIframeOnly;   // TODO factor in playback speed...
+    } else {
+      canSelect = ! isIframeOnly && canSelect;
+    }
+    return canSelect;
+
   }
 
   /**


### PR DESCRIPTION
Thank you all for merging the iFrame only support pull request.  I apologize for not rebasing it to fewer commits first, as it has grown old.  So the single commit 88de774 was great,I like the idea to put the iFrames in the same with the other variants.   This change was @ojw28's design, I just missed making them the same list.

This version of my changes will work just fine, however I would strongly recommend you include the commit in this pull (already rebased to dev-v2).   This will prevent i-Frame tracks from being selected at 1x forward speed.

I can rebase again and factor in the TODO (basically only needed if there are multiple iFrame only tracks).  Let me know.

We are re-testing our code with the latest `dev-v2` and found this.