### PR TITLE
Calculate HLS target live offset from #EXT-START-TIME if available

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaSource.java
@@ -616,7 +616,9 @@ public final class HlsMediaSource extends BaseMediaSource
     HlsMediaPlaylist.ServerControl serverControl = playlist.serverControl;
     // Select part hold back only if the playlist has a part target duration.
     long offsetToEndOfPlaylistUs;
-    if (serverControl.partHoldBackUs != C.TIME_UNSET
+    if (playlist.startOffsetUs != C.TIME_UNSET) {
+      offsetToEndOfPlaylistUs = playlist.durationUs - playlist.startOffsetUs;
+    } else if (serverControl.partHoldBackUs != C.TIME_UNSET
         && playlist.partTargetDurationUs != C.TIME_UNSET) {
       offsetToEndOfPlaylistUs = serverControl.partHoldBackUs;
     } else if (serverControl.holdBackUs != C.TIME_UNSET) {


### PR DESCRIPTION
From r2.12.3 to r2.13.0 there seems to be a regression where #EXT-START-TIME is not honored for live playlists. This PR tries to get the target live offset from the parsed playlist start time before falling back to the other methods.