### PR TITLE
Support ebutts:multiRowAlign in TTML text renderer

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlDecoder.java
@@ -533,22 +533,7 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
               TtmlNode.ITALIC.equalsIgnoreCase(attributeValue));
           break;
         case TtmlNode.ATTR_TTS_TEXT_ALIGN:
-          switch (Util.toLowerInvariant(attributeValue)) {
-            case TtmlNode.LEFT:
-            case TtmlNode.START:
-              style = createIfNull(style).setTextAlign(Layout.Alignment.ALIGN_NORMAL);
-              break;
-            case TtmlNode.RIGHT:
-            case TtmlNode.END:
-              style = createIfNull(style).setTextAlign(Layout.Alignment.ALIGN_OPPOSITE);
-              break;
-            case TtmlNode.CENTER:
-              style = createIfNull(style).setTextAlign(Layout.Alignment.ALIGN_CENTER);
-              break;
-            default:
-              // ignore
-              break;
-          }
+          style = createIfNull(style).setTextAlign(parseAlignment(attributeValue));
           break;
         case TtmlNode.ATTR_TTS_TEXT_COMBINE:
           switch (Util.toLowerInvariant(attributeValue)) {
@@ -621,6 +606,9 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
         case TtmlNode.ATTR_TTS_SHEAR:
           style = createIfNull(style).setShearPercentage(parseShear(attributeValue));
           break;
+        case TtmlNode.ATTR_EBUTTS_MULTI_ROW_ALIGN:
+          style = createIfNull(style).setMultiRowAlign(parseAlignment(attributeValue));
+          break;
         default:
           // ignore
           break;
@@ -631,6 +619,24 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
 
   private static TtmlStyle createIfNull(@Nullable TtmlStyle style) {
     return style == null ? new TtmlStyle() : style;
+  }
+
+  @Nullable
+  private static Layout.Alignment parseAlignment(@Nullable String alignment) {
+    switch (Util.toLowerInvariant(alignment)) {
+      case TtmlNode.LEFT:
+      case TtmlNode.START:
+        return Layout.Alignment.ALIGN_NORMAL;
+      case TtmlNode.RIGHT:
+      case TtmlNode.END:
+        return Layout.Alignment.ALIGN_OPPOSITE;
+      case TtmlNode.CENTER:
+        return Layout.Alignment.ALIGN_CENTER;
+      default:
+        // ignore
+        break;
+    }
+    return null;
   }
 
   private static TtmlNode parseNode(

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlRenderUtil.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlRenderUtil.java
@@ -17,10 +17,12 @@ package com.google.android.exoplayer2.text.ttml;
 
 import static com.google.android.exoplayer2.util.Assertions.checkNotNull;
 
+import android.text.Layout;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.AbsoluteSizeSpan;
+import android.text.style.AlignmentSpan;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.RelativeSizeSpan;
@@ -89,8 +91,8 @@ import java.util.Map;
       TtmlStyle style,
       @Nullable TtmlNode parent,
       Map<String, TtmlStyle> globalStyles,
-      @Cue.VerticalType int verticalType) {
-
+      @Cue.VerticalType int verticalType,
+      boolean isPNode) {
     if (style.getStyle() != TtmlStyle.UNSPECIFIED) {
       builder.setSpan(new StyleSpan(style.getStyle()), start, end,
           Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -209,6 +211,16 @@ import java.util.Map;
       SpanUtil.addOrReplaceSpan(
           builder,
           new HorizontalTextInVerticalContextSpan(),
+          start,
+          end,
+          Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    }
+    if (style.getMultiRowAlign() != null && isPNode) {
+      // Only applies to P nodes
+      // https://www.w3.org/TR/ttml-imsc1.1/#text-multiRowAlign
+      SpanUtil.addOrReplaceSpan(
+          builder,
+          new AlignmentSpan.Standard(style.getMultiRowAlign()),
           start,
           end,
           Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlStyle.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlStyle.java
@@ -89,6 +89,7 @@ import java.lang.annotation.RetentionPolicy;
   @OptionalBoolean private int textCombine;
   @Nullable private TextEmphasis textEmphasis;
   private float shearPercentage;
+  @Nullable private Layout.Alignment multiRowAlign;
 
   public TtmlStyle() {
     linethrough = UNSPECIFIED;
@@ -197,6 +198,16 @@ import java.lang.annotation.RetentionPolicy;
     return shearPercentage;
   }
 
+  @Nullable
+  public Layout.Alignment getMultiRowAlign() {
+    return multiRowAlign;
+  }
+
+  public TtmlStyle setMultiRowAlign(@Nullable Layout.Alignment multiRowAlign) {
+    this.multiRowAlign = multiRowAlign;
+    return this;
+  }
+
   /**
    * Chains this style to referential style. Local properties which are already set are never
    * overridden.
@@ -256,6 +267,9 @@ import java.lang.annotation.RetentionPolicy;
       }
       if (shearPercentage == UNSPECIFIED_SHEAR) {
         shearPercentage = ancestor.shearPercentage;
+      }
+      if (multiRowAlign == null && ancestor.multiRowAlign != null) {
+        multiRowAlign = ancestor.multiRowAlign;
       }
       // attributes not inherited as of http://www.w3.org/TR/ttml1/
       if (chaining && !hasBackgroundColor && ancestor.hasBackgroundColor) {

--- a/library/core/src/test/java/com/google/android/exoplayer2/text/ttml/TtmlDecoderTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/text/ttml/TtmlDecoderTest.java
@@ -70,6 +70,7 @@ public final class TtmlDecoderTest {
   private static final String RUBIES_FILE = "media/ttml/rubies.xml";
   private static final String TEXT_EMPHASIS_FILE = "media/ttml/text_emphasis.xml";
   private static final String SHEAR_FILE = "media/ttml/shear.xml";
+  private static final String MULTI_ROW_ALIGN_FILE = "media/ttml/multi_row_align.xml";
 
   @Test
   public void inlineAttributes() throws IOException, SubtitleDecoderException {
@@ -844,6 +845,55 @@ public final class TtmlDecoderTest {
 
     Cue eighthCue = getOnlyCueAtTimeUs(subtitle, 80_000_000);
     assertThat(eighthCue.shearDegrees).isWithin(0.01f).of(90f);
+  }
+
+  @Test
+  public void multiRowAlign() throws IOException, SubtitleDecoderException {
+    TtmlSubtitle subtitle = getSubtitle(MULTI_ROW_ALIGN_FILE);
+
+    Cue firstCue = getOnlyCueAtTimeUs(subtitle, 10_000_000);
+    assertThat(firstCue.textAlignment).isEqualTo(Layout.Alignment.ALIGN_CENTER);
+
+    Spanned firstSpanned = getOnlyCueTextAtTimeUs(subtitle, 10_000_000);
+    assertThat(firstSpanned)
+        .hasAlignmentSpanBetween("".length(), "text align center\nmulti row align start".length())
+        .withAlignment(Layout.Alignment.ALIGN_NORMAL);
+
+    Cue secondCue = getOnlyCueAtTimeUs(subtitle, 20_000_000);
+    assertThat(secondCue.textAlignment).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    Spanned secondSpanned = getOnlyCueTextAtTimeUs(subtitle, 20_000_000);
+    assertThat(secondSpanned)
+        .hasAlignmentSpanBetween("".length(), "text align start\nmulti row align center".length())
+        .withAlignment(Layout.Alignment.ALIGN_CENTER);
+
+    Cue thirdCue = getOnlyCueAtTimeUs(subtitle, 30_000_000);
+    assertThat(thirdCue.textAlignment).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    Spanned thirdSpanned = getOnlyCueTextAtTimeUs(subtitle, 30_000_000);
+    assertThat(thirdSpanned)
+        .hasAlignmentSpanBetween("".length(), "text align left\nmulti row align end".length())
+        .withAlignment(Layout.Alignment.ALIGN_OPPOSITE);
+
+    Cue fourthCue = getOnlyCueAtTimeUs(subtitle, 40_000_000);
+    assertThat(fourthCue.textAlignment).isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    Spanned fourthSpanned = getOnlyCueTextAtTimeUs(subtitle, 40_000_000);
+    assertThat(fourthSpanned)
+        .hasAlignmentSpanBetween("".length(), "text align right\nmulti row align left".length())
+        .withAlignment(Layout.Alignment.ALIGN_NORMAL);
+
+    Cue fifthCue = getOnlyCueAtTimeUs(subtitle, 50_000_000);
+    assertThat(fifthCue.textAlignment).isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    Spanned fifthSpanned = getOnlyCueTextAtTimeUs(subtitle, 50_000_000);
+    assertThat(fifthSpanned)
+        .hasAlignmentSpanBetween("".length(), "text align end\nmulti row align right".length())
+        .withAlignment(Layout.Alignment.ALIGN_OPPOSITE);
+
+    Spanned sixthSpanned = getOnlyCueTextAtTimeUs(subtitle, 60_000_000);
+    assertThat(sixthSpanned)
+        .hasNoAlignmentSpanBetween("".length(), "not a p node\nmulti row align start".length());
   }
 
   private static Spanned getOnlyCueTextAtTimeUs(Subtitle subtitle, long timeUs) {

--- a/library/core/src/test/java/com/google/android/exoplayer2/text/ttml/TtmlStyleTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/text/ttml/TtmlStyleTest.java
@@ -68,7 +68,8 @@ public final class TtmlStyleTest {
           .setTextAlign(TEXT_ALIGN)
           .setTextCombine(TEXT_COMBINE)
           .setTextEmphasis(TextEmphasis.parse(TEXT_EMPHASIS_STYLE))
-          .setShearPercentage(SHEAR_PERCENTAGE);
+          .setShearPercentage(SHEAR_PERCENTAGE)
+          .setMultiRowAlign(Layout.Alignment.ALIGN_NORMAL);
 
   @Test
   public void inheritStyle() {
@@ -97,6 +98,7 @@ public final class TtmlStyleTest {
     assertThat(style.getTextEmphasis().markFill).isEqualTo(TextEmphasisSpan.MARK_FILL_FILLED);
     assertThat(style.getTextEmphasis().position).isEqualTo(POSITION_BEFORE);
     assertThat(style.getShearPercentage()).isEqualTo(SHEAR_PERCENTAGE);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
   }
 
   @Test
@@ -125,6 +127,7 @@ public final class TtmlStyleTest {
     assertThat(style.getTextEmphasis().markFill).isEqualTo(TextEmphasisSpan.MARK_FILL_FILLED);
     assertThat(style.getTextEmphasis().position).isEqualTo(POSITION_BEFORE);
     assertThat(style.getShearPercentage()).isEqualTo(SHEAR_PERCENTAGE);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
   }
 
   @Test
@@ -282,5 +285,17 @@ public final class TtmlStyleTest {
     assertThat(style.getShearPercentage()).isEqualTo(-200f);
     style.setShearPercentage(0.1f);
     assertThat(style.getShearPercentage()).isEqualTo(0.1f);
+  }
+
+  @Test
+  public void multiRowAlign() {
+    TtmlStyle style = new TtmlStyle();
+    assertThat(style.getMultiRowAlign()).isEqualTo(null);
+    style.setMultiRowAlign(Layout.Alignment.ALIGN_CENTER);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_CENTER);
+    style.setMultiRowAlign(Layout.Alignment.ALIGN_NORMAL);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+    style.setMultiRowAlign(Layout.Alignment.ALIGN_OPPOSITE);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
   }
 }

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/SpannedToHtmlConverter.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/SpannedToHtmlConverter.java
@@ -18,8 +18,10 @@ package com.google.android.exoplayer2.ui;
 
 import android.graphics.Typeface;
 import android.text.Html;
+import android.text.Layout;
 import android.text.Spanned;
 import android.text.style.AbsoluteSizeSpan;
+import android.text.style.AlignmentSpan;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.RelativeSizeSpan;
@@ -208,6 +210,11 @@ import java.util.regex.Pattern;
               + "-webkit-text-emphasis-position:%2$s;text-emphasis-position:%2$s;"
               + "display:inline-block;'>",
           style, position);
+    } else if (span instanceof AlignmentSpan) {
+      AlignmentSpan alignmentSpan = (AlignmentSpan) span;
+      return Util.formatInvariant(
+          "<span style='display:inline-block; text-align:%s;'>",
+          convertAlignmentToCss(alignmentSpan.getAlignment()));
     } else {
       return null;
     }
@@ -221,7 +228,8 @@ import java.util.regex.Pattern;
         || span instanceof HorizontalTextInVerticalContextSpan
         || span instanceof AbsoluteSizeSpan
         || span instanceof RelativeSizeSpan
-        || span instanceof TextEmphasisSpan) {
+        || span instanceof TextEmphasisSpan
+        || span instanceof AlignmentSpan) {
       return "</span>";
     } else if (span instanceof TypefaceSpan) {
       @Nullable String fontFamily = ((TypefaceSpan) span).getFamily();
@@ -379,6 +387,21 @@ import java.util.regex.Pattern;
     public Transition() {
       this.spansAdded = new ArrayList<>();
       this.spansRemoved = new ArrayList<>();
+    }
+  }
+
+  static String convertAlignmentToCss(@Nullable Layout.Alignment alignment) {
+    if (alignment == null) {
+      return "center";
+    }
+    switch (alignment) {
+      case ALIGN_NORMAL:
+        return "start";
+      case ALIGN_OPPOSITE:
+        return "end";
+      case ALIGN_CENTER:
+      default:
+        return "center";
     }
   }
 }

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/WebViewSubtitleOutput.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/WebViewSubtitleOutput.java
@@ -21,7 +21,6 @@ import static com.google.android.exoplayer2.ui.SubtitleView.DEFAULT_TEXT_SIZE_FR
 
 import android.content.Context;
 import android.graphics.Color;
-import android.text.Layout;
 import android.util.AttributeSet;
 import android.util.Base64;
 import android.util.DisplayMetrics;
@@ -225,7 +224,7 @@ import java.util.Map;
               ? Util.formatInvariant("%.2f%%", cue.size * 100)
               : "fit-content";
 
-      String textAlign = convertAlignmentToCss(cue.textAlignment);
+      String textAlign = SpannedToHtmlConverter.convertAlignmentToCss(cue.textAlignment);
       String writingMode = convertVerticalTypeToCss(cue.verticalType);
       String cueTextSizeCssPx = convertTextSizeToCss(cue.textSizeType, cue.textSize);
       String windowCssColor =
@@ -385,21 +384,6 @@ import java.util.Map;
       case Cue.TYPE_UNSET:
       default:
         return "horizontal-tb";
-    }
-  }
-
-  private static String convertAlignmentToCss(@Nullable Layout.Alignment alignment) {
-    if (alignment == null) {
-      return "center";
-    }
-    switch (alignment) {
-      case ALIGN_NORMAL:
-        return "start";
-      case ALIGN_OPPOSITE:
-        return "end";
-      case ALIGN_CENTER:
-      default:
-        return "center";
     }
   }
 

--- a/library/ui/src/test/java/com/google/android/exoplayer2/ui/SpannedToHtmlConverterTest.java
+++ b/library/ui/src/test/java/com/google/android/exoplayer2/ui/SpannedToHtmlConverterTest.java
@@ -20,9 +20,11 @@ import static com.google.common.truth.Truth.assertThat;
 
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.text.Layout;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.style.AbsoluteSizeSpan;
+import android.text.style.AlignmentSpan;
 import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.RelativeSizeSpan;
@@ -331,6 +333,49 @@ public class SpannedToHtmlConverterTest {
 
     assertThat(htmlAndCss.cssRuleSets).isEmpty();
     assertThat(htmlAndCss.html).isEqualTo("String with <u>underlined</u> section.");
+  }
+
+  @Test
+  public void convert_supportsAlignmentSpan() {
+    SpannableString startSpanned = new SpannableString("String with\nmultirow alignment.");
+    startSpanned.setSpan(
+        new AlignmentSpan.Standard(Layout.Alignment.ALIGN_NORMAL),
+        "".length(),
+        "String with\nmultirow alignment.".length(),
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+    SpannedToHtmlConverter.HtmlAndCss htmlAndCss =
+        SpannedToHtmlConverter.convert(startSpanned, displayDensity);
+
+    assertThat(htmlAndCss.cssRuleSets).isEmpty();
+    assertThat(htmlAndCss.html).isEqualTo(
+        "<span style='display:inline-block; text-align:start;'>String with<br>multirow alignment.</span>");
+
+    SpannableString centerSpanned = new SpannableString("String with\nmultirow alignment.");
+    centerSpanned.setSpan(
+        new AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER),
+        "".length(),
+        "String with\nmultirow alignment.".length(),
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+    htmlAndCss = SpannedToHtmlConverter.convert(centerSpanned, displayDensity);
+
+    assertThat(htmlAndCss.cssRuleSets).isEmpty();
+    assertThat(htmlAndCss.html).isEqualTo(
+        "<span style='display:inline-block; text-align:center;'>String with<br>multirow alignment.</span>");
+
+    SpannableString endSpanned = new SpannableString("String with\nmultirow alignment.");
+    endSpanned.setSpan(
+        new AlignmentSpan.Standard(Layout.Alignment.ALIGN_OPPOSITE),
+        "".length(),
+        "String with\nmultirow alignment.".length(),
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+
+    htmlAndCss = SpannedToHtmlConverter.convert(endSpanned, displayDensity);
+
+    assertThat(htmlAndCss.cssRuleSets).isEmpty();
+    assertThat(htmlAndCss.html).isEqualTo(
+        "<span style='display:inline-block; text-align:end;'>String with<br>multirow alignment.</span>");
   }
 
   @Test

--- a/testdata/src/test/assets/media/ttml/multi_row_align.xml
+++ b/testdata/src/test/assets/media/ttml/multi_row_align.xml
@@ -1,0 +1,31 @@
+<tt xmlns:ttm="http://www.w3.org/2006/10/ttaf1#metadata"
+  xmlns:ttp="http://www.w3.org/2006/10/ttaf1#parameter"
+  xmlns:tts="http://www.w3.org/2006/10/ttaf1#style"
+  xmlns="http://www.w3.org/ns/ttml"
+  xmlns:ebutts="urn:ebu:tt:style" >
+  <head>
+    <region xml:id="region_tbrl" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="tbrl"/>
+    <region xml:id="region_tblr" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="tblr"/>
+    <region xml:id="region_lr" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="lr"/>
+  </head>
+  <body>
+    <div>
+      <p begin="10s" end="18s" region="region_lr" tts:textAlign="center" ebutts:multiRowAlign="start">text align center<br/>multi row align start</p>
+    </div>
+    <div>
+      <p begin="20s" end="28s" region="region_tblr" tts:textAlign="start" ebutts:multiRowAlign="center">text align start<br/>multi row align center</p>
+    </div>
+    <div>
+      <p begin="30s" end="38s" region="region_tbrl" tts:textAlign="left" ebutts:multiRowAlign="end">text align left<br/>multi row align end</p>
+    </div>
+    <div>
+      <p begin="40s" end="48s" region="region_lr" tts:textAlign="right" ebutts:multiRowAlign="left">text align right<br/>multi row align left</p>
+    </div>
+    <div>
+      <p begin="50s" end="58s" region="region_lr" tts:textAlign="end" ebutts:multiRowAlign="right">text align end<br/>multi row align right</p>
+    </div>
+    <div>
+      <p begin="60s" end="68s" region="region_lr"><span ebutts:multiRowAlign="start">not a p node<br/>multi row align start</span></p>
+    </div>
+  </body>
+</tt>


### PR DESCRIPTION
Fix bug in text alignment inheritance where child does not
correctly inherit ancestor's setting

@icbaker 