### PR TITLE
Detect external surround sound on Xiaomi devices

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
@@ -156,6 +156,7 @@ public final class AudioCapabilities {
   }
 
   private static boolean deviceMaySetExternalSurroundSoundGlobalSetting() {
-    return Util.SDK_INT >= 17 && "Amazon".equals(Util.MANUFACTURER);
+    return Util.SDK_INT >= 17 &&
+            ("Amazon".equals(Util.MANUFACTURER) || "Xiaomi".equals(Util.MANUFACTURER));
   }
 }


### PR DESCRIPTION
Detect external surround when Spdif connection to an AVR that handles Dolby Digital+
When play Dolby stream by "play movie" on XiaomiTV, when set output mode to Spdif and passthrough, Exoplayer just out raw uncompressed PCM to audio hal, but AVR can support decode Dolby audio.
So,we need encoded audio be output in this case.

Signed-off-by: zhangqi16 <zhangqi16@xiaomi.com>