### PR TITLE
fix the end point of span exceeds the length of SpannableStringBuilder

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/tx3g/Tx3gDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/tx3g/Tx3gDecoder.java
@@ -185,6 +185,9 @@ public final class Tx3gDecoder extends SimpleSubtitleDecoder {
     int fontFace = parsableByteArray.readUnsignedByte();
     parsableByteArray.skipBytes(1); // font size
     int colorRgba = parsableByteArray.readInt();
+    if (end > cueText.length()) {
+      end = cueText.length();
+    }
     attachFontFace(cueText, fontFace, defaultFontFace, start, end, SPAN_PRIORITY_HIGH);
     attachColor(cueText, colorRgba, defaultColorRgba, start, end, SPAN_PRIORITY_HIGH);
   }


### PR DESCRIPTION
Hello, guys of developer. I found that the end point of span exceeds the length of SpannableStringBuilder in Tx3gDecoder sometime. In this case, it will throw exception when setting span. Therefore, we may add a judgment whether the end point will exceed the length.

Here is the test url: https://drive.google.com/file/d/1ETVLaO5Y3hiZ8UlP1-EZn-lt3sU5VYKD/view?usp=sharing