### PR TITLE
Improved generic exception "Error reading non-2xx response body" 

### DIFF
--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
@@ -304,13 +304,13 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
 
     // Check for a valid response code.
     if (!response.isSuccessful()) {
-      Map<String, List<String>> headers = response.headers().toMultimap();
       byte[] errorResponseBody;
       try {
         errorResponseBody = Util.toByteArray(Assertions.checkNotNull(responseByteStream));
       } catch (IOException e) {
         errorResponseBody = Util.EMPTY_BYTE_ARRAY;
       }
+      Map<String, List<String>> headers = response.headers().toMultimap();
       closeConnectionQuietly();
       InvalidResponseCodeException exception =
           new InvalidResponseCodeException(

--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
@@ -304,14 +304,14 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
 
     // Check for a valid response code.
     if (!response.isSuccessful()) {
+      Map<String, List<String>> headers = response.headers().toMultimap();
       byte[] errorResponseBody;
       try {
         errorResponseBody = Util.toByteArray(Assertions.checkNotNull(responseByteStream));
       } catch (IOException e) {
-        throw new HttpDataSourceException(
-            "Error reading non-2xx response body", e, dataSpec, HttpDataSourceException.TYPE_OPEN);
+        throw new InvalidResponseCodeException(
+            responseCode, response.message(), headers, dataSpec, null);
       }
-      Map<String, List<String>> headers = response.headers().toMultimap();
       closeConnectionQuietly();
       InvalidResponseCodeException exception =
           new InvalidResponseCodeException(

--- a/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
+++ b/extensions/okhttp/src/main/java/com/google/android/exoplayer2/ext/okhttp/OkHttpDataSource.java
@@ -309,8 +309,7 @@ public class OkHttpDataSource extends BaseDataSource implements HttpDataSource {
       try {
         errorResponseBody = Util.toByteArray(Assertions.checkNotNull(responseByteStream));
       } catch (IOException e) {
-        throw new InvalidResponseCodeException(
-            responseCode, response.message(), headers, dataSpec, null);
+        errorResponseBody = Util.EMPTY_BYTE_ARRAY;
       }
       closeConnectionQuietly();
       InvalidResponseCodeException exception =

--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
@@ -369,8 +369,7 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
     }
 
     // Check for a valid response code.
-    if (responseCode < 200 || responseCode > 299) {
-      Map<String, List<String>> headers = connection.getHeaderFields();
+    if (responseCode < 200 || responseCode > 299) {      
       @Nullable InputStream errorStream = connection.getErrorStream();
       byte[] errorResponseBody;
       try {
@@ -379,6 +378,7 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
       } catch (IOException e) {
         errorResponseBody = Util.EMPTY_BYTE_ARRAY;
       }
+      Map<String, List<String>> headers = connection.getHeaderFields();
       closeConnectionQuietly();
       InvalidResponseCodeException exception =
           new InvalidResponseCodeException(

--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
@@ -378,7 +378,7 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
             errorStream != null ? Util.toByteArray(errorStream) : Util.EMPTY_BYTE_ARRAY;
       } catch (IOException e) {
         throw new InvalidResponseCodeException(
-              responseCode, responseMessage, headers, dataSpec, null);
+            responseCode, responseMessage, headers, dataSpec, null);
       }
       closeConnectionQuietly();
       InvalidResponseCodeException exception =

--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
@@ -377,8 +377,8 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
         errorResponseBody =
             errorStream != null ? Util.toByteArray(errorStream) : Util.EMPTY_BYTE_ARRAY;
       } catch (IOException e) {
-        throw new HttpDataSourceException(
-            "Error reading non-2xx response body", e, dataSpec, HttpDataSourceException.TYPE_OPEN);
+        throw new InvalidResponseCodeException(
+              responseCode, responseMessage, headers, dataSpec, null);
       }
       closeConnectionQuietly();
       InvalidResponseCodeException exception =

--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultHttpDataSource.java
@@ -377,8 +377,7 @@ public class DefaultHttpDataSource extends BaseDataSource implements HttpDataSou
         errorResponseBody =
             errorStream != null ? Util.toByteArray(errorStream) : Util.EMPTY_BYTE_ARRAY;
       } catch (IOException e) {
-        throw new InvalidResponseCodeException(
-            responseCode, responseMessage, headers, dataSpec, null);
+        errorResponseBody = Util.EMPTY_BYTE_ARRAY;
       }
       closeConnectionQuietly();
       InvalidResponseCodeException exception =


### PR DESCRIPTION
This will allow the **onPlayerError** method to get the response http status code, message and headers also when there is an error getting the **errorResponseBody**