### PR TITLE
Add missing resource ids from StyledPlayerControlView

### DIFF
--- a/library/ui/src/main/res/values/ids.xml
+++ b/library/ui/src/main/res/values/ids.xml
@@ -34,6 +34,7 @@
   <item name="exo_repeat_toggle" type="id"/>
   <item name="exo_duration" type="id"/>
   <item name="exo_position" type="id"/>
+  <item name="exo_settings" type="id"/>
   <item name="exo_progress_placeholder" type="id"/>
   <item name="exo_progress" type="id"/>
   <item name="exo_buffering" type="id"/>
@@ -41,4 +42,16 @@
   <item name="exo_vr" type="id"/>
   <item name="exo_subtitle" type="id"/>
   <item name="exo_fullscreen" type="id"/>
+  <item name="exo_center_view" type="id"/>
+  <item name="exo_embedded_transport_controls" type="id"/>
+  <item name="exo_minimal_controls" type="id"/>
+  <item name="exo_bottom_bar" type="id"/>
+  <item name="exo_time" type="id"/>
+  <item name="exo_basic_controls" type="id"/>
+  <item name="exo_extra_controls" type="id"/>
+  <item name="exo_extra_controls_scroll_view" type="id"/>
+  <item name="exo_overflow_show" type="id"/>
+  <item name="exo_overflow_hide" type="id"/>
+  <item name="exo_rew_with_amount" type="id"/>
+  <item name="exo_ffwd_with_amount" type="id"/>
 </resources>


### PR DESCRIPTION
App crashes when specifying a custom control layout for StyledPlayerView when proguard minification is enabled and not all controls are present.  Example:
```
 Caused by: java.lang.NoSuchFieldError: No static field exo_settings of type I in class Lb/k/a/b/c2/g0; or its superclasses (declaration of 'b.k.a.b.c2.g0' appears in /data/app/com.butterflynetinc.helios.release-ERbjRDQ2lI-pNgy7B5rzdg==/base.apk)
    at b.k.a.b.c2.o0.<init>(StyledPlayerControlView.java:61)
    at com.google.android.exoplayer2.ui.StyledPlayerView.<init>(StyledPlayerView.java:86)
    at java.lang.reflect.Constructor.newInstance0(Native Method) 
    at java.lang.reflect.Constructor.newInstance(Constructor.java:343) 
    at android.view.LayoutInflater.createView(LayoutInflater.java:854) 
    at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:1006) 
    at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:961) 
    at android.view.LayoutInflater.rInflate(LayoutInflater.java:1123) 
    at android.view.LayoutInflater.inflate(LayoutInflater.java:656) 
    at android.view.LayoutInflater.inflate(LayoutInflater.java:534) 
```
The proposed fix is to declare all control view IDs in `ids.xml`, which seems to be what was done previously for `PlayerControlView`.

**Disclaimer:** I didn't test this.  I simply made similar changes in our own app's `ids.xml` as a workaround for now.