### PR TITLE
Fix VP9 on Android M and below by advertising profile level

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecInfo.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecInfo.java
@@ -47,7 +47,6 @@ import com.google.android.exoplayer2.util.Assertions;
 import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.MimeTypes;
 import com.google.android.exoplayer2.util.Util;
-import java.util.ArrayList;
 
 /** Information about a {@link MediaCodec} for a given mime type. */
 @SuppressWarnings("InlinedApi")
@@ -301,10 +300,10 @@ public final class MediaCodecInfo {
     }
 
     CodecProfileLevel[] codecProfileLevels = getProfileLevels();
-    if (MimeTypes.VIDEO_VP9.equals(mimeType) &&
-        Util.SDK_INT <= 23 &&
-        codecProfileLevels.length == 0 &&
-        capabilities != null) {
+    if (MimeTypes.VIDEO_VP9.equals(mimeType)
+        && Util.SDK_INT <= 23
+        && codecProfileLevels.length == 0
+        && capabilities != null) {
       codecProfileLevels = getVp9CodecProfileLevelsV23(capabilities);
     }
 


### PR DESCRIPTION
On Android M and below, VP9 codecCapabilities do not advertise profile level support. In this case, estimate the level from MediaCodecInfo.VideoCapabilities instead. https://developer.android.com/reference/android/media/MediaCodecInfo.CodecProfileLevel.html

This change is ported from chromium media: https://chromium.googlesource.com/chromium/src/media/+/master/base/android/java/src/org/chromium/media/MediaCodecUtil.java#296