### PR TITLE
Updating WorkManager from 2.5.0 to 2.7.0-alpha04

### DIFF
--- a/extensions/workmanager/build.gradle
+++ b/extensions/workmanager/build.gradle
@@ -17,7 +17,7 @@ apply from: "$gradle.ext.exoplayerSettingsDir/common_library_config.gradle"
 
 dependencies {
     implementation project(modulePrefix + 'library-core')
-    implementation 'androidx.work:work-runtime:2.5.0'
+    implementation 'androidx.work:work-runtime:2.7.0-alpha04'
     compileOnly 'org.jetbrains.kotlin:kotlin-annotations-jvm:' + kotlinAnnotationsVersion
 }
 


### PR DESCRIPTION
There is a behavior change in Android 12 which requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent if the app is targeting Android 12. Current stable versions of WorkManager don’t have these flags, and so it affects all apps directly, or indirectly using WorkManager. 

ExoPlayer's extension has a dependency on an older version of WorkManager and so is affected.

Updating the version 2.7.0-alpha03 to solve this issue.