### PR TITLE
apply output surface workaround for F02H, F03H

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -1611,6 +1611,8 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
             case "ELUGA_Prim":
             case "ELUGA_Ray_X":
             case "EverStar_S":
+            case "F02H":
+            case "F03H":
             case "F3111":
             case "F3113":
             case "F3116":


### PR DESCRIPTION
## Overview

F02H, F03H devices fail playback when trying switching player views within a short amount of time (like 1~2s).
I think this is the same issue as https://github.com/google/ExoPlayer/issues/3236, or https://github.com/google/ExoPlayer/issues/3355, etc.

I confirmed that this is solved after applying the output surface workaround.