### PR TITLE
text: Fix handling of unbreakable-space in ssa subtitles

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -264,7 +264,8 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
     String text =
         SsaStyle.Overrides.stripStyleOverrides(rawText)
             .replaceAll("\\\\N", "\n")
-            .replaceAll("\\\\n", "\n");
+            .replaceAll("\\\\n", "\n")
+            .replaceAll("\\\\h", " ");
     Cue cue = createCue(text, style, styleOverrides, screenWidth, screenHeight);
 
     int startTimeIndex = addCuePlacerholderByTime(startTimeUs, cueTimesUs, cues);


### PR DESCRIPTION
The character sequence \h is used for "unbreakable space".
Replace these sequences with space to avoid strings of \h
showing up on screen.


HandBrake inserts many \h characters in captions transcoded
from mpeg-ts to mkv. I see phrases like this on screen:
"I, um, can't go anywhere\h\h\h\h\h\h\h\hby myself"
This is difficult to read.

References:
https://fileformats.fandom.com/wiki/SubStation_Alpha
https://www.md-subs.com/line-spacing-in-ssa
