### PR TITLE
Test case for fix for issue #7975

### DIFF
--- a/library/core/src/test/java/com/google/android/exoplayer2/ExoPlayerTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/ExoPlayerTest.java
@@ -9374,6 +9374,54 @@ public final class ExoPlayerTest {
   }
 
   @Test
+  public void seekTo_toPositionZero_overridesLiveStartPosition()
+          throws Exception {
+    ExoPlayer player =
+        new TestExoPlayerBuilder(context)
+            .setClock(
+                new FakeClock(/* initialTimeMs= */ 20_000, /* isAutoAdvancing= */ true))
+            .setUseLazyPreparation(true)  // This is default for ExoPlayer.Builder()
+            .build();
+
+    // TODO - if you set expectedInitialPositionUs to 0, the test will fail... And it shouldn't
+    int expectedInitialPositionUs = 10_000;
+    player.seekTo(expectedInitialPositionUs);
+    FakeMediaSource mediaSource = new FakeMediaSource();
+    player.setMediaSource(mediaSource, false);
+    player.prepare();
+    TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_BUFFERING);
+
+    MediaItem mediaItem =
+        new MediaItem.Builder().setUri(Uri.EMPTY).build();
+    Timeline liveTimeline =
+        new SinglePeriodTimeline(
+            /* presentationStartTimeMs= */ C.TIME_UNSET,
+            /* windowStartTimeMs= */ C.TIME_UNSET,
+            /* elapsedRealtimeEpochOffsetMs= */ C.TIME_UNSET,
+            /* periodDurationUs= */ 1000 * C.MICROS_PER_SECOND,
+            /* windowDurationUs= */ 1000 * C.MICROS_PER_SECOND,
+            /* windowPositionInPeriodUs= */ 0,
+            /* windowDefaultStartPositionUs= */ 20 * C.MICROS_PER_SECOND,
+            /* isSeekable= */ true,
+            /* isDynamic= */ true,
+            /* manifest= */ null,
+            mediaItem,
+            mediaItem.liveConfiguration);
+    mediaSource.setNewSourceInfo(liveTimeline, true);
+
+    runUntilTimelineChanged(player);
+
+    // Trigger EPII to copy current PlaybackInfo to EP - TODO I'll use
+    player.setPlaybackParameters(new PlaybackParameters(/* speed= */ 2.0f));
+    runUntilPendingCommandsAreFullyHandled(player);
+    long contentPosition = player.getCurrentPosition();
+    player.release();
+
+    assertThat(contentPosition).isEqualTo(expectedInitialPositionUs);
+
+  }
+
+  @Test
   public void onEvents_correspondToListenerCalls() throws Exception {
     ExoPlayer player = new TestExoPlayerBuilder(context).build();
     Player.Listener listener = mock(Player.Listener.class);

--- a/library/core/src/test/java/com/google/android/exoplayer2/source/MaskingMediaSourceTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/source/MaskingMediaSourceTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer2.source;
+
+import android.net.Uri;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.testutil.FakeMediaPeriod;
+import com.google.android.exoplayer2.testutil.MediaSourceTestRunner;
+import com.google.android.exoplayer2.upstream.Allocator;
+import com.google.android.exoplayer2.upstream.TransferListener;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+/** Unit tests for {@link MaskingMediaSource}. */
+@RunWith(AndroidJUnit4.class)
+public class MaskingMediaSourceTest {
+  private static final MediaItem EMPTY_MEDIA_ITEM =
+      new MediaItem.Builder().setUri(Uri.EMPTY).build();
+  @Rule
+  public final MockitoRule mockito = MockitoJUnit.rule();
+
+  @Mock
+  private MediaPeriod mockMediaPeriod;
+
+
+  class FakeDynamicTimelineMediaSource extends BaseMediaSource {
+
+    @Override
+    protected void prepareSourceInternal(TransferListener mediaTransferListener) {
+    }
+
+    @Override
+    protected void releaseSourceInternal() {
+    }
+
+    @Override
+    public MediaItem getMediaItem() {
+      return EMPTY_MEDIA_ITEM;
+    }
+
+    @Override
+    public void maybeThrowSourceInfoRefreshError() {
+    }
+
+    @Override
+    public MediaPeriod createPeriod(MediaPeriodId id, Allocator allocator, long startPositionUs) {
+      return mockMediaPeriod;
+    }
+
+    @Override
+    public void releasePeriod(MediaPeriod mediaPeriod) {
+
+    }
+
+    public void setNewSourceInfo(Timeline liveTimeline) {
+      refreshSourceInfo(liveTimeline);
+    }
+  }
+
+  @Before
+  public void setupMocks() {
+
+  }
+
+  @Test
+  public void onChildSourceInfoRefreshed_withLiveTimeline_initialSeek() throws IOException {
+    MediaItem mediaItem =
+        new MediaItem.Builder().setUri(Uri.EMPTY).build();
+    Timeline liveTimeline =
+        new SinglePeriodTimeline(
+            /* presentationStartTimeMs= */ 0,
+            /* windowStartTimeMs= */ 0,
+            /* elapsedRealtimeEpochOffsetMs= */ C.TIME_UNSET,
+            /* periodDurationUs= */ 1000 * C.MICROS_PER_SECOND,
+            /* windowDurationUs= */ 1000 * C.MICROS_PER_SECOND,
+            /* windowPositionInPeriodUs= */ 0,
+            /* windowDefaultStartPositionUs= */ 20 * C.MICROS_PER_SECOND,
+            /* isSeekable= */ true,
+            /* isDynamic= */ true,
+            /* manifest= */ null,
+            mediaItem,
+            mediaItem.liveConfiguration);
+    Object periodId = liveTimeline.getUidOfPeriod(0);
+    FakeDynamicTimelineMediaSource mediaSource = new FakeDynamicTimelineMediaSource();
+    MaskingMediaSource testedMediaSource = new MaskingMediaSource(mediaSource, true);
+    MediaSourceTestRunner testRunner = new MediaSourceTestRunner(mediaSource, null);
+    try {
+      testRunner.runOnPlaybackThread(() -> {
+        testedMediaSource.prepareSourceInternal(null);
+      });
+
+      // This is the sequence of calls when EPII:
+      //  - lazy prepares the initial masked media source
+      //  - updatePeriods() creates the first period
+      //  - the Timeline update occurs with a live timeline with start position and duration
+
+      testRunner.prepareSourceLazy();
+
+      testRunner.runOnPlaybackThread(() -> {
+        int startPositionUs = 20;   // TODO - if this value is 0, the test will fail, of course it should not.
+        MaskingMediaPeriod period = testedMediaSource.createPeriod(new MediaSource.MediaPeriodId(periodId), null, startPositionUs);
+        mediaSource.setNewSourceInfo(liveTimeline);
+        assertThat(period.getPreparePositionOverrideUs()).isEqualTo(startPositionUs);
+      });
+
+
+      testRunner.releaseSource();
+    } finally {
+      testRunner.release();
+    }
+  }
+}

--- a/testutils/src/main/java/com/google/android/exoplayer2/testutil/MediaSourceTestRunner.java
+++ b/testutils/src/main/java/com/google/android/exoplayer2/testutil/MediaSourceTestRunner.java
@@ -27,6 +27,7 @@ import android.util.Pair;
 import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.LoadEventInfo;
+import com.google.android.exoplayer2.source.MaskingMediaSource;
 import com.google.android.exoplayer2.source.MediaLoadData;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.source.MediaSource;
@@ -129,6 +130,17 @@ public class MediaSourceTestRunner {
       throw prepareError[0];
     }
     return assertTimelineChangeBlocking();
+  }
+
+  /**
+   * Prepares source on playback thread without expecting a timeline change.  Use for "lazy" prepare
+   * MediaSource, e.g. {@link MaskingMediaSource}
+   */
+  public void prepareSourceLazy() {
+    runOnPlaybackThread(
+        () -> {
+          mediaSource.prepareSource(mediaSourceListener, /* mediaTransferListener= */ null);
+        });
   }
 
   /**


### PR DESCRIPTION
First steps for fixing issue #7975 a unit test case[s] that show the bug.   

The first commit, https://github.com/google/ExoPlayer/pull/9174/commits/b9d959cdcdd367d2dabc09bd74f3492c3918c5bf is a functional test, if the fix goes outside of `MaskingMediaSource` itself then we'll need this test case

The next commit, https://github.com/google/ExoPlayer/pull/9174/commits/ac044ae60e is a unit test case for`MaskingMediaSource` itself, if the code change to fix involves how the position override works in this class then this test case should be all we need.

Looking at the logic in [line 2575](https://github.com/google/ExoPlayer/blob/3f5dbf2ef3fe19f392d46027b7ffce0783d28427/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java#L2575)

````java
        } else {
          newPeriodUid = periodPosition.first;
          newContentPositionUs = periodPosition.second;
          // Use explicit initial seek as new target live offset.
          setTargetLiveOffset = true;
        }
````

The initial seek is resolved here, against the `PlaylistTimeline` this happens when the initial `MedaiItem`[s] are set so we have no idea even the duration of the window for the live playlist.   

Also, I believe using this as the target live offset may be a mistake, the usual use case for setting a position in a live playlist with an initial seek is a SOCU (start-over-catchup) where live is buffered to a rolling buffer, in this case you want to treat it more like VOD (the rolling buffer playlist is typically labeled "EVENT" type until the program ends at which point an end tag is added.  

So, there are these basic use cases for live:

1. No initial seek/position set -- default to the playlist requested live offset (default or EXT-X-START)
1. Initial position (usually 0) requested -- start a SOCU (here the playlist duration will be the entire event up to present time, the playlist live point is irrelevant)
1. Saved position ( 0 - duration ) -- return to a saved position in a SOCU playlist.  Here the user has navigated away from playback but returns via a "My Shows" list to the in-progress SOCU recording

The most strait forward fix I see is to make the initial `preparePositionUs` in the `MaskingMediaPeriod` / `MaskingMediaSource` have an unset value unless an initial seek or other explicit user action set it.  This frees up 0 from serving as the default value as well as a possible user choice.

@tonihei and @marcbaechinger you both have way more invested in this code and no doubt a bunch of refactoring plans I'm unaware of, so I don't want to add more test cases to code you may be refactoring away.   As long as the first commit (the functional test) passes with 0 as the seek value the requirements are met and bug #7975 can likely be closed.

