### PR TITLE
Explicitly remove peeked event from queue

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/ListenerSet.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/ListenerSet.java
@@ -201,9 +201,12 @@ public final class ListenerSet<T, E extends MutableFlags> {
       // Recursive call to flush. Let the outer call handle the flush queue.
       return;
     }
-    while (!flushingEvents.isEmpty()) {
-      flushingEvents.peekFirst().run();
-      flushingEvents.removeFirst();
+
+    Runnable event;
+    while ((event = flushingEvents.peekFirst()) != null) {
+      if (flushingEvents.removeFirstOccurrence(event)) {
+        event.run();
+      }
     }
   }
 


### PR DESCRIPTION
`removeFirst` will throw an exception if the queue is empty. Since the `flushEvents` method does not use any synchronization guards, it is possible for multiple events to occur concurrently that both cause `flushEvents` to be called. In the current version of ExoPlayer, I have sen this cause a `NoSuchElement` exception (at least this is what it looked like when de-obfuscating a stack trace):

```
Uncaught Exception
java.util.NoSuchElementException: null
	at java.util.ArrayDeque.removeFirst(ArrayDeque.java:248) ~[na:0.0]
	at com.google.android.exoplayer2.ExoPlayerImpl.notifyListeners() ~[na:0.0]
	at com.google.android.exoplayer2.ExoPlayerImpl.updatePlaybackInfo() ~[na:0.0]
	at com.google.android.exoplayer2.ExoPlayerImpl.handlePlaybackInfo() ~[na:0.0]
	at com.google.android.exoplayer2.ExoPlayerImpl.lambda$new$0() ~[na:0.0]
	at com.google.android.exoplayer2.ExoPlayerImpl.lambda$new$0$ExoPlayerImpl() ~[na:0.0]
	at com.google.android.exoplayer2.$$Lambda$ExoPlayerImpl$Krt_XK5S7OaAWWQo8WMLuiuwNGE.run() ~[na:0.0]
	at android.os.Handler.handleCallback(Handler.java:739) ~[na:0.0]
	at android.os.Handler.dispatchMessage(Handler.java:95) ~[na:0.0]
	at android.os.Looper.loop(Looper.java:135) ~[na:0.0]
	at android.os.HandlerThread.run(HandlerThread.java:61) ~[na:0.0]
```

By removing the peaked element explicitly, and only running the event if it is removed, some concurrency is added to the method, although a `ConcurrentQueue` would be even safer.