### PR TITLE
Add support for SSA (V4+) PrimaryColour style

### DIFF
--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -507,6 +507,13 @@
         "subtitle_language": "en"
       },
       {
+        "name": "SubStation Alpha colors",
+        "uri": "https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-avc-baseline-480.mp4",
+        "subtitle_uri": "https://drive.google.com/uc?export=download&id=13EdW4Qru-vQerUlwS_Ht5Cely_Tn0tQe",
+        "subtitle_mime_type": "text/x-ssa",
+        "subtitle_language": "en"
+      },
+      {
         "name": "MPEG-4 Timed Text",
         "uri": "https://storage.googleapis.com/exoplayer-test-media-1/mp4/dizzy-with-tx3g.mp4"
       }

--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -507,13 +507,6 @@
         "subtitle_language": "en"
       },
       {
-        "name": "SubStation Alpha colors",
-        "uri": "https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-avc-baseline-480.mp4",
-        "subtitle_uri": "https://drive.google.com/uc?export=download&id=13EdW4Qru-vQerUlwS_Ht5Cely_Tn0tQe",
-        "subtitle_mime_type": "text/x-ssa",
-        "subtitle_language": "en"
-      },
-      {
         "name": "MPEG-4 Timed Text",
         "uri": "https://storage.googleapis.com/exoplayer-test-media-1/mp4/dizzy-with-tx3g.mp4"
       }

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -19,6 +19,8 @@ import static com.google.android.exoplayer2.text.Cue.LINE_TYPE_FRACTION;
 import static com.google.android.exoplayer2.util.Util.castNonNull;
 
 import android.text.Layout;
+import android.text.SpannableString;
+import android.text.style.ForegroundColorSpan;
 import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.text.Cue;
