### PR TITLE
fix durationUs error caused by different track timescale

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -258,12 +258,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
       duration = tkhdData.duration;
     }
     long movieTimescale = parseMvhd(mvhd.data);
-    long durationUs;
-    if (duration == C.TIME_UNSET) {
-      durationUs = C.TIME_UNSET;
-    } else {
-      durationUs = Util.scaleLargeTimestamp(duration, C.MICROS_PER_SECOND, movieTimescale);
-    }
+
     Atom.ContainerAtom stbl =
         checkNotNull(
             checkNotNull(mdia.getContainerAtomOfType(Atom.TYPE_minf))
@@ -271,6 +266,12 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
 
     Pair<Long, String> mdhdData =
         parseMdhd(checkNotNull(mdia.getLeafAtomOfType(Atom.TYPE_mdhd)).data);
+    long durationUs;
+    if (duration == C.TIME_UNSET) {
+      durationUs = C.TIME_UNSET;
+    } else {
+      durationUs = Util.scaleLargeTimestamp(duration, C.MICROS_PER_SECOND, mdhdData.first);
+    }
     StsdData stsdData =
         parseStsd(
             checkNotNull(stbl.getLeafAtomOfType(Atom.TYPE_stsd)).data,


### PR DESCRIPTION
I have a video that contains two tracks. The timescale of one track is 1000, the timescale of the other track is 48000, and the movieTimescale is 1000. As a result, the video time I get is 48 times the real video time.

