### PR TITLE
Fix surface.setFrameRate Exception catch

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/video/VideoFrameReleaseHelper.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/VideoFrameReleaseHelper.java
@@ -387,7 +387,7 @@ public final class VideoFrameReleaseHelper {
             : Surface.FRAME_RATE_COMPATIBILITY_FIXED_SOURCE;
     try {
       surface.setFrameRate(frameRate, compatibility);
-    } catch (IllegalStateException e) {
+    } catch (IllegalArgumentException e) {
       Log.e(TAG, "Failed to call Surface.setFrameRate", e);
     }
   }


### PR DESCRIPTION
In android source code Surface.setFrameRate() throws IllegalArgumentException and RuntimeException, not IllegalStateException