### PR TITLE
Use default text size if captioning manager is disabled

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/SubtitleView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/SubtitleView.java
@@ -229,7 +229,9 @@ public final class SubtitleView extends FrameLayout implements TextOutput {
    * default size before API level 19.
    */
   public void setUserDefaultTextSize() {
-    float fontScale = Util.SDK_INT >= 19 && !isInEditMode() ? getUserCaptionFontScaleV19() : 1f;
+    float fontScale = Util.SDK_INT >= 19 && isCaptionManagerEnabled() && !isInEditMode()
+        ? getUserCaptionFontScaleV19()
+        : 1f;
     setFractionalTextSize(DEFAULT_TEXT_SIZE_FRACTION * fontScale);
   }
 


### PR DESCRIPTION
This fixes an issue where, even if captioning manager is disabled, the latest used captioning manager preference
related to text size is applied.

In order to replicate:
1. Go to Captioning Preferences under device Settings and enable it
2. Change the text size to "very large"
3. Observe the selected text size is used for subtitles, for example in YouTube app
4. Go to Captioning Preferences under device Settings and disable it
5. Observe the text size used for subtitles does not come back to normal. Stays on "very large"