### PR TITLE
Fix bottom-cropped text in WebView output

### DIFF
--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/WebViewSubtitleOutput.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/WebViewSubtitleOutput.java
@@ -175,7 +175,7 @@ import java.util.Map;
                 + "right:0;"
                 + "color:%s;"
                 + "font-size:%s;"
-                + "line-height:%.2fem;"
+                + "line-height:%.2f;"
                 + "text-shadow:%s;"
                 + "'>",
             HtmlUtils.toCssRgba(style.foregroundColor),


### PR DESCRIPTION
Use unitless numbers for WebView line-height values

See
https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#prefer_unitless_numbers_for_line-height_values

