### PR TITLE
feat: developers can add devices to the widevine l3 forced ones

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
@@ -40,8 +40,10 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /** An {@link ExoMediaDrm} implementation that wraps the framework {@link MediaDrm}. */
@@ -69,11 +71,11 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   private static final String MOCK_LA_URL_VALUE = "https://x";
   private static final String MOCK_LA_URL = "<LA_URL>" + MOCK_LA_URL_VALUE + "</LA_URL>";
   private static final int UTF_16_BYTES_PER_CHARACTER = 2;
+  private static final Set<String> WIDEVINE_L3_FORCED_DEVICES = new HashSet<>(Arrays.asList("ASUS_Z00AD"));
 
   private final UUID uuid;
   private final MediaDrm mediaDrm;
   private int referenceCount;
-  private final ArrayList<String> widevineL3ForcedDevices = new ArrayList<>(Arrays.asList("ASUS_Z00AD"));
 
   /**
    * Returns whether the DRM scheme with the given UUID is supported on this device.
@@ -128,8 +130,8 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
    *
    * @param deviceModelName
    */
-  public void addWidevineL3ForcedDevice(String deviceModelName) {
-    widevineL3ForcedDevices.add(deviceModelName);
+  public static void addWidevineL3ForcedDevice(String deviceModelName) {
+    WIDEVINE_L3_FORCED_DEVICES.add(deviceModelName);
   }
 
   /**
@@ -440,7 +442,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
    * <p>See <a href="https://github.com/google/ExoPlayer/issues/4413">GitHub issue #4413</a>.
    */
   private boolean needsForceWidevineL3Workaround() {
-    return widevineL3ForcedDevices.contains(Util.MODEL);
+    return WIDEVINE_L3_FORCED_DEVICES.contains(Util.MODEL);
   }
 
   /**

--- a/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/drm/FrameworkMediaDrm.java
@@ -38,6 +38,7 @@ import com.google.common.base.Charsets;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +73,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
   private final UUID uuid;
   private final MediaDrm mediaDrm;
   private int referenceCount;
+  private final ArrayList<String> widevineL3ForcedDevices = new ArrayList<>(Arrays.asList("ASUS_Z00AD"));
 
   /**
    * Returns whether the DRM scheme with the given UUID is supported on this device.
@@ -119,6 +121,15 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
             ? null
             : (mediaDrm, sessionId, event, extra, data) ->
                 listener.onEvent(FrameworkMediaDrm.this, sessionId, event, extra, data));
+  }
+
+  /**
+   * Adds the given BuildModel identifier to the list of devices on which L3 will be forced
+   *
+   * @param deviceModelName
+   */
+  public void addWidevineL3ForcedDevice(String deviceModelName) {
+    widevineL3ForcedDevices.add(deviceModelName);
   }
 
   /**
@@ -428,8 +439,8 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
    *
    * <p>See <a href="https://github.com/google/ExoPlayer/issues/4413">GitHub issue #4413</a>.
    */
-  private static boolean needsForceWidevineL3Workaround() {
-    return "ASUS_Z00AD".equals(Util.MODEL);
+  private boolean needsForceWidevineL3Workaround() {
+    return widevineL3ForcedDevices.contains(Util.MODEL);
   }
 
   /**


### PR DESCRIPTION
Hi developers,

there are several devices which won't work with L1 but with L3 they do (e.g. Pixel C).
Why shouldn't we let the developers decide which devices they want to force to L3.

Kind regards,
Moritz