### PR TITLE
Peeked event from Queue

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/ListenerSet.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/ListenerSet.java
@@ -201,9 +201,12 @@ public final class ListenerSet<T, E extends MutableFlags> {
       // Recursive call to flush. Let the outer call handle the flush queue.
       return;
     }
+    
+    Runnable event;
     while (!flushingEvents.isEmpty()) {
       flushingEvents.peekFirst().run();
       flushingEvents.removeFirst();
+       event.run();
     }
   }
 


### PR DESCRIPTION
Removed the peaked element explicitly, and only running the event if it is removed, some concurrency is added to the method, although a ConcurrentQueue would be even safer.