### PR TITLE
Fix issues with pass-thru surround audio and external audio devices

### DIFF
--- a/library/core/build.gradle
+++ b/library/core/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     api project(modulePrefix + 'library-common')
     api project(modulePrefix + 'library-extractor')
     implementation 'androidx.annotation:annotation:' + androidxAnnotationVersion
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.mediarouter:mediarouter:1.1.0'
     compileOnly 'com.google.code.findbugs:jsr305:' + jsr305Version
     compileOnly 'org.checkerframework:checker-qual:' + checkerframeworkVersion
     compileOnly 'org.checkerframework:checker-compat-qual:' + checkerframeworkCompatVersion

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
@@ -48,6 +48,9 @@ public final class AudioCapabilities {
   /** Global settings key for devices that can specify external surround sound. */
   private static final String EXTERNAL_SURROUND_SOUND_KEY = "external_surround_sound_enabled";
 
+  private static boolean externalPcmOnlySound = false;
+  public static final int[] EXTERNAL_PCM_ONLY = {AudioFormat.ENCODING_PCM_16BIT,
+          AudioFormat.ENCODING_PCM_8BIT, AudioFormat.ENCODING_PCM_FLOAT, AudioFormat.ENCODING_MP3};
   /**
    * Returns the current audio capabilities for the device.
    *
@@ -113,6 +116,9 @@ public final class AudioCapabilities {
     this.maxChannelCount = maxChannelCount;
   }
 
+  public static void setExternalPcmOnlySoundset(boolean flag) {
+    externalPcmOnlySound = flag;
+  }
   /**
    * Returns whether this device supports playback of the specified audio {@code encoding}.
    *
@@ -120,6 +126,9 @@ public final class AudioCapabilities {
    * @return Whether this device supports playback the specified audio {@code encoding}.
    */
   public boolean supportsEncoding(@C.Encoding int encoding) {
+    if (externalPcmOnlySound) {
+      return Arrays.binarySearch(EXTERNAL_PCM_ONLY, encoding) >= 0;
+    }
     return Arrays.binarySearch(supportedEncodings, encoding) >= 0;
   }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilitiesReceiver.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilitiesReceiver.java
@@ -195,7 +195,7 @@ public final class AudioCapabilitiesReceiver {
 
             @Override
             public void onRouteSelected(MediaRouter router, RouteInfo route) {
-              if (route.getDeviceType() == 3) {
+              if (route.getDeviceType() == RouteInfo.DEVICE_TYPE_BLUETOOTH) {
                 AudioCapabilities.setExternalPcmOnlySoundset(true);
                 onNewAudioCapabilities(AudioCapabilities.getCapabilities(context, null));
               }
@@ -203,7 +203,7 @@ public final class AudioCapabilitiesReceiver {
 
             @Override
             public void onRouteUnselected(MediaRouter router, RouteInfo route, int reason) {
-              if (route.getDeviceType() == 3) {
+              if (route.getDeviceType() == RouteInfo.DEVICE_TYPE_BLUETOOTH) {
                 AudioCapabilities.setExternalPcmOnlySoundset(false);
                 onNewAudioCapabilities(AudioCapabilities.getCapabilities(context, stickyIntent));
               }

--- a/library/core/src/main/java/com/google/android/exoplayer2/trackselection/TrackSelector.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/trackselection/TrackSelector.java
@@ -143,7 +143,7 @@ public abstract class TrackSelector {
    * Calls {@link InvalidationListener#onTrackSelectionsInvalidated()} to invalidate all previously
    * generated track selections.
    */
-  protected final void invalidate() {
+  public final void invalidate() {
     if (listener != null) {
       listener.onTrackSelectionsInvalidated();
     }


### PR DESCRIPTION
Broadcom based AndroidTV devices (and likely others) present the raw (pass-thru) audio CODEC when an external PCM
only (Bluetooth or wired headphones) device is connected. his occurs as well if the connection is
dynamic (Bluetooth device powers up and pairs with the AndroidTV during pass-thru playback).

Basically, the AndroidTV device reports the pass-thru CODEC via
([MediaCodecInfo](https://developer.android.com/reference/android/media/MediaCodecInfo)) if an surround
capable HDMI device is connected regardless of the current audio route.

This is the cause of issue [#7788](https://github.com/google/ExoPlayer/issues/7788)

The solution in this commit watches the
[MediaRouter](https://developer.android.com/guide/topics/media/mediarouter#router-callback) and modifies the returned AudioCapabilities based on changes.