### PR TITLE
Manually set up the Widevine L3 Workaround

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
@@ -91,8 +91,12 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
    * @throws UnsupportedDrmException If the DRM scheme is unsupported or cannot be instantiated.
    */
   public static FrameworkMediaDrm newInstance(UUID uuid) throws UnsupportedDrmException {
+    return newInstance(uuid, false);
+  }
+
+  public static FrameworkMediaDrm newInstance(UUID uuid, Boolean forceWidevineL3) throws UnsupportedDrmException {
     try {
-      return new FrameworkMediaDrm(uuid);
+      return new FrameworkMediaDrm(uuid, forceWidevineL3);
     } catch (UnsupportedSchemeException e) {
       throw new UnsupportedDrmException(UnsupportedDrmException.REASON_UNSUPPORTED_SCHEME, e);
     } catch (Exception e) {
@@ -100,14 +104,14 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     }
   }
 
-  private FrameworkMediaDrm(UUID uuid) throws UnsupportedSchemeException {
+  private FrameworkMediaDrm(UUID uuid, Boolean forceWidevineL3) throws UnsupportedSchemeException {
     Assertions.checkNotNull(uuid);
     Assertions.checkArgument(!C.COMMON_PSSH_UUID.equals(uuid), "Use C.CLEARKEY_UUID instead");
     this.uuid = uuid;
     this.mediaDrm = new MediaDrm(adjustUuid(uuid));
     // Creators of an instance automatically acquire ownership of the created instance.
     referenceCount = 1;
-    if (C.WIDEVINE_UUID.equals(uuid) && needsForceWidevineL3Workaround()) {
+    if (C.WIDEVINE_UUID.equals(uuid) && (needsForceWidevineL3Workaround() || forceWidevineL3)) {
       forceWidevineL3(mediaDrm);
     }
   }

--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
@@ -64,6 +64,8 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
         }
       };
 
+  private static final String KEY_SECURITY_LEVEL = "securityLevel";
+
   private static final String CENC_SCHEME_MIME_TYPE = "cenc";
   private static final String MOCK_LA_URL_VALUE = "https://x";
   private static final String MOCK_LA_URL = "<LA_URL>" + MOCK_LA_URL_VALUE + "</LA_URL>";
@@ -296,7 +298,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     // Work around a bug prior to Lollipop where L1 Widevine forced into L3 mode would still
     // indicate that it required secure video decoders [Internal ref: b/11428937].
     boolean forceAllowInsecureDecoderComponents = Util.SDK_INT < 21
-        && C.WIDEVINE_UUID.equals(uuid) && "L3".equals(getPropertyString("securityLevel"));
+        && C.WIDEVINE_UUID.equals(uuid) && getSecurityLevel().equals("L3");
     return new FrameworkMediaCrypto(
         adjustUuid(uuid), initData, forceAllowInsecureDecoderComponents);
   }
@@ -420,7 +422,11 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
 
   @SuppressLint("WrongConstant") // Suppress spurious lint error [Internal ref: b/32137960]
   private static void forceWidevineL3(MediaDrm mediaDrm) {
-    mediaDrm.setPropertyString("securityLevel", "L3");
+    mediaDrm.setPropertyString(KEY_SECURITY_LEVEL, "L3");
+  }
+
+  public String getSecurityLevel() {
+    return getPropertyString(KEY_SECURITY_LEVEL);
   }
 
   /**


### PR DESCRIPTION
some content (possibly DRM based) gives an error. When securityLevel is manually set to L3, the player continues to play. I haven't a sample video