### PR TITLE
text: Fix for garbage displayed at end of ssa subtitles

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -210,8 +210,11 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
   private void parseEventBody(ParsableByteArray data, List<List<Cue>> cues, List<Long> cueTimesUs) {
     @Nullable
     SsaDialogueFormat format = haveInitializationData ? dialogueFormatFromInitializationData : null;
-    @Nullable String currentLine;
-    while ((currentLine = data.readLine()) != null) {
+    String fullData = data.readNullTerminatedString();
+    String[] lines = fullData.split("\r|\n");
+    for (String currentLine : lines) {
+      if (currentLine.length() == 0) // ignore empty string between /r and /n
+        continue;
       if (currentLine.startsWith(FORMAT_LINE_PREFIX)) {
         format = SsaDialogueFormat.fromFormatLine(currentLine);
       } else if (currentLine.startsWith(DIALOGUE_LINE_PREFIX)) {


### PR DESCRIPTION
This occurs on some mkv files. The subtitles show perfectly in VLC player
and parole. These are files encoded from TS to mkv using HandbrakeCLI
v1.3.3.

The ssa text is terminated by a null (\x00). In these mkv files the null
is followed by zero to five bytes of random data. The random data is
showing on the screen as junk characters at the end of the subtitle
text. The solution is to change SsaDecoder to use readNullTerminatedString
instead of readLine.

Sample video:
https://www.filezzz.com/d/c6f1229633284d1388d21b18ca568230/SSA_subtitle_garbage_at_end.mkv/preview

Subtitle examples from above video as seen without this fix:
(Swallows pill) Yeah. 0vd
     You read it yet?
- Yeah, I started it. You? DTG1
- It's on my list of many
      things to do. �O_