### PR TITLE
Update media.exolist.json Reslove playready test stream can't play's issue

### DIFF
--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -238,7 +238,9 @@
       {
         "name": "Super speed (PlayReady)",
         "uri": "https://playready.directtaps.net/smoothstreaming/SSWSS720H264PR/SuperSpeedway_720.ism/Manifest",
-        "drm_scheme": "playready"
+        "drm_scheme": "playready",
+        "drm_license_uri": "https://playready.directtaps.net/pr/svc/rightsmanager.asmx",
+        "drm_force_default_license_uri": true
       }
     ]
   },


### PR DESCRIPTION
Add Super speed(Playready) Test Stream's KeyUrl and
force use the key url to sure exoplayer can play this
est stream.