### PR TITLE
Detect external surround sound on Xiaomi devices

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
@@ -155,6 +155,7 @@ public final class AudioCapabilities {
   }
 
   private static boolean deviceMaySetExternalSurroundSoundGlobalSetting() {
-    return Util.SDK_INT >= 17 && "Amazon".equals(Util.MANUFACTURER);
+    return Util.SDK_INT >= 17 &&
+            ("Amazon".equals(Util.MANUFACTURER) || "Xiaomi".equals(Util.MANUFACTURER));
   }
 }


### PR DESCRIPTION
exoplayer can enable dolby passthrough on xiaomi device when get
EXTERNAL_SURROUND_SOUND_KEY

Signed-off-by: joakimzhang <zq15011526977@gmail.com>