### PR TITLE
Make it possible to override DefaultAudioSink

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/DefaultRenderersFactory.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/DefaultRenderersFactory.java
@@ -23,6 +23,7 @@ import androidx.annotation.IntDef;
 import com.google.android.exoplayer2.audio.AudioCapabilities;
 import com.google.android.exoplayer2.audio.AudioProcessor;
 import com.google.android.exoplayer2.audio.AudioRendererEventListener;
+import com.google.android.exoplayer2.audio.AudioSink;
 import com.google.android.exoplayer2.audio.DefaultAudioSink;
 import com.google.android.exoplayer2.audio.DefaultAudioSink.DefaultAudioProcessorChain;
 import com.google.android.exoplayer2.audio.MediaCodecAudioRenderer;
@@ -452,10 +453,9 @@ public class DefaultRenderersFactory implements RenderersFactory {
             enableDecoderFallback,
             eventHandler,
             eventListener,
-            new DefaultAudioSink(
+            buildAudioSink(
                 AudioCapabilities.getCapabilities(context),
-                new DefaultAudioProcessorChain(audioProcessors),
-                /* enableFloatOutput= */ false,
+                audioProcessors,
                 enableOffload));
     audioRenderer.experimental_setMediaCodecOperationMode(audioMediaCodecOperationMode);
     out.add(audioRenderer);
@@ -531,6 +531,17 @@ public class DefaultRenderersFactory implements RenderersFactory {
       // The extension is present, but instantiation failed.
       throw new RuntimeException("Error instantiating FFmpeg extension", e);
     }
+  }
+
+  protected AudioSink buildAudioSink(
+      AudioCapabilities audioCapabilities,
+      AudioProcessor[] audioProcessors,
+      boolean enableOffload) {
+    return new DefaultAudioSink(
+        audioCapabilities,
+        new DefaultAudioProcessorChain(audioProcessors),
+        /* enableFloatOutput= */ false,
+        enableOffload);
   }
 
   /**


### PR DESCRIPTION
My ultimate goal is to be able to access the `AudioTrack` inside the `DefaultAudioSink`, so I can check the audio routing via [OnRoutingChangedListener](https://developer.android.com/reference/android/media/AudioTrack#addOnRoutingChangedListener(android.media.AudioTrack.OnRoutingChangedListener,%20android.os.Handler))/[getRoutedDevice](https://developer.android.com/reference/android/media/AudioTrack#getRoutedDevice()).

However I started small to see if there's any plans to support this at all, or a better way it could be implemented?