### PR TITLE
Support ebutts:multiRowAlign in TTML text renderer

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/text/Cue.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/text/Cue.java
@@ -140,6 +140,12 @@ public final class Cue {
   /** The alignment of the cue text within the cue box, or null if the alignment is undefined. */
   @Nullable public final Alignment textAlignment;
 
+  /**
+   * The alignment of the other lines of text relative to the longest line of text, or null if the
+   * alignment is undefined.
+   */
+  @Nullable public final Alignment multiRowAlignment;
+
   /** The cue image, or null if this is a text cue. */
   @Nullable public final Bitmap bitmap;
 
@@ -377,7 +383,8 @@ public final class Cue {
         /* windowColorSet= */ false,
         /* windowColor= */ Color.BLACK,
         /* verticalType= */ TYPE_UNSET,
-        /* shearDegrees= */ 0f);
+        /* shearDegrees= */ 0f,
+        /* multiRowAlignment= */ null);
   }
 
   /**
@@ -423,7 +430,8 @@ public final class Cue {
         windowColorSet,
         windowColor,
         /* verticalType= */ TYPE_UNSET,
-        /* shearDegrees= */ 0f);
+        /* shearDegrees= */ 0f,
+        /* multiRowAlignment= */null);
   }
 
   private Cue(
@@ -442,7 +450,8 @@ public final class Cue {
       boolean windowColorSet,
       int windowColor,
       @VerticalType int verticalType,
-      float shearDegrees) {
+      float shearDegrees,
+      @Nullable Alignment multiRowAlignment) {
     // Exactly one of text or bitmap should be set.
     if (text == null) {
       Assertions.checkNotNull(bitmap);
@@ -465,6 +474,7 @@ public final class Cue {
     this.textSize = textSize;
     this.verticalType = verticalType;
     this.shearDegrees = shearDegrees;
+    this.multiRowAlignment = multiRowAlignment;
   }
 
   /** Returns a new {@link Cue.Builder} initialized with the same values as this Cue. */
@@ -477,6 +487,7 @@ public final class Cue {
     @Nullable private CharSequence text;
     @Nullable private Bitmap bitmap;
     @Nullable private Alignment textAlignment;
+    @Nullable private Alignment multiRowAlignment;
     private float line;
     @LineType private int lineType;
     @AnchorType private int lineAnchor;
@@ -495,6 +506,7 @@ public final class Cue {
       text = null;
       bitmap = null;
       textAlignment = null;
+      multiRowAlignment = null;
       line = DIMEN_UNSET;
       lineType = TYPE_UNSET;
       lineAnchor = TYPE_UNSET;
@@ -513,6 +525,7 @@ public final class Cue {
       text = cue.text;
       bitmap = cue.bitmap;
       textAlignment = cue.textAlignment;
+      multiRowAlignment = cue.multiRowAlignment;
       line = cue.line;
       lineType = cue.lineType;
       lineAnchor = cue.lineAnchor;
@@ -590,6 +603,18 @@ public final class Cue {
     @Nullable
     public Alignment getTextAlignment() {
       return textAlignment;
+    }
+
+    /**
+     * Sets the multi-row alignment of the cue within the cue box.
+     *
+     * <p>Passing null means the alignment is undefined.
+     *
+     * @see Cue#multiRowAlignment
+     */
+    public Builder setMultiRowAlignment(@Nullable Layout.Alignment multiRowAlignment) {
+      this.multiRowAlignment = multiRowAlignment;
+      return this;
     }
 
     /**
@@ -840,7 +865,8 @@ public final class Cue {
           windowColorSet,
           windowColor,
           verticalType,
-          shearDegrees);
+          shearDegrees,
+          multiRowAlignment);
     }
   }
 }

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlDecoder.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlDecoder.java
@@ -19,6 +19,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 
 import android.text.Layout;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.text.Cue;
@@ -534,22 +535,7 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
               TtmlNode.ITALIC.equalsIgnoreCase(attributeValue));
           break;
         case TtmlNode.ATTR_TTS_TEXT_ALIGN:
-          switch (Ascii.toLowerCase(attributeValue)) {
-            case TtmlNode.LEFT:
-            case TtmlNode.START:
-              style = createIfNull(style).setTextAlign(Layout.Alignment.ALIGN_NORMAL);
-              break;
-            case TtmlNode.RIGHT:
-            case TtmlNode.END:
-              style = createIfNull(style).setTextAlign(Layout.Alignment.ALIGN_OPPOSITE);
-              break;
-            case TtmlNode.CENTER:
-              style = createIfNull(style).setTextAlign(Layout.Alignment.ALIGN_CENTER);
-              break;
-            default:
-              // ignore
-              break;
-          }
+          style = createIfNull(style).setTextAlign(parseAlignment(attributeValue));
           break;
         case TtmlNode.ATTR_TTS_TEXT_COMBINE:
           switch (Ascii.toLowerCase(attributeValue)) {
@@ -620,6 +606,9 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
         case TtmlNode.ATTR_TTS_SHEAR:
           style = createIfNull(style).setShearPercentage(parseShear(attributeValue));
           break;
+        case TtmlNode.ATTR_EBUTTS_MULTI_ROW_ALIGN:
+          style = createIfNull(style).setMultiRowAlign(parseAlignment(attributeValue));
+          break;
         default:
           // ignore
           break;
@@ -630,6 +619,24 @@ public final class TtmlDecoder extends SimpleSubtitleDecoder {
 
   private static TtmlStyle createIfNull(@Nullable TtmlStyle style) {
     return style == null ? new TtmlStyle() : style;
+  }
+
+  @Nullable
+  private static Layout.Alignment parseAlignment(@NonNull String alignment) {
+    switch (Ascii.toLowerCase(alignment)) {
+      case TtmlNode.LEFT:
+      case TtmlNode.START:
+        return Layout.Alignment.ALIGN_NORMAL;
+      case TtmlNode.RIGHT:
+      case TtmlNode.END:
+        return Layout.Alignment.ALIGN_OPPOSITE;
+      case TtmlNode.CENTER:
+        return Layout.Alignment.ALIGN_CENTER;
+      default:
+        // ignore
+        break;
+    }
+    return null;
   }
 
   private static TtmlNode parseNode(

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlNode.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlNode.java
@@ -72,6 +72,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
   public static final String ATTR_TTS_TEXT_EMPHASIS = "textEmphasis";
   public static final String ATTR_TTS_WRITING_MODE = "writingMode";
   public static final String ATTR_TTS_SHEAR = "shear";
+  public static final String ATTR_EBUTTS_MULTI_ROW_ALIGN = "multiRowAlign";
 
   // Values for ruby
   public static final String RUBY_CONTAINER = "container";
@@ -376,7 +377,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       return;
     }
     String resolvedRegionId = ANONYMOUS_REGION_ID.equals(regionId) ? inheritedRegion : regionId;
-
     for (Map.Entry<String, Integer> entry : nodeEndsByRegion.entrySet()) {
       String regionId = entry.getKey();
       int start = nodeStartsByRegion.containsKey(regionId) ? nodeStartsByRegion.get(regionId) : 0;
@@ -409,17 +409,29 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     if (resolvedStyle != null) {
       TtmlRenderUtil.applyStylesToSpan(
           text, start, end, resolvedStyle, parent, globalStyles, verticalType);
-      if (resolvedStyle.getShearPercentage() != TtmlStyle.UNSPECIFIED_SHEAR && TAG_P.equals(tag)) {
-        // Shear style should only be applied to P nodes
-        // https://www.w3.org/TR/2018/REC-ttml2-20181108/#style-attribute-shear
-        // The spec doesn't specify the coordinate system to use for block shear
-        // however the spec shows examples of how different values are expected to be rendered.
-        // See: https://www.w3.org/TR/2018/REC-ttml2-20181108/#style-attribute-shear
-        // https://www.w3.org/TR/2018/REC-ttml2-20181108/#style-attribute-fontShear
-        // This maps the shear percentage to shear angle in graphics coordinates
-        regionOutput.setShearDegrees((resolvedStyle.getShearPercentage() * -90) / 100);
+      if (TAG_P.equals(tag)) {
+        if (resolvedStyle.getShearPercentage() != TtmlStyle.UNSPECIFIED_SHEAR) {
+          // Shear style should only be applied to P nodes
+          // https://www.w3.org/TR/2018/REC-ttml2-20181108/#style-attribute-shear
+          // The spec doesn't specify the coordinate system to use for block shear
+          // however the spec shows examples of how different values are expected to be rendered.
+          // See: https://www.w3.org/TR/2018/REC-ttml2-20181108/#style-attribute-shear
+          // https://www.w3.org/TR/2018/REC-ttml2-20181108/#style-attribute-fontShear
+          // This maps the shear percentage to shear angle in graphics coordinates
+          regionOutput.setShearDegrees((resolvedStyle.getShearPercentage() * -90) / 100);
+        }
+        if (resolvedStyle.getMultiRowAlign() != null) {
+          // Multi-row align should only be applied to P nodes
+          // https://www.w3.org/TR/ttml-imsc1.1/#text-multiRowAlign
+          regionOutput.setMultiRowAlignment(resolvedStyle.getMultiRowAlign());
+        }
       }
-      regionOutput.setTextAlignment(resolvedStyle.getTextAlign());
+
+      if (resolvedStyle.getTextAlign() != null) {
+        // Only set text alignment if defined in current node, otherwise could overwrite
+        // inherited text alignment
+        regionOutput.setTextAlignment(resolvedStyle.getTextAlign());
+      }
     }
   }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlNode.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlNode.java
@@ -426,12 +426,6 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
           regionOutput.setMultiRowAlignment(resolvedStyle.getMultiRowAlign());
         }
       }
-
-      if (resolvedStyle.getTextAlign() != null) {
-        // Only set text alignment if defined in current node, otherwise could overwrite
-        // inherited text alignment
-        regionOutput.setTextAlignment(resolvedStyle.getTextAlign());
-      }
     }
   }
 

--- a/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlStyle.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/text/ttml/TtmlStyle.java
@@ -89,6 +89,7 @@ import java.lang.annotation.RetentionPolicy;
   @OptionalBoolean private int textCombine;
   @Nullable private TextEmphasis textEmphasis;
   private float shearPercentage;
+  @Nullable private Layout.Alignment multiRowAlign;
 
   public TtmlStyle() {
     linethrough = UNSPECIFIED;
@@ -197,6 +198,16 @@ import java.lang.annotation.RetentionPolicy;
     return shearPercentage;
   }
 
+  @Nullable
+  public Layout.Alignment getMultiRowAlign() {
+    return multiRowAlign;
+  }
+
+  public TtmlStyle setMultiRowAlign(@Nullable Layout.Alignment multiRowAlign) {
+    this.multiRowAlign = multiRowAlign;
+    return this;
+  }
+
   /**
    * Chains this style to referential style. Local properties which are already set are never
    * overridden.
@@ -256,6 +267,9 @@ import java.lang.annotation.RetentionPolicy;
       }
       if (shearPercentage == UNSPECIFIED_SHEAR) {
         shearPercentage = ancestor.shearPercentage;
+      }
+      if (multiRowAlign == null && ancestor.multiRowAlign != null) {
+        multiRowAlign = ancestor.multiRowAlign;
       }
       // attributes not inherited as of http://www.w3.org/TR/ttml1/
       if (chaining && !hasBackgroundColor && ancestor.hasBackgroundColor) {

--- a/library/core/src/test/java/com/google/android/exoplayer2/text/CueTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/text/CueTest.java
@@ -46,6 +46,7 @@ public class CueTest {
             .setWindowColor(Color.CYAN)
             .setVerticalType(Cue.VERTICAL_TYPE_RL)
             .setShearDegrees(-15f)
+            .setMultiRowAlignment(Layout.Alignment.ALIGN_NORMAL)
             .build();
 
     Cue modifiedCue = cue.buildUpon().build();
@@ -63,6 +64,7 @@ public class CueTest {
     assertThat(cue.windowColorSet).isTrue();
     assertThat(cue.verticalType).isEqualTo(Cue.VERTICAL_TYPE_RL);
     assertThat(cue.shearDegrees).isEqualTo(-15f);
+    assertThat(cue.multiRowAlignment).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
 
     assertThat(modifiedCue.text).isSameInstanceAs(cue.text);
     assertThat(modifiedCue.textAlignment).isEqualTo(cue.textAlignment);
@@ -77,6 +79,7 @@ public class CueTest {
     assertThat(modifiedCue.windowColorSet).isEqualTo(cue.windowColorSet);
     assertThat(modifiedCue.verticalType).isEqualTo(cue.verticalType);
     assertThat(modifiedCue.shearDegrees).isEqualTo(cue.shearDegrees);
+    assertThat(modifiedCue.multiRowAlignment).isEqualTo(cue.multiRowAlignment);
   }
 
   @Test

--- a/library/core/src/test/java/com/google/android/exoplayer2/text/ttml/TtmlDecoderTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/text/ttml/TtmlDecoderTest.java
@@ -70,6 +70,7 @@ public final class TtmlDecoderTest {
   private static final String RUBIES_FILE = "media/ttml/rubies.xml";
   private static final String TEXT_EMPHASIS_FILE = "media/ttml/text_emphasis.xml";
   private static final String SHEAR_FILE = "media/ttml/shear.xml";
+  private static final String MULTI_ROW_ALIGN_FILE = "media/ttml/multi_row_align.xml";
 
   @Test
   public void inlineAttributes() throws IOException, SubtitleDecoderException {
@@ -844,6 +845,29 @@ public final class TtmlDecoderTest {
 
     Cue eighthCue = getOnlyCueAtTimeUs(subtitle, 80_000_000);
     assertThat(eighthCue.shearDegrees).isWithin(0.01f).of(90f);
+  }
+
+  @Test
+  public void multiRowAlign() throws IOException, SubtitleDecoderException {
+    TtmlSubtitle subtitle = getSubtitle(MULTI_ROW_ALIGN_FILE);
+
+    Cue firstCue = getOnlyCueAtTimeUs(subtitle, 10_000_000);
+    assertThat(firstCue.multiRowAlignment).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    Cue secondCue = getOnlyCueAtTimeUs(subtitle, 20_000_000);
+    assertThat(secondCue.multiRowAlignment).isEqualTo(Layout.Alignment.ALIGN_CENTER);
+
+    Cue thirdCue = getOnlyCueAtTimeUs(subtitle, 30_000_000);
+    assertThat(thirdCue.multiRowAlignment).isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    Cue fourthCue = getOnlyCueAtTimeUs(subtitle, 40_000_000);
+    assertThat(fourthCue.multiRowAlignment).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+
+    Cue fifthCue = getOnlyCueAtTimeUs(subtitle, 50_000_000);
+    assertThat(fifthCue.multiRowAlignment).isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
+
+    Cue sixthCue = getOnlyCueAtTimeUs(subtitle, 60_000_000);
+    assertThat(sixthCue.multiRowAlignment).isNull();
   }
 
   private static Spanned getOnlyCueTextAtTimeUs(Subtitle subtitle, long timeUs) {

--- a/library/core/src/test/java/com/google/android/exoplayer2/text/ttml/TtmlStyleTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/text/ttml/TtmlStyleTest.java
@@ -68,7 +68,8 @@ public final class TtmlStyleTest {
           .setTextAlign(TEXT_ALIGN)
           .setTextCombine(TEXT_COMBINE)
           .setTextEmphasis(TextEmphasis.parse(TEXT_EMPHASIS_STYLE))
-          .setShearPercentage(SHEAR_PERCENTAGE);
+          .setShearPercentage(SHEAR_PERCENTAGE)
+          .setMultiRowAlign(Layout.Alignment.ALIGN_NORMAL);
 
   @Test
   public void inheritStyle() {
@@ -97,6 +98,7 @@ public final class TtmlStyleTest {
     assertThat(style.getTextEmphasis().markFill).isEqualTo(TextEmphasisSpan.MARK_FILL_FILLED);
     assertThat(style.getTextEmphasis().position).isEqualTo(POSITION_BEFORE);
     assertThat(style.getShearPercentage()).isEqualTo(SHEAR_PERCENTAGE);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
   }
 
   @Test
@@ -125,6 +127,7 @@ public final class TtmlStyleTest {
     assertThat(style.getTextEmphasis().markFill).isEqualTo(TextEmphasisSpan.MARK_FILL_FILLED);
     assertThat(style.getTextEmphasis().position).isEqualTo(POSITION_BEFORE);
     assertThat(style.getShearPercentage()).isEqualTo(SHEAR_PERCENTAGE);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
   }
 
   @Test
@@ -282,5 +285,17 @@ public final class TtmlStyleTest {
     assertThat(style.getShearPercentage()).isEqualTo(-200f);
     style.setShearPercentage(0.1f);
     assertThat(style.getShearPercentage()).isEqualTo(0.1f);
+  }
+
+  @Test
+  public void multiRowAlign() {
+    TtmlStyle style = new TtmlStyle();
+    assertThat(style.getMultiRowAlign()).isEqualTo(null);
+    style.setMultiRowAlign(Layout.Alignment.ALIGN_CENTER);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_CENTER);
+    style.setMultiRowAlign(Layout.Alignment.ALIGN_NORMAL);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_NORMAL);
+    style.setMultiRowAlign(Layout.Alignment.ALIGN_OPPOSITE);
+    assertThat(style.getMultiRowAlign()).isEqualTo(Layout.Alignment.ALIGN_OPPOSITE);
   }
 }

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/WebViewSubtitleOutput.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/WebViewSubtitleOutput.java
@@ -302,11 +302,21 @@ import java.util.Map;
                   horizontalTranslatePercent,
                   verticalTranslatePercent,
                   getBlockShearTransformFunction(cue)))
-          .append(Util.formatInvariant("<span class='%s'>", DEFAULT_BACKGROUND_CSS_CLASS))
-          .append(htmlAndCss.html)
-          .append("</span>")
+          .append(Util.formatInvariant("<span class='%s'>", DEFAULT_BACKGROUND_CSS_CLASS));
+
+      if (cue.multiRowAlignment != null) {
+          html.append(Util.formatInvariant("<span style='display:inline-block; text-align:%s;'>",
+            convertAlignmentToCss(cue.multiRowAlignment)))
+              .append(htmlAndCss.html)
+              .append("</span>");
+      } else {
+        html.append(htmlAndCss.html);
+      }
+
+      html.append("</span>")
           .append("</div>");
     }
+
     html.append("</div></body></html>");
 
     StringBuilder htmlHead = new StringBuilder();

--- a/testdata/src/test/assets/media/ttml/multi_row_align.xml
+++ b/testdata/src/test/assets/media/ttml/multi_row_align.xml
@@ -1,0 +1,31 @@
+<tt xmlns:ttm="http://www.w3.org/2006/10/ttaf1#metadata"
+  xmlns:ttp="http://www.w3.org/2006/10/ttaf1#parameter"
+  xmlns:tts="http://www.w3.org/2006/10/ttaf1#style"
+  xmlns="http://www.w3.org/ns/ttml"
+  xmlns:ebutts="urn:ebu:tt:style" >
+  <head>
+    <region xml:id="region_tbrl" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="tbrl"/>
+    <region xml:id="region_tblr" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="tblr"/>
+    <region xml:id="region_lr" tts:extent="80.000% 80.000%" tts:origin="10.000% 10.000%" tts:writingMode="lr"/>
+  </head>
+  <body>
+    <div>
+      <p begin="10s" end="18s" region="region_lr" ebutts:multiRowAlign="start">multi row<br/>align start</p>
+    </div>
+    <div>
+      <p begin="20s" end="28s" region="region_tblr" ebutts:multiRowAlign="center">multi row<br/>align center</p>
+    </div>
+    <div>
+      <p begin="30s" end="38s" region="region_tbrl" ebutts:multiRowAlign="end">multi row<br/>align end</p>
+    </div>
+    <div>
+      <p begin="40s" end="48s" region="region_lr" ebutts:multiRowAlign="left">multi row<br/>align left</p>
+    </div>
+    <div>
+      <p begin="50s" end="58s" region="region_lr" ebutts:multiRowAlign="right">multi row<br/>align right</p>
+    </div>
+    <div>
+      <p begin="60s" end="68s" region="region_lr"><span ebutts:multiRowAlign="end">multi row<br/>align start</span></p>
+    </div>
+  </body>
+</tt>


### PR DESCRIPTION
Fix bug in text alignment inheritance where child does not correctly inherit ancestor's setting

@icbaker 