### PR TITLE
Keep the MediaSession paused state during buffering without playWhenReady.

### DIFF
--- a/extensions/mediasession/src/main/java/com/google/android/exoplayer2/ext/mediasession/MediaSessionConnector.java
+++ b/extensions/mediasession/src/main/java/com/google/android/exoplayer2/ext/mediasession/MediaSessionConnector.java
@@ -946,7 +946,9 @@ public final class MediaSessionConnector {
       @Player.State int exoPlayerPlaybackState, boolean playWhenReady) {
     switch (exoPlayerPlaybackState) {
       case Player.STATE_BUFFERING:
-        return PlaybackStateCompat.STATE_BUFFERING;
+        return playWhenReady
+            ? PlaybackStateCompat.STATE_BUFFERING
+            : PlaybackStateCompat.STATE_PAUSED;
       case Player.STATE_READY:
         return playWhenReady ? PlaybackStateCompat.STATE_PLAYING : PlaybackStateCompat.STATE_PAUSED;
       case Player.STATE_ENDED:


### PR DESCRIPTION
The PlaybackStateCompat#STATE_BUFFERING expects the playback to begin
once enough data has been buffered. This is however not the case if
playWhenReady is not set on the exoplayer.

Fixes #7206 

