### PR TITLE
remove statusListener after ended session

### DIFF
--- a/extensions/cast/src/main/java/com/google/android/exoplayer2/ext/cast/CastPlayer.java
+++ b/extensions/cast/src/main/java/com/google/android/exoplayer2/ext/cast/CastPlayer.java
@@ -480,8 +480,8 @@ public final class CastPlayer extends BasePlayer {
   @Override
   public void release() {
     SessionManager sessionManager = castContext.getSessionManager();
-    sessionManager.removeSessionManagerListener(statusListener, CastSession.class);
     sessionManager.endCurrentSession(false);
+    sessionManager.removeSessionManagerListener(statusListener, CastSession.class);
   }
 
   @Override


### PR DESCRIPTION
Hi, I've noticed that `SessionAvailabilityListener.onCastSessionUnavailable` is not called after `castPlayer.release()` is called.
As the current session would be destroyed at `release()`, I think it would be better `onCastSessionUnavailable` is notified.

Our use case is that we are trying to start casting on `onCastSessionAvailable`, and switch back to playing media locally on a device when `onCastSessionUnavailable`. However, I can't find the right time to start playing locally after session is ended at `release()`.
`SessionManagerListener` could be used, but I would rather use `SessionAvailabilityListener` because listener would be notified after remoteMediaClient is properly setup/released.
