### PR TITLE
Compatible video coding with mpeg1video in Mp4Extractor

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/Atom.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/Atom.java
@@ -385,6 +385,9 @@ import java.util.List;
   @SuppressWarnings("ConstantCaseForConstants")
   public static final int TYPE_twos = 0x74776f73;
 
+  @SuppressWarnings("ConstantCaseForConstants")
+  public static final int TYPE__m1v = 0x6d317620;
+
   public final int type;
 
   public Atom(int type) {

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -869,7 +869,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
           || childAtomType == Atom.TYPE_dvav
           || childAtomType == Atom.TYPE_dva1
           || childAtomType == Atom.TYPE_dvhe
-          || childAtomType == Atom.TYPE_dvh1) {
+          || childAtomType == Atom.TYPE_dvh1
+          || childAtomType == Atom.TYPE__m1v) {
         parseVideoSampleEntry(stsd, childAtomType, childStartPosition, childAtomSize, trackId,
             rotationDegrees, drmInitData, out, i);
       } else if (childAtomType == Atom.TYPE_mp4a
@@ -1085,6 +1086,10 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
         }
       }
       childPosition += childAtomSize;
+    }
+
+    if (mimeType == null && atomType == Atom.TYPE__m1v) {
+      mimeType = MimeTypes.VIDEO_MPEG;
     }
 
     // If the media type was not recognized, ignore the track.


### PR DESCRIPTION
Hello, guy of developers. I found that it doesn't support mpeg1video in Mp4Extractor. Therefore, I add mpeg1video which name is m1v to make it compatible.

Here is the testing video:[https://drive.google.com/file/d/116_x0RwRYEAcCDnQyOlTHMHqPe67D3-J/view?usp=sharing](url)