### PR TITLE
Handle trailing semicolon on RTSP fmtp attribute

### DIFF
--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/MediaDescription.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/MediaDescription.java
@@ -314,7 +314,8 @@ import java.util.HashMap;
 
     // Format of the parameter: RFC3640 Section 4.4.1:
     //   <parameter name>=<value>[; <parameter name>=<value>].
-    String[] parameters = Util.split(fmtpComponents[1], ";\\s?");
+    // Split with implicit limit of 0 to handle an optional trailing semicolon.
+    String[] parameters = fmtpComponents[1].split(";\\s?");
     ImmutableMap.Builder<String, String> formatParametersBuilder = new ImmutableMap.Builder<>();
     for (String parameter : parameters) {
       // The parameter values can bear equal signs, so splitAtFirst must be used.

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/MediaDescription.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/MediaDescription.java
@@ -314,8 +314,8 @@ import java.util.HashMap;
 
     // Format of the parameter: RFC3640 Section 4.4.1:
     //   <parameter name>=<value>[; <parameter name>=<value>].
-    // Split with implicit limit of 0 to handle an optional trailing semicolon.
-    String[] parameters = fmtpComponents[1].split(";\\s?");
+    // Split with an explicit limit of 0 to handle an optional trailing semicolon.
+    String[] parameters = fmtpComponents[1].split(";\\s?", /* limit= */ 0);
     ImmutableMap.Builder<String, String> formatParametersBuilder = new ImmutableMap.Builder<>();
     for (String parameter : parameters) {
       // The parameter values can bear equal signs, so splitAtFirst must be used.

--- a/library/rtsp/src/test/java/com/google/android/exoplayer2/source/rtsp/RtspMediaTrackTest.java
+++ b/library/rtsp/src/test/java/com/google/android/exoplayer2/source/rtsp/RtspMediaTrackTest.java
@@ -81,6 +81,48 @@ public class RtspMediaTrackTest {
   }
 
   @Test
+  public void generatePayloadFormat_withH264MediaDescriptionAndFmtpTrailingSemicolon_succeeds() {
+    MediaDescription mediaDescription =
+        new MediaDescription.Builder(
+            MEDIA_TYPE_VIDEO, /* port= */ 0, RTP_AVP_PROFILE, /* payloadType= */ 96)
+            .setConnection("IN IP4 0.0.0.0")
+            .setBitrate(500_000)
+            .addAttribute(ATTR_RTPMAP, "96 H264/90000")
+            .addAttribute(
+                ATTR_FMTP,
+                "96 packetization-mode=1;profile-level-id=64001F;sprop-parameter-sets=Z2QAH6zZQPARabIAAAMACAAAAwGcHjBjLA==,aOvjyyLA;")
+            .addAttribute(ATTR_CONTROL, "track1")
+            .build();
+
+    RtpPayloadFormat format = RtspMediaTrack.generatePayloadFormat(mediaDescription);
+    RtpPayloadFormat expectedFormat =
+        new RtpPayloadFormat(
+            new Format.Builder()
+                .setSampleMimeType(MimeTypes.VIDEO_H264)
+                .setAverageBitrate(500_000)
+                .setPixelWidthHeightRatio(1.0f)
+                .setHeight(544)
+                .setWidth(960)
+                .setCodecs("avc1.64001F")
+                .setInitializationData(
+                    ImmutableList.of(
+                        new byte[] {
+                            0, 0, 0, 1, 103, 100, 0, 31, -84, -39, 64, -16, 17, 105, -78, 0, 0, 3, 0,
+                            8, 0, 0, 3, 1, -100, 30, 48, 99, 44
+                        },
+                        new byte[] {0, 0, 0, 1, 104, -21, -29, -53, 34, -64}))
+                .build(),
+            /* rtpPayloadType= */ 96,
+            /* clockRate= */ 90_000,
+            /* fmtpParameters= */ ImmutableMap.of(
+            "packetization-mode", "1",
+            "profile-level-id", "64001F",
+            "sprop-parameter-sets", "Z2QAH6zZQPARabIAAAMACAAAAwGcHjBjLA==,aOvjyyLA"));
+
+    assertThat(format).isEqualTo(expectedFormat);
+  }
+
+  @Test
   public void generatePayloadFormat_withAacMediaDescription_succeeds() {
     MediaDescription mediaDescription =
         new MediaDescription.Builder(


### PR DESCRIPTION
As documented [here](https://github.com/google/ExoPlayer/issues/9114#issuecomment-890573497), an `ArrayIndexOutOfBoundsException` occurs if an `a=fmtp` line from an RTSP SDP response ends with a trailing semicolon. This change switches from using a limit of -1 on the String `split(...)` function via the Util class when parsing fmtp parameters, to using the implicit limit of 0. As a result, empty trailing strings are discarded which avoids this error condition.

Fixes #9114 