### PR TITLE
Adding ascending sort of TrackGroup

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/TrackSelectionDialogBuilder.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/TrackSelectionDialogBuilder.java
@@ -59,6 +59,7 @@ public final class TrackSelectionDialogBuilder {
   private boolean showDisableOption;
   @Nullable private TrackNameProvider trackNameProvider;
   private boolean isDisabled;
+  private boolean sortTrackAscending = false;
   private List<SelectionOverride> overrides;
 
   /**
@@ -207,6 +208,18 @@ public final class TrackSelectionDialogBuilder {
     return this;
   }
 
+  /**
+   *
+   * Sets Whether the TrackGroupArray of the {@code rendererIndex} specified should be
+   * display in ascending order
+   * @param sort Whether to sort in ascending order or let it as it is received
+   * @return This builder, for convenience.
+   */
+  public TrackSelectionDialogBuilder setSortTrack(boolean sort) {
+    this.sortTrackAscending = sort;
+    return this;
+  }
+
   /** Builds the dialog. */
   public Dialog build() {
     @Nullable Dialog dialog = buildForAndroidX();
@@ -274,7 +287,7 @@ public final class TrackSelectionDialogBuilder {
     if (trackNameProvider != null) {
       selectionView.setTrackNameProvider(trackNameProvider);
     }
-    selectionView.init(mappedTrackInfo, rendererIndex, isDisabled, overrides, /* listener= */ null);
+    selectionView.init(mappedTrackInfo, rendererIndex, isDisabled, overrides, /* listener= */ null, sortTrackAscending);
     return (dialog, which) ->
         callback.onTracksSelected(selectionView.getIsDisabled(), selectionView.getOverrides());
   }


### PR DESCRIPTION
This enhancement match with this issue https://github.com/google/ExoPlayer/issues/7709

This is my first time contributing to a project, feel free to tell me if I did something wrong.

I'm comparing the bitrate of the `TrackGroup` as it works for both Audio and Video.

I've also notice that the original `TrackGroup` from `trackGroups.get(groupIndex);` is always 0, maybe I could delete the first loop over the `groupIndex`