### PR TITLE
Initialize Format.codecs from AVC SPS NAL unit (#8393)

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/video/AvcConfig.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/video/AvcConfig.java
@@ -15,6 +15,7 @@
  */
 package com.google.android.exoplayer2.video;
 
+import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.ParserException;
 import com.google.android.exoplayer2.util.CodecSpecificDataUtil;
@@ -34,13 +35,14 @@ public final class AvcConfig {
   public final int width;
   public final int height;
   public final float pixelWidthAspectRatio;
+  @Nullable public final String codecs;
 
   /**
    * Parses AVC configuration data.
    *
    * @param data A {@link ParsableByteArray}, whose position is set to the start of the AVC
    *     configuration data to parse.
-   * @return A parsed representation of the HEVC configuration data.
+   * @return A parsed representation of the AVC configuration data.
    * @throws ParserException If an error occurred parsing the data.
    */
   public static AvcConfig parse(ParsableByteArray data) throws ParserException {
@@ -63,6 +65,7 @@ public final class AvcConfig {
       int width = Format.NO_VALUE;
       int height = Format.NO_VALUE;
       float pixelWidthAspectRatio = 1;
+      @Nullable String codecs = null;
       if (numSequenceParameterSets > 0) {
         byte[] sps = initializationData.get(0);
         SpsData spsData = NalUnitUtil.parseSpsNalUnit(initializationData.get(0),
@@ -70,21 +73,24 @@ public final class AvcConfig {
         width = spsData.width;
         height = spsData.height;
         pixelWidthAspectRatio = spsData.pixelWidthAspectRatio;
+        codecs = CodecSpecificDataUtil.buildAvcCodecString(spsData.profileIdc, spsData.constraintsFlagsAndReservedZero2Bits, spsData.levelIdc);
       }
+
       return new AvcConfig(initializationData, nalUnitLengthFieldLength, width, height,
-          pixelWidthAspectRatio);
+          pixelWidthAspectRatio, codecs);
     } catch (ArrayIndexOutOfBoundsException e) {
       throw new ParserException("Error parsing AVC config", e);
     }
   }
 
   private AvcConfig(List<byte[]> initializationData, int nalUnitLengthFieldLength,
-      int width, int height, float pixelWidthAspectRatio) {
+      int width, int height, float pixelWidthAspectRatio, @Nullable String codecs) {
     this.initializationData = initializationData;
     this.nalUnitLengthFieldLength = nalUnitLengthFieldLength;
     this.width = width;
     this.height = height;
     this.pixelWidthAspectRatio = pixelWidthAspectRatio;
+    this.codecs = codecs;
   }
 
   private static byte[] buildNalUnitForChild(ParsableByteArray data) {

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/flv/VideoTagPayloadReader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/flv/VideoTagPayloadReader.java
@@ -93,6 +93,7 @@ import com.google.android.exoplayer2.video.AvcConfig;
       Format format =
           new Format.Builder()
               .setSampleMimeType(MimeTypes.VIDEO_H264)
+              .setCodecs(avcConfig.codecs)
               .setWidth(avcConfig.width)
               .setHeight(avcConfig.height)
               .setPixelWidthHeightRatio(avcConfig.pixelWidthAspectRatio)

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mkv/MatroskaExtractor.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mkv/MatroskaExtractor.java
@@ -2086,6 +2086,7 @@ public class MatroskaExtractor implements Extractor {
           AvcConfig avcConfig = AvcConfig.parse(new ParsableByteArray(getCodecPrivate(codecId)));
           initializationData = avcConfig.initializationData;
           nalUnitLengthFieldLength = avcConfig.nalUnitLengthFieldLength;
+          codecs = avcConfig.codecs;
           break;
         case CODEC_ID_H265:
           mimeType = MimeTypes.VIDEO_H265;

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -1058,6 +1058,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
         if (!pixelWidthHeightRatioFromPasp) {
           pixelWidthHeightRatio = avcConfig.pixelWidthAspectRatio;
         }
+        codecs = avcConfig.codecs;
       } else if (childAtomType == Atom.TYPE_hvcC) {
         Assertions.checkState(mimeType == null);
         mimeType = MimeTypes.VIDEO_H265;


### PR DESCRIPTION
This will allow ExoPlayer to check if video track's profile
and level are supported by decoder when playing progressive media sources.

Also fix typo in AvcConfig.