@@ -301,8 +303,17 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
       SsaStyle.Overrides styleOverrides,
       float screenWidth,
       float screenHeight) {
-    Cue.Builder cue = new Cue.Builder().setText(text);
+    SpannableString spannableText = new SpannableString(text);
+    Cue.Builder cue = new Cue.Builder().setText(spannableText);
 
+    // Apply primary color.
+    if (style != null) {
+      if (style.primaryColor != SsaStyle.SSA_COLOR_UNKNOWN) {
+        spannableText.setSpan(new ForegroundColorSpan(style.primaryColor),
+            0, spannableText.length(), SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);
+      }
+    }
+    // Apply alignment.
     @SsaStyle.SsaAlignment int alignment;
     if (styleOverrides.alignment != SsaStyle.SSA_ALIGNMENT_UNKNOWN) {
       alignment = styleOverrides.alignment;

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -308,8 +308,8 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
 
     // Apply primary color.
     if (style != null) {
-      if (style.primaryColor != SsaStyle.SSA_COLOR_UNKNOWN) {
-        spannableText.setSpan(new ForegroundColorSpan(style.primaryColor),
+      if (style.primaryColor.isSet) {
+        spannableText.setSpan(new ForegroundColorSpan(style.primaryColor.value),
             0, spannableText.length(), SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);
       }
     }

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -308,8 +308,8 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
 
     // Apply primary color.
     if (style != null) {
-      if (style.primaryColor.isSet) {
-        spannableText.setSpan(new ForegroundColorSpan(style.primaryColor.value),
+      if (style.primaryColor.isSet()) {
+        spannableText.setSpan(new ForegroundColorSpan(style.primaryColor.getColor()),
             0, spannableText.length(), SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);
       }
     }

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
@@ -31,6 +31,7 @@ import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.Util;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
+import java.util.NoSuchElementException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -166,12 +167,23 @@ import java.util.regex.Pattern;
 
     public static SsaColor UNSET = new SsaColor(0, false);
 
-    public final @ColorInt int value;
-    public final boolean isSet;
+    private final @ColorInt int color;
+    private final boolean isSet;
 
-    private SsaColor(@ColorInt int value, boolean isSet) {
-      this.value = value;
+    private SsaColor(@ColorInt int color, boolean isSet) {
+      this.color = color;
       this.isSet = isSet;
+    }
+
+    public @ColorInt int getColor() {
+      if (!isSet) {
+        throw new NoSuchElementException("No color is present");
+      }
+      return color;
+    }
+
+    public boolean isSet() {
+      return isSet;
     }
 
     public static SsaColor from(@ColorInt int value) {

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
@@ -89,9 +89,9 @@ import java.util.regex.Pattern;
 
   public final String name;
   @SsaAlignment public final int alignment;
-  @ColorInt public int primaryColor;
+  public SsaColor primaryColor;
 
-  private SsaStyle(String name, @SsaAlignment int alignment, @ColorInt int primaryColor) {
+  private SsaStyle(String name, @SsaAlignment int alignment, SsaColor primaryColor) {
     this.name = name;
     this.alignment = alignment;
     this.primaryColor = primaryColor;
@@ -152,14 +152,33 @@ import java.util.regex.Pattern;
     }
   }
 
-  @ColorInt
-  private static int parsePrimaryColor(String primaryColorStr) {
+  private static SsaColor parsePrimaryColor(String primaryColorStr) {
     try {
-      return ColorParser.parseSsaColor(primaryColorStr);
+      return SsaColor.from(ColorParser.parseSsaColor(primaryColorStr.trim()));
     } catch (IllegalArgumentException ex) {
       Log.w(TAG, "Failed parsing color value: " + primaryColorStr);
     }
-    return SSA_COLOR_UNKNOWN;
+    return SsaColor.UNSET;
+  }
+
+  /**
+   * Represents an SSA V4+ style color in ARGB format.
+   */
+  /* package */ static final class SsaColor {
+
+    public static SsaColor UNSET = new SsaColor(0, false);
+
+    public final @ColorInt int value;
+    public final boolean isSet;
+
+    private SsaColor(@ColorInt int value, boolean isSet) {
+      this.value = value;
+      this.isSet = isSet;
+    }
+
+    public static SsaColor from(@ColorInt int value) {
+      return new SsaColor(value, true);
+    }
   }
 
   /**

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
@@ -85,8 +85,6 @@ import java.util.regex.Pattern;
   public static final int SSA_ALIGNMENT_TOP_CENTER = 8;
   public static final int SSA_ALIGNMENT_TOP_RIGHT = 9;
 
-  public static final int SSA_COLOR_UNKNOWN = -1;
-
   public final String name;
   @SsaAlignment public final int alignment;
   public SsaColor primaryColor;

--- a/library/core/src/main/java/com/google/android/exoplayer2/util/ColorParser.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/ColorParser.java
@@ -67,6 +67,27 @@ public final class ColorParser {
     return parseColorInternal(colorExpression, true);
   }
 
+  /**
+   * Parses a SSA V4+ color expression.
+   *
+   * @param colorExpression The color expression.
+   * @return The parsed ARGB color.
+   */
+  @ColorInt
+  public static int parseSsaColor(String colorExpression) {
+    // SSA V4+ color format is &HAABBGGRR.
+    if (colorExpression.length() != 10 || !"&H".equals(colorExpression.substring(0, 2))) {
+      throw new IllegalArgumentException();
+    }
+    // Convert &HAABBGGRR to #RRGGBBAA.
+    String rgba = new StringBuilder()
+        .append(colorExpression.substring(2))
+        .append("#")
+        .reverse()
+        .toString();
+    return parseColorInternal(rgba, true);
+  }
+
   @ColorInt
   private static int parseColorInternal(String colorExpression, boolean alphaHasFloatFormat) {
     Assertions.checkArgument(!TextUtils.isEmpty(colorExpression));

--- a/library/core/src/main/java/com/google/android/exoplayer2/util/ColorParser.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/util/ColorParser.java
@@ -90,7 +90,7 @@ public final class ColorParser {
             rgbaStringBuilder.insert(2, "0");
           }
         }
-        abgr = (int) Long.parseLong(colorExpression.substring(2), 16);
+        abgr = (int) Long.parseLong(rgbaStringBuilder.substring(2), 16);
       } else {
         // Parse color from decimal format (bytes order AABBGGRR).
         abgr = (int) Long.parseLong(colorExpression);

--- a/library/core/src/test/java/com/google/android/exoplayer2/util/ColorParserTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/util/ColorParserTest.java
@@ -18,8 +18,10 @@ package com.google.android.exoplayer2.util;
 import static android.graphics.Color.BLACK;
 import static android.graphics.Color.RED;
 import static android.graphics.Color.WHITE;
+import static android.graphics.Color.YELLOW;
 import static android.graphics.Color.argb;
 import static android.graphics.Color.parseColor;
+import static com.google.android.exoplayer2.util.ColorParser.parseSsaColor;
 import static com.google.android.exoplayer2.util.ColorParser.parseTtmlColor;
 import static com.google.common.truth.Truth.assertThat;
 
@@ -64,6 +66,9 @@ public final class ColorParserTest {
     // Hex colors in ColorParser are RGBA, where-as {@link Color#parseColor} takes ARGB.
     assertThat(parseTtmlColor("#FFFFFF00")).isEqualTo(parseColor("#00FFFFFF"));
     assertThat(parseTtmlColor("#12345678")).isEqualTo(parseColor("#78123456"));
+    // SSA colors are in &HAABBGGRR format.
+    assertThat(parseSsaColor("&HFF0000FF")).isEqualTo(RED);
+    assertThat(parseSsaColor("&HFF00FFFF")).isEqualTo(YELLOW);
   }
 
   @Test

--- a/library/core/src/test/java/com/google/android/exoplayer2/util/ColorParserTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/util/ColorParserTest.java
@@ -16,6 +16,8 @@
 package com.google.android.exoplayer2.util;
 
 import static android.graphics.Color.BLACK;
+import static android.graphics.Color.BLUE;
+import static android.graphics.Color.GREEN;
 import static android.graphics.Color.RED;
 import static android.graphics.Color.WHITE;
 import static android.graphics.Color.YELLOW;
@@ -66,9 +68,21 @@ public final class ColorParserTest {
     // Hex colors in ColorParser are RGBA, where-as {@link Color#parseColor} takes ARGB.
     assertThat(parseTtmlColor("#FFFFFF00")).isEqualTo(parseColor("#00FFFFFF"));
     assertThat(parseTtmlColor("#12345678")).isEqualTo(parseColor("#78123456"));
-    // SSA colors are in &HAABBGGRR format.
-    assertThat(parseSsaColor("&HFF0000FF")).isEqualTo(RED);
-    assertThat(parseSsaColor("&HFF00FFFF")).isEqualTo(YELLOW);
+  }
+
+  @Test
+  public void ssaColorParsing() {
+    // Hex format (&HAABBGGRR).
+    assertThat(parseSsaColor("&H000000FF")).isEqualTo(RED);
+    assertThat(parseSsaColor("&H0000FFFF")).isEqualTo(YELLOW);
+    assertThat(parseSsaColor("&H400000FF")).isEqualTo(parseColor("#BFFF0000"));
+    // Leading zeros.
+    assertThat(parseSsaColor("&HFF")).isEqualTo(RED);
+    assertThat(parseSsaColor("&HFF00")).isEqualTo(GREEN);
+    assertThat(parseSsaColor("&HFF0000")).isEqualTo(BLUE);
+    // Decimal format (AABBGGRR byte order).
+    assertThat(parseSsaColor(/*#000000FF*/"255")).isEqualTo(parseColor("#FFFF0000"));
+    assertThat(parseSsaColor(/*#FF0000FF*/"4278190335")).isEqualTo(parseColor("#00FF0000"));
   }
 
   @Test

--- a/testdata/src/test/assets/media/ssa/colors
+++ b/testdata/src/test/assets/media/ssa/colors
@@ -1,0 +1,24 @@
+[Script Info]
+Title: Coloring
+Script Type: V4.00+
+PlayResX: 1280
+PlayResY: 720
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: PrimaryColourStyleHexRed        ,Roboto,50,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2,50,50,70,1
+Style: PrimaryColourStyleHexYellow     ,Roboto,50,&H0000FFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2,50,50,70,1
+Style: PrimaryColourStyleHexGreen      ,Roboto,50,&HFF00    ,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2,50,50,70,1
+Style: PrimaryColourStyleHexAlpha      ,Roboto,50,&H400000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2,50,50,70,1
+Style: PrimaryColourStyleDecimal       ,Roboto,50,16711680  ,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2,50,50,70,1
+Style: PrimaryColourStyleDecimalAlpha  ,Roboto,50,2164195328,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2,50,50,70,1
+
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:00.95,0:00:03.11,PrimaryColourStyleHexRed         ,Arnold,0,0,0,,First line in RED (&H000000FF).
+Dialogue: 0,0:00:04.50,0:00:07.50,PrimaryColourStyleHexYellow      ,Arnold,0,0,0,,Second line in YELLOW (&H0000FFFF).
+Dialogue: 0,0:00:08.50,0:00:11.50,PrimaryColourStyleHexGreen       ,Arnold,0,0,0,,Third line in GREEN (leading zeros &HFF00).
+Dialogue: 0,0:00:12.50,0:00:15.50,PrimaryColourStyleHexAlpha       ,Arnold,0,0,0,,Fourth line in RED with alpha (&H400000FF).
+Dialogue: 0,0:00:16.50,0:00:19.50,PrimaryColourStyleDecimal        ,Arnold,0,0,0,,Fifth line in BLUE (16711680).
+Dialogue: 0,0:00:20.70,0:00:23.00,PrimaryColourStyleDecimalAlpha   ,Arnold,0,0,0,,Sixth line in BLUE with alpha (2164195328).


### PR DESCRIPTION
@icbaker This is an initial PR for SSA (V4+) PrimaryColour style.

A question in general, just to make sure we start this style support in the right way:

- Parsing of the style attributes should be done in the `SsaStyle` so then this class will have all the styles prepared to be used directly from the `SsaDecoder`, or the `SsaStyle` should be just a holder and the parsing needs to be done on the decoder side?

Open point:
- Not sure what is the code of the the primary colour style **override**, as the spec on this from [Matroska](http://moodub.free.fr/video/ass-specs.doc) is pretty confusing, and it is not aligned with [this](https://fileformats.fandom.com/wiki/SubStation_Alpha) other spec. I'll try to figure it out by taking VLC for reference.