### PR TITLE
Added DTS:X Audio Mime Type

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
@@ -75,6 +75,7 @@ public final class MimeTypes {
   public static final String AUDIO_DTS = BASE_TYPE_AUDIO + "/vnd.dts";
   public static final String AUDIO_DTS_HD = BASE_TYPE_AUDIO + "/vnd.dts.hd";
   public static final String AUDIO_DTS_EXPRESS = BASE_TYPE_AUDIO + "/vnd.dts.hd;profile=lbr";
+  public static final String AUDIO_DTS_X = BASE_TYPE_AUDIO + "/vnd.dts.uhd";
   public static final String AUDIO_VORBIS = BASE_TYPE_AUDIO + "/vorbis";
   public static final String AUDIO_OPUS = BASE_TYPE_AUDIO + "/opus";
   public static final String AUDIO_AMR = BASE_TYPE_AUDIO + "/amr";


### PR DESCRIPTION
For dtsx mimetype to be IANA compliant using vnd.dts.uhd instead of vnd.dts.x