### PR TITLE
Add SessionPlayer#movePlaylistItem(int, int) support

### DIFF
--- a/extensions/media2/src/main/java/com/google/android/exoplayer2/ext/media2/PlayerCommandQueue.java
+++ b/extensions/media2/src/main/java/com/google/android/exoplayer2/ext/media2/PlayerCommandQueue.java
@@ -97,6 +97,8 @@ import java.util.concurrent.Callable;
   /** Command code for {@link SessionPlayer#removePlaylistItem(int)} */
   public static final int COMMAND_CODE_PLAYER_REMOVE_PLAYLIST_ITEM = 16;
 
+  /** Command code for {@link SessionPlayer#movePlaylistItem(int, int)} */
+  public static final int COMMAND_CODE_PLAYER_MOVE_PLAYLIST_ITEM = 17;
   /** List of session commands whose result would be set after the command is finished. */
   @Documented
   @Retention(RetentionPolicy.SOURCE)
@@ -119,6 +121,7 @@ import java.util.concurrent.Callable;
         COMMAND_CODE_PLAYER_SET_PLAYLIST,
         COMMAND_CODE_PLAYER_ADD_PLAYLIST_ITEM,
         COMMAND_CODE_PLAYER_REMOVE_PLAYLIST_ITEM,
+        COMMAND_CODE_PLAYER_MOVE_PLAYLIST_ITEM,
       })
   public @interface CommandCode {}
 

--- a/extensions/media2/src/main/java/com/google/android/exoplayer2/ext/media2/PlayerWrapper.java
+++ b/extensions/media2/src/main/java/com/google/android/exoplayer2/ext/media2/PlayerWrapper.java
@@ -223,6 +223,18 @@ import java.util.List;
     return true;
   }
 
+  public boolean movePlaylistItem(@IntRange(from = 0) int fromIndex, @IntRange(from = 0) int toIndex) {
+    int itemCount = player.getMediaItemCount();
+    if (!(fromIndex < itemCount && toIndex < itemCount)) {
+      return false;
+    }
+    if (fromIndex == toIndex) {
+      return true;
+    }
+    player.moveMediaItem(fromIndex, toIndex);
+    return true;
+  }
+
   public boolean skipToPreviousPlaylistItem() {
     Timeline timeline = player.getCurrentTimeline();
     Assertions.checkState(!timeline.isEmpty());

--- a/extensions/media2/src/main/java/com/google/android/exoplayer2/ext/media2/SessionCallback.java
+++ b/extensions/media2/src/main/java/com/google/android/exoplayer2/ext/media2/SessionCallback.java
@@ -226,7 +226,7 @@ import java.util.concurrent.TimeoutException;
       build = new SessionCommandGroup.Builder();
     }
 
-    build.addAllPredefinedCommands(SessionCommand.COMMAND_VERSION_1);
+    build.addAllPredefinedCommands(SessionCommand.COMMAND_VERSION_2);
     // TODO(internal b/142848015): Use removeCommand(int) when it's added.
     if (mediaItemProvider == null) {
       build.removeCommand(new SessionCommand(SessionCommand.COMMAND_CODE_PLAYER_SET_MEDIA_ITEM));
@@ -234,6 +234,7 @@ import java.util.concurrent.TimeoutException;
       build.removeCommand(new SessionCommand(SessionCommand.COMMAND_CODE_PLAYER_ADD_PLAYLIST_ITEM));
       build.removeCommand(
           new SessionCommand(SessionCommand.COMMAND_CODE_PLAYER_REPLACE_PLAYLIST_ITEM));
+      build.removeCommand(new SessionCommand(SessionCommand.COMMAND_CODE_PLAYER_MOVE_PLAYLIST_ITEM));
     }
     if (ratingCallback == null) {
       build.removeCommand(new SessionCommand(SessionCommand.COMMAND_CODE_SESSION_SET_RATING));

--- a/extensions/media2/src/main/java/com/google/android/exoplayer2/ext/media2/SessionPlayerConnector.java
+++ b/extensions/media2/src/main/java/com/google/android/exoplayer2/ext/media2/SessionPlayerConnector.java
@@ -325,6 +325,17 @@ public final class SessionPlayerConnector extends SessionPlayer {
   }
 
   @Override
+  public ListenableFuture<PlayerResult> movePlaylistItem(int fromIndex, int toIndex) {
+    Assertions.checkArgument(fromIndex >= 0);
+    Assertions.checkArgument(toIndex >= 0);
+    ListenableFuture<PlayerResult> result =
+        playerCommandQueue.addCommand(
+            PlayerCommandQueue.COMMAND_CODE_PLAYER_MOVE_PLAYLIST_ITEM,
+            /* command= */ () -> player.movePlaylistItem(fromIndex, toIndex));
+    return result;
+  }
+
+  @Override
   public ListenableFuture<PlayerResult> skipToPreviousPlaylistItem() {
     ListenableFuture<PlayerResult> result =
         playerCommandQueue.addCommand(


### PR DESCRIPTION
Closes #8410.

This pull request adds the [`SessionPlayer.movePlaylistItem()`](https://developer.android.com/reference/androidx/media2/common/SessionPlayer?hl=ja#movePlaylistItem(int,%20int)) method implementation which has been introduced to media2 v1.1.0. 