### PR TITLE
Make DefaultDashChunkSource also take into account segments ending before/until manifest 'publishTime'

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
@@ -818,6 +818,12 @@ public class DefaultDashChunkSource implements DashChunkSource {
     }
 
     public boolean isSegmentAvailableAtFullNetworkSpeed(long segmentNum, long nowPeriodTimeUs) {
+      if (segmentIndex.isExplicit()) {
+        // We don't support segment availability for explicit indices. Hence, also assume all
+        // segments in explicit indices are always available at full network speed even if they
+        // end in the future.
+        return true;
+      }
       return nowPeriodTimeUs == C.TIME_UNSET || getSegmentEndTimeUs(segmentNum) <= nowPeriodTimeUs;
     }
   }


### PR DESCRIPTION
DefaultDashChunkSource did not take into account segments ending after 'now' in the specific case where 'publishTime' value is after 'now'. This commit fixes this behavior described in #8847.