### PR TITLE
Update HTTP status codes expected in CDN failover scenarios

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultLoadErrorHandlingPolicy.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultLoadErrorHandlingPolicy.java
@@ -72,9 +72,12 @@ public class DefaultLoadErrorHandlingPolicy implements LoadErrorHandlingPolicy {
     IOException exception = loadErrorInfo.exception;
     if (exception instanceof InvalidResponseCodeException) {
       int responseCode = ((InvalidResponseCodeException) exception).responseCode;
-      return responseCode == 404 // HTTP 404 Not Found.
+      return responseCode == 403 // HTTP 403 Forbidden.
+              || responseCode == 404 // HTTP 404 Not Found.
               || responseCode == 410 // HTTP 410 Gone.
               || responseCode == 416 // HTTP 416 Range Not Satisfiable.
+              || responseCode == 500 // HTTP 500 Internal Server Error.
+              || responseCode == 503 // HTTP 503 Service Unavailable.
           ? DEFAULT_TRACK_BLACKLIST_MS
           : C.TIME_UNSET;
     }

--- a/library/core/src/test/java/com/google/android/exoplayer2/upstream/DefaultLoadErrorHandlingPolicyTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/upstream/DefaultLoadErrorHandlingPolicyTest.java
@@ -77,8 +77,8 @@ public final class DefaultLoadErrorHandlingPolicyTest {
   public void getExclusionDurationMsFor_dontExcludeUnexpectedHttpCodes() {
     InvalidResponseCodeException exception =
         new InvalidResponseCodeException(
-            500,
-            "Internal Server Error",
+            418,
+            "I'm a teapot",
             Collections.emptyMap(),
             new DataSpec(Uri.EMPTY),
             /* responseBody= */ Util.EMPTY_BYTE_ARRAY);


### PR DESCRIPTION
Hey ExoPlayer team!

I've chatted with @ojw28 about this change, but here's a formal PR to trigger some more discussion.

This PR adds extra status codes to the list of status codes which trigger ExoPlayer to fail over to alternate/redundant renditions for HLS or DASH playback, rather than triggering immediate "Playback failed" errors.

While the default behaviour could be overridden by each user of ExoPlayer, this PR represents my experience of real world CDN and infrastructure outages, and as such I believe is more user friendly default behavior. 

The changes break down into 2 sets:

1) 403 - Many CDNs/Object stores return 403s rather than 404s when an object is unavailable as a "security feature" - the most common example of this is the default deployment of Cloudfront as a CDN and S3 as an object store.

2) 500 / 503 - Unfortunately when CDNs or manifest services go down, or are overloaded, they often return 5XX series status codes - there have been 2 major CDN outages in the last month in the US where the CDN started returning 5XX errors - trying an alternate media CDN in these cases would have allowed streams to play back through the outages.

This PR brings ExoPlayer more in-line with most player implementations, including AVPlayer/Safari, Video.js. HLS.js, THEOPlayer, JWPlayer etc. However, it is worth highlighting that most other players treat any 4XX / 5XX status (yes, including 418) as an indicator to try alternate renditions.

Thanks!