### PR TITLE
FlacStreamMetadata: set bitrate and PCM encoding for Format

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/FlacStreamMetadata.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/FlacStreamMetadata.java
@@ -244,6 +244,9 @@ public final class FlacStreamMetadata {
         .setMaxInputSize(maxInputSize)
         .setChannelCount(channels)
         .setSampleRate(sampleRate)
+        .setAverageBitrate(getDecodedBitrate())
+        .setPeakBitrate(getDecodedBitrate())
+        .setPcmEncoding(Util.getPcmEncoding(bitsPerSample))
         .setInitializationData(Collections.singletonList(streamMarkerAndInfoBlock))
         .setMetadata(metadataWithId3)
         .build();


### PR DESCRIPTION
the extractor of Flac extension sets these values, the core extractor should have the same behaviour.