### PR TITLE
Document potential pitfall with AnalyticsListener implementations

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/analytics/AnalyticsListener.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/analytics/AnalyticsListener.java
@@ -47,6 +47,9 @@ import java.util.List;
  * time at the time of the event.
  *
  * <p>All methods have no-op default implementations to allow selective overrides.
+ *
+ * <p>NOTE: implementations must not alter playback state during the processing of the event, for
+ * example in {@link #onPlayerError(EventTime, ExoPlaybackException)}, instead implement {@link Player.EventListener}
  */
 public interface AnalyticsListener {
 


### PR DESCRIPTION
Update javadoc to encourage implementations not to alter the playback state.  Doing so can lead to issues like #8048
