### PR TITLE
Fix for Apple's I-Frame-only stream playback.

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/BundledHlsMediaChunkExtractor.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/BundledHlsMediaChunkExtractor.java
@@ -68,6 +68,11 @@ public final class BundledHlsMediaChunkExtractor implements HlsMediaChunkExtract
   }
 
   @Override
+  public void seek(long position, long timeUs) {
+    extractor.seek( position, timeUs );
+  }
+
+  @Override
   public boolean isPackedAudioExtractor() {
     return extractor instanceof AdtsExtractor
         || extractor instanceof Ac3Extractor

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
@@ -403,6 +403,15 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
       }
       try {
         while (!loadCanceled && extractor.read(input)) {}
+      } catch(EOFException e) {
+        // See bug: https://github.com/google/ExoPlayer/issues/7512 for more details.
+        if( input.getPosition() == dataSpec.position + input.getLength() ) {
+          extractor.seek(0, C.TIME_UNSET);
+        }
+        else {
+          e.fillInStackTrace();
+          throw e;
+        }
       } finally {
         nextLoadPosition = (int) (input.getPosition() - dataSpec.position);
       }

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunkExtractor.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunkExtractor.java
@@ -48,6 +48,14 @@ public interface HlsMediaChunkExtractor {
    */
   boolean read(ExtractorInput extractorInput) throws IOException;
 
+  /**
+   * Notifies the extractor that a seek has occurred.
+   *
+   * @param position The byte offset in the stream from which data will be provided.
+   * @param timeUs The seek time in microseconds.
+   */
+  void seek(long position, long timeUs);
+
   /** Returns whether this is a packed audio extractor, as defined in RFC 8216, Section 3.4. */
   boolean isPackedAudioExtractor();
 


### PR DESCRIPTION
Fixes issue #7512.  Apple's i-Frame playlist is published as byte-range indexes into the main fMP4 segments.  

These byte ranges have the IDR sample required, but this results in a partial MDAT which leaves the `FragmentedMp4Extractor` in an unusable state for the next segment load.

The fix simply resets the Extractor by performing a vacuous `Extractor.seek()` operation.
