### PR TITLE
HLS: Allows playback through gap > maxBufferMs

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -2312,8 +2312,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
       return false;
     }
     MediaPeriodHolder loadingPeriodHolder = queue.getLoadingPeriod();
+    long bufferedPositionUs = loadingPeriodHolder.getBufferedPositionUs();
     long bufferedDurationUs =
-        getTotalBufferedDurationUs(loadingPeriodHolder.getNextLoadPositionUs());
+        getTotalBufferedDurationUs(bufferedPositionUs);
     long playbackPositionUs =
         loadingPeriodHolder == queue.getPlayingPeriod()
             ? loadingPeriodHolder.toPeriodTime(rendererPositionUs)

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsMediaChunk.java
@@ -413,6 +413,15 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
     isPublished = true;
   }
 
+  /**
+   * If their are any samples loaded in this chunk.
+   *
+   * @return true if samples were loaded
+   */
+  boolean hasSamples() {
+    return ! hasGapTag;   // TOOD - could expand upon this to be more accurate, but for sure GAP has none
+  }
+
   // Internal methods.
 
   @RequiresNonNull("output")

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsSampleStreamWrapper.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsSampleStreamWrapper.java
@@ -715,7 +715,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
           lastMediaChunk.isLoadCompleted()
               ? lastMediaChunk
               : mediaChunks.size() > 1 ? mediaChunks.get(mediaChunks.size() - 2) : null;
-      if (lastCompletedMediaChunk != null) {
+      if (lastCompletedMediaChunk != null && lastCompletedMediaChunk.hasSamples()) {
         bufferedPositionUs = max(bufferedPositionUs, lastCompletedMediaChunk.endTimeUs);
       }
       if (sampleQueuesBuilt) {


### PR DESCRIPTION
This change fixes #8959

The issue is caused because the current logic assumes it is fully buffered after
fetching `minBufferMs` worth of GAP segments, which of course contain no
samples.  ExoPlayer normally jumps past the GAP but the infinite buffering
stall prevents this.

The fix changes the HLS implementation of `SequenceableLoader.getBufferedPositionUs()`
so to not report a GAP segment as potentially adding to the buffered time.
This allows deferring to the `SampleQueue`, a more complete source of truth.

Note the jump to end of the GAP occurs with no buffer, and loading has not triggered
so at least one handler loop is required to prevent false trigger of the
"Playback stuck buffering and not loading" error.