### PR TITLE
Role trick-play tracks incorrectly included in adaptive set

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsSampleStreamWrapper.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsSampleStreamWrapper.java
@@ -1314,6 +1314,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
             .setLabel(playlistFormat.label)
             .setLanguage(playlistFormat.language)
             .setSelectionFlags(playlistFormat.selectionFlags)
+            .setRoleFlags(playlistFormat.roleFlags)
             .setAverageBitrate(propagateBitrates ? playlistFormat.averageBitrate : Format.NO_VALUE)
             .setPeakBitrate(propagateBitrates ? playlistFormat.peakBitrate : Format.NO_VALUE)
             .setCodecs(codecs)


### PR DESCRIPTION
@ojw28 merge of trick-play support missed the change that includes the `Format.roleFlags` when 
using sample prepare (the non-chunkless prepare path).   This was an easy path to miss, with little unit test coverage in this part of the code