### PR TITLE
Prevent wrong value from getTotalBufferedDurationUs

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -2104,7 +2104,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
   private long getTotalBufferedDurationUs(long bufferedPositionInLoadingPeriodUs) {
     MediaPeriodHolder loadingPeriodHolder = queue.getLoadingPeriod();
-    if (loadingPeriodHolder == null) {
+    if (loadingPeriodHolder == null || rendererPositionUs < 0) {
       return 0;
     }
     long totalBufferedDurationUs =


### PR DESCRIPTION
prevent negative value for rendererPositionUs, in random cases
for a split second the value of rendererPositionUs is negative
after a seekto or starting a playback with a ResumePosition >>> 0
for example, what results on a wrong and too big value be returned

Signed-off-by: fgl27 <fglfgl27@gmail.com>