### PR TITLE
TS Extractor: Fix problem with locating first PCR in HD-PVR recordings

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ts/TsDurationReader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ts/TsDurationReader.java
@@ -38,7 +38,8 @@ import java.io.IOException;
  */
 /* package */ final class TsDurationReader {
 
-  private static final int TIMESTAMP_SEARCH_BYTES = 600 * TsExtractor.TS_PACKET_SIZE;
+  private static final int TIMESTAMP_SEARCH_BYTES_START = 1200 * TsExtractor.TS_PACKET_SIZE;
+  private static final int TIMESTAMP_SEARCH_BYTES_END = 600 * TsExtractor.TS_PACKET_SIZE;
 
   private final TimestampAdjuster pcrTimestampAdjuster;
   private final ParsableByteArray packetBuffer;
@@ -125,7 +126,7 @@ import java.io.IOException;
 
   private int readFirstPcrValue(ExtractorInput input, PositionHolder seekPositionHolder, int pcrPid)
       throws IOException {
-    int bytesToSearch = (int) min(TIMESTAMP_SEARCH_BYTES, input.getLength());
+    int bytesToSearch = (int) min(TIMESTAMP_SEARCH_BYTES_START, input.getLength());
     int searchStartPosition = 0;
     if (input.getPosition() != searchStartPosition) {
       seekPositionHolder.position = searchStartPosition;
@@ -161,7 +162,7 @@ import java.io.IOException;
   private int readLastPcrValue(ExtractorInput input, PositionHolder seekPositionHolder, int pcrPid)
       throws IOException {
     long inputLength = input.getLength();
-    int bytesToSearch = (int) min(TIMESTAMP_SEARCH_BYTES, inputLength);
+    int bytesToSearch = (int) min(TIMESTAMP_SEARCH_BYTES_END, inputLength);
     long searchStartPosition = inputLength - bytesToSearch;
     if (input.getPosition() != searchStartPosition) {
       seekPositionHolder.position = searchStartPosition;


### PR DESCRIPTION
TV shows recorded with Hauppauge HD-PVR will play, but do not allow
seeking and do not show the length. This is because the TsDurationReader
cannot locate the first PCR in the first 112800 bytes. Increasing that
buffer to 122200 bytes solves the problem. To be on the safe side I am
setting it to double the original, or 225600 bytes. The search for last
PCR does not have this problem so I am leaving that at 122200 bytes.