### PR TITLE
Detect external surround sound on Xiaomi devices

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
@@ -156,6 +156,7 @@ public final class AudioCapabilities {
   }
 
   private static boolean deviceMaySetExternalSurroundSoundGlobalSetting() {
-    return Util.SDK_INT >= 17 && "Amazon".equals(Util.MANUFACTURER);
+    return Util.SDK_INT >= 17 &&
+            ("Amazon".equals(Util.MANUFACTURER) || "Xiaomi".equals(Util.MANUFACTURER));
   }
 }


### PR DESCRIPTION
Detect external surround when spdif connection to an AVR that handles Dolby Digital+

Signed-off-by: zhangqi16 <zq15011526977@gmail.com>