### PR TITLE
CEA-708 Decoder fixes for issue #1807

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/cea/Cea708Decoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/cea/Cea708Decoder.java
@@ -1226,18 +1226,18 @@ public final class Cea708Decoder extends CeaDecoder {
       //   |           |
       //   6-----7-----8
       @AnchorType int verticalAnchorType;
-      if (anchorId % 3 == 0) {
+      if (anchorId / 3 == 0) {
         verticalAnchorType = Cue.ANCHOR_TYPE_START;
-      } else if (anchorId % 3 == 1) {
+      } else if (anchorId / 3 == 1) {
         verticalAnchorType = Cue.ANCHOR_TYPE_MIDDLE;
       } else {
         verticalAnchorType = Cue.ANCHOR_TYPE_END;
       }
       // TODO: Add support for right-to-left languages (i.e. where start is on the right).
       @AnchorType int horizontalAnchorType;
-      if (anchorId / 3 == 0) {
+      if (anchorId % 3 == 0) {
         horizontalAnchorType = Cue.ANCHOR_TYPE_START;
-      } else if (anchorId / 3 == 1) {
+      } else if (anchorId % 3 == 1) {
         horizontalAnchorType = Cue.ANCHOR_TYPE_MIDDLE;
       } else {
         horizontalAnchorType = Cue.ANCHOR_TYPE_END;


### PR DESCRIPTION
Fixed the verticalAnchorType and horizontalAnchorType calculation

The anchorID 0, 1 and 2 should correspond to verticalAnchorType=ANCHOR_TYPE_START, anchorID 3, 4 and 5 is ANCHOR_TYPE_MIDDLE, anchorID 6, 7 and 8 is ANCHOR_TYPE_END

The anchorID 0, 3 and 6 should correspond to horizzonatlAnchor=ANCHOR_TYPE_START, anchorID 1, 4, 7 is ANCHOR_TYPE_MIDDLE, anchorID 2, 5 and 8 is ANCHOR_TYPE_END