### PR TITLE
Fix empty CastTimeline on reconnect

### DIFF
--- a/extensions/cast/src/main/java/com/google/android/exoplayer2/ext/cast/CastTimelineTracker.java
+++ b/extensions/cast/src/main/java/com/google/android/exoplayer2/ext/cast/CastTimelineTracker.java
@@ -29,6 +29,8 @@ import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaQueueItem;
 import com.google.android.gms.cast.MediaStatus;
 import com.google.android.gms.cast.framework.media.RemoteMediaClient;
+import com.google.common.primitives.Ints;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -96,13 +98,6 @@ import java.util.List;
    * @return A {@link CastTimeline} that represents the given {@code remoteMediaClient} status.
    */
   public CastTimeline getCastTimeline(RemoteMediaClient remoteMediaClient) {
-    int[] itemIds = remoteMediaClient.getMediaQueue().getItemIds();
-    if (itemIds.length > 0) {
-      // Only remove unused items when there is something in the queue to avoid removing all entries
-      // if the remote media client clears the queue temporarily. See [Internal ref: b/128825216].
-      removeUnusedItemDataEntries(itemIds);
-    }
-
     // TODO: Reset state when the app instance changes [Internal ref: b/129672468].
     MediaStatus mediaStatus = remoteMediaClient.getMediaStatus();
     if (mediaStatus == null) {
@@ -119,7 +114,11 @@ import java.util.List;
         currentContentId,
         /* defaultPositionUs= */ C.TIME_UNSET);
 
+    // Collect the item ids manually, MediaQueue#getItemIds is empty after a reconnect.
+    ArrayList<Integer> itemIdList = new ArrayList<>();
+
     for (MediaQueueItem queueItem : mediaStatus.getQueueItems()) {
+      itemIdList.add(queueItem.getItemId());
       long defaultPositionUs = (long) (queueItem.getStartTime() * C.MICROS_PER_SECOND);
       @Nullable MediaInfo mediaInfo = queueItem.getMedia();
       String contentId = mediaInfo != null ? mediaInfo.getContentId() : UNKNOWN_CONTENT_ID;
@@ -131,6 +130,14 @@ import java.util.List;
           contentId,
           defaultPositionUs);
     }
+
+    int[] itemIds = Ints.toArray(itemIdList);
+    if (itemIds.length > 0) {
+      // Only remove unused items when there is something in the queue to avoid removing all entries
+      // if the remote media client clears the queue temporarily. See [Internal ref: b/128825216].
+      removeUnusedItemDataEntries(itemIds);
+    }
+
     return new CastTimeline(itemIds, itemIdToData);
   }
 

--- a/extensions/cast/src/test/java/com/google/android/exoplayer2/ext/cast/CastTimelineTrackerTest.java
+++ b/extensions/cast/src/test/java/com/google/android/exoplayer2/ext/cast/CastTimelineTrackerTest.java
@@ -34,7 +34,6 @@ import com.google.android.gms.cast.framework.media.RemoteMediaClient;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -291,11 +290,20 @@ public class CastTimelineTrackerTest {
         .build();
   }
 
-  private static RemoteMediaClient mockRemoteMediaClient(
+  private List<MediaQueueItem> createMediaQueueItems(int[] itemIds) {
+    ArrayList<MediaQueueItem> items = new ArrayList<>(itemIds.length);
+    for (int itemId : itemIds) {
+      MediaItem mediaItem = createMediaItem(itemId);
+      items.add(createMediaQueueItem(mediaItem, itemId));
+    }
+    return items;
+  }
+
+  private RemoteMediaClient mockRemoteMediaClient(
       int[] itemIds, int currentItemId, long currentDurationMs) {
     RemoteMediaClient remoteMediaClient = mock(RemoteMediaClient.class);
     MediaStatus status = mock(MediaStatus.class);
-    when(status.getQueueItems()).thenReturn(Collections.emptyList());
+    when(status.getQueueItems()).thenReturn(createMediaQueueItems(itemIds));
     when(remoteMediaClient.getMediaStatus()).thenReturn(status);
     when(status.getMediaInfo()).thenReturn(getMediaInfo(currentDurationMs));
     when(status.getCurrentItemId()).thenReturn(currentItemId);


### PR DESCRIPTION
After connecting to a cast device that is already playing, the `CastTimeline` would initially stay empty.  
And in turn all methods that rely on the timeline would also report incorrect data.  

The reason for this is that the `MediaQueue` would always return an empty array as active ids until there are further state changes on the cast. This does appear to be an issue in the cast framework, but it can easily be worked around by checking the `MediaStatus` instead.

Fixes https://github.com/google/ExoPlayer/issues/9026