### PR TITLE
fix a calculation error in adGroupTimeUs

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaAdsLoader.java
@@ -1261,7 +1261,7 @@ public final class ImaAdsLoader implements Player.EventListener, AdsLoader {
     }
 
     // adPodInfo.podIndex may be 0-based or 1-based, so for now look up the cue point instead.
-    long adGroupTimeUs = (long) (((float) adPodInfo.getTimeOffset()) * C.MICROS_PER_SECOND);
+    long adGroupTimeUs = (long) (adPodInfo.getTimeOffset() * C.MICROS_PER_SECOND);
     for (int adGroupIndex = 0; adGroupIndex < adPlaybackState.adGroupCount; adGroupIndex++) {
       if (adPlaybackState.adGroupTimesUs[adGroupIndex] == adGroupTimeUs) {
         return adGroupIndex;


### PR DESCRIPTION
# Overview
Hi, I found a bug in getAdGroupIndexForAdPod in ImaAdsLoader.
I'm trying to play a video that contains the following mid.

`AdCuePoints: [0.0, 39.0, 1765.0, 2554.0, 2766.0]`

If you do this with the following calculation from getAdGroupIndexForAdPod, the calculation will go wrong if it exceeds 4 digits.

```
 long adGroupTimeUs = (long) (((float) adPodInfo.getTimeOffset()) * C.MICROS_PER_SECOND);
```

Is there an intention to make it a float type?
If not, I would like to see it treated as a double.

Thank you.

# Screenshot
Here's what happens when you do the actual 4+ digit calculation.
<img width="988" alt="スクリーンショット 2020-06-19 17 24 44" src="https://user-images.githubusercontent.com/14940949/85119190-591c8c80-b25c-11ea-81bc-0970689cce38.png">

# Error log
```
2020-06-18 19:01:27.707 12544-12544 E/ImaAdsLoader: Internal error in loadAd
      java.lang.IllegalStateException: Failed to find cue point
        at com.google.android.exoplayer2.ext.ima.ImaAdsLoader.getAdGroupIndexForAdPod(ImaAdsLoader.java:1457)
        at com.google.android.exoplayer2.ext.ima.ImaAdsLoader.loadAd(ImaAdsLoader.java:845)
        at com.google.ads.interactivemedia.v3.internal.akf.a(IMASDK:23)
        at com.google.ads.interactivemedia.v3.internal.akb.a(IMASDK:177)
        at com.google.ads.interactivemedia.v3.internal.akb.a(IMASDK:44)
        at com.google.ads.interactivemedia.v3.internal.ake.b(IMASDK:28)
        at com.google.ads.interactivemedia.v3.internal.akc.shouldOverrideUrlLoading(IMASDK:6)
        at android.webkit.WebViewClient.shouldOverrideUrlLoading(WebViewClient.java:83)
        at org.chromium.android_webview.AwContentsClientBridge.shouldOverrideUrlLoading(chromium-TrichromeWebViewGoogle.apk-stable-410410683:16)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:336)
        at android.os.Looper.loop(Looper.java:197)
        at android.app.ActivityThread.main(ActivityThread.java:8016)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1076)
2020-06-18 19:01:27.735 12544-12544 E/AndroidRuntime: FATAL EXCEPTION: main
    Process: PID: 12544
    java.lang.NullPointerException: throw with null exception
        at com.google.android.exoplayer2.util.Assertions.checkNotNull(Assertions.java:147)
        at com.google.android.exoplayer2.ext.ima.ImaAdsLoader.playAd(ImaAdsLoader.java:910)
        at com.google.ads.interactivemedia.v3.internal.akf.a(IMASDK:16)
        at com.google.ads.interactivemedia.v3.internal.akb.a(IMASDK:177)
        at com.google.ads.interactivemedia.v3.internal.akb.a(IMASDK:44)
        at com.google.ads.interactivemedia.v3.internal.ake.b(IMASDK:28)
        at com.google.ads.interactivemedia.v3.internal.akc.shouldOverrideUrlLoading(IMASDK:6)
        at android.webkit.WebViewClient.shouldOverrideUrlLoading(WebViewClient.java:83)
        at org.chromium.android_webview.AwContentsClientBridge.shouldOverrideUrlLoading(chromium-TrichromeWebViewGoogle.apk-stable-410410683:16)
        at android.os.MessageQueue.nativePollOnce(Native Method)
        at android.os.MessageQueue.next(MessageQueue.java:336)
        at android.os.Looper.loop(Looper.java:197)
        at android.app.ActivityThread.main(ActivityThread.java:8016)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1076)
```