### PR TITLE
let evictor change cache max bytes

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/cache/LeastRecentlyUsedCacheEvictor.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/cache/LeastRecentlyUsedCacheEvictor.java
@@ -21,7 +21,7 @@ import java.util.TreeSet;
 /** Evicts least recently used cache files first. */
 public final class LeastRecentlyUsedCacheEvictor implements CacheEvictor {
 
-  private final long maxBytes;
+  private long maxBytes;
   private final TreeSet<CacheSpan> leastRecentlyUsed;
 
   private long currentSize;
@@ -80,5 +80,10 @@ public final class LeastRecentlyUsedCacheEvictor implements CacheEvictor {
       return lhs.compareTo(rhs);
     }
     return lhs.lastTouchTimestamp < rhs.lastTouchTimestamp ? -1 : 1;
+  }
+
+  public void changeMaxBytes(Cache cache, long maxBytes) {
+    this.maxBytes = maxBytes;
+    evictCache(cache, 0);
   }
 }


### PR DESCRIPTION
This PR lets the app's users change cache size at runtime. Also it lets applications to decrease cache size when low storage space is detected.