### PR TITLE
Adjust initial selection of HlsChunckSource.InitializationTrackSelection

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -592,7 +592,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
     public InitializationTrackSelection(TrackGroup group, int[] tracks) {
       super(group, tracks);
-      selectedIndex = indexOf(group.getFormat(0));
+      selectedIndex = 0;
     }
 
     @Override


### PR DESCRIPTION
With the changes done in 0670782de80560a42874dbe6f94b070d94d8390d, there exists the possibility that `indexOf(group.getFormat(0))` returns `-1` (i.e. the track is not part of the selection).
This will earlier or later result in an `ArrayIndexOutOfBoundsException`.*

After having a look at the `BaseTrackSelection` I assumed that the `selectedIndex` may not be `-1` or in general any invalid index for the selection.
To always have a valid selection we just select the first one. (Which is basically equivalent to the previous behaviour if the above mentioned change was not implemented.)

---
_* I observed the exception in the `updateSelectedTrack -> isBlacklisted` call_