### PR TITLE
Assume default 4G bitrate for 5G

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultBandwidthMeter.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultBandwidthMeter.java
@@ -203,10 +203,11 @@ public final class DefaultBandwidthMeter implements BandwidthMeter, TransferList
       result.append(C.NETWORK_TYPE_2G, DEFAULT_INITIAL_BITRATE_ESTIMATES_2G[groupIndices[1]]);
       result.append(C.NETWORK_TYPE_3G, DEFAULT_INITIAL_BITRATE_ESTIMATES_3G[groupIndices[2]]);
       result.append(C.NETWORK_TYPE_4G, DEFAULT_INITIAL_BITRATE_ESTIMATES_4G[groupIndices[3]]);
-      // Assume default Wifi bitrate for Ethernet and 5G to prevent using the slower fallback.
+      // Assume default Wifi and 4G bitrate for Ethernet and 5G, respectively, to prevent using the
+      // slower fallback.
       result.append(
           C.NETWORK_TYPE_ETHERNET, DEFAULT_INITIAL_BITRATE_ESTIMATES_WIFI[groupIndices[0]]);
-      result.append(C.NETWORK_TYPE_5G, DEFAULT_INITIAL_BITRATE_ESTIMATES_WIFI[groupIndices[0]]);
+      result.append(C.NETWORK_TYPE_5G, DEFAULT_INITIAL_BITRATE_ESTIMATES_4G[groupIndices[3]]);
       return result;
     }
 


### PR DESCRIPTION
There's no data for 5G, but it's likely that 5G speeds will be closer to 4G than to Wifi. 

According to the bitrate tables in `DefaultBandwidthMeter`, in 109 out of 238 countries, 4G is faster than Wifi; In 64 of them the difference is 1200kbps or more - in favor of 4G.

CSV with data from the tables:
https://gist.github.com/noamtamim/64b9a85338bff5c22b609f591b77deb2