### PR TITLE
Fix MOV with pcm_alaw which is fixedSampleSize

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -232,7 +232,9 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
     // Fixed sample size raw audio may need to be rechunked.
     boolean isFixedSampleSizeRawAudio =
         sampleSizeBox.isFixedSampleSize()
-            && MimeTypes.AUDIO_RAW.equals(track.format.sampleMimeType)
+            && (MimeTypes.AUDIO_RAW.equals(track.format.sampleMimeType)
+            || MimeTypes.AUDIO_MLAW.equals(track.format.sampleMimeType)
+            || MimeTypes.AUDIO_ALAW.equals(track.format.sampleMimeType))
             && remainingTimestampDeltaChanges == 0
             && remainingTimestampOffsetChanges == 0
             && remainingSynchronizationSamples == 0;
@@ -362,8 +364,14 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
         chunkOffsetsBytes[chunkIterator.index] = chunkIterator.offset;
         chunkSampleCounts[chunkIterator.index] = chunkIterator.numSamples;
       }
-      int fixedSampleSize =
-          Util.getPcmFrameSize(track.format.pcmEncoding, track.format.channelCount);
+      int fixedSampleSize;
+      if (MimeTypes.AUDIO_ALAW.equalsIgnoreCase(track.format.sampleMimeType)
+          || MimeTypes.AUDIO_MLAW.equalsIgnoreCase(track.format.sampleMimeType)) {
+        fixedSampleSize = sampleSizeBox.isFixedSampleSize() ? sampleSizeBox.readNextSampleSize() : 1;
+      } else {
+        fixedSampleSize =
+            Util.getPcmFrameSize(track.format.pcmEncoding, track.format.channelCount);
+      }
       FixedSampleSizeRechunker.Results rechunkedResults = FixedSampleSizeRechunker.rechunk(
           fixedSampleSize, chunkOffsetsBytes, chunkSampleCounts, timestampDeltaInTimeUnits);
       offsets = rechunkedResults.offsets;


### PR DESCRIPTION
Hello, I found that MOV with pcm_alaw or pcm_mulaw couldn't play, which use Mp4Extractor. The pcm_alaw is also one of raw audio, though we don't know how much bits it uses. However, pcm_alaw and pcm_mulaw also use fixedSampleSize, we can see the sample_size which in the box of "moov/trak/mdia/minf/stbl/stsz". As a result, we should treat pcm_alaw and pcm_mulaw as fixedSampleSize, and recheck it to calculate the real frame size.

Here is the testing video:
pcm_alaw: [https://drive.google.com/file/d/1J5LcRO49HHWqr-hfoSB8Y9M4PVlmgDDy/view](url)
pcm_mulaw: [https://drive.google.com/file/d/1ulKeHKvqK6bppmFct1ZLd2SnaOlrZtZs/view](url)