### PR TITLE
Parse mid-stream SPS NAL units in MP4 streams and update the aspect ratio accordingly

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,0 +1,1 @@
+jdk: openjdk11

--- a/library/common/src/main/java/com/google/android/exoplayer2/util/NalUnitUtil.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/NalUnitUtil.java
@@ -158,6 +158,7 @@ public final class NalUnitUtil {
   private static final int H264_NAL_UNIT_TYPE_SEI = 6; // Supplemental enhancement information
   private static final int H264_NAL_UNIT_TYPE_SPS = 7; // Sequence parameter set
   private static final int H265_NAL_UNIT_TYPE_PREFIX_SEI = 39;
+  private static final int H265_NAL_UNIT_TYPE_SPS = 33;
 
   private static final Object scratchEscapePositionsLock = new Object();
 
@@ -265,6 +266,21 @@ public final class NalUnitUtil {
             && (nalUnitHeaderFirstByte & 0x1F) == H264_NAL_UNIT_TYPE_SEI)
         || (MimeTypes.VIDEO_H265.equals(mimeType)
             && ((nalUnitHeaderFirstByte & 0x7E) >> 1) == H265_NAL_UNIT_TYPE_PREFIX_SEI);
+  }
+
+  /**
+   * Returns whether the NAL unit with the specified header contains a sequence parameter set.
+   *
+   * @param mimeType The sample MIME type, or {@code null} if unknown.
+   * @param nalUnitHeaderFirstByte The first byte of nal_unit().
+   * @return Whether the NAL unit with the specified header is a SPS NAL unit. False is returned if
+   *     the {@code MimeType} is {@code null}.
+   */
+  public static boolean isNalUnitSps(@Nullable String mimeType, byte nalUnitHeaderFirstByte) {
+    return (MimeTypes.VIDEO_H264.equals(mimeType)
+            && (nalUnitHeaderFirstByte & 0x1F) == H264_NAL_UNIT_TYPE_SPS)
+        || (MimeTypes.VIDEO_H265.equals(mimeType)
+            && ((nalUnitHeaderFirstByte & 0x7E) >> 1) == H265_NAL_UNIT_TYPE_SPS);
   }
 
   /**


### PR DESCRIPTION
This PR resolves an issue with HLS/DASH fMP4 streams with changing aspect ratios.

These can occur e.g. in live TV (DVB) streams where the program, for example an old 4:3 movie, is interrupted by a modern 16:9 commercial with a different aspect ratio.  In this scenario, the H264/HEVC elementary stream that was packaged into the fMP4 segments contains SPS NAL units which inform the player about the aspect ratio change.

Currently ExoPlayer ignores them completely which causes the picture to be stretched after an aspect ratio change. 
Also, in case of HEVC, the initial SPS from the `hvcC` atom/box was not parsed for its aspect ratio which resulted in all content being played back with aspect ratio 1:1 ([see here](https://github.com/google/ExoPlayer/compare/dev-v2...MarcusWichelmann:mp4-parse-mid-stream-sps?expand=1#diff-c4f8a7953ee8a7eb6b5c11b5d978b31fe3ab2008951f581840da58f33aaeb33fR1143)).

This PR ...
- introduces a `parseH265SpsNalUnitPayload` method to parse the SPS NAL unit, just like it's done for H.264, too. The parsing code is derived from `H265Reader.parseMediaFormat`.
- extends the `HevcConfig` class to parse the initial SPS and sets the aspect ratio correctly when reading the `hvcC` atom.
- makes sure that the received mid-stream SPS NAL units are parsed instead of being ignored.
- refactors the `buildHevcCodecStringFromSps` method to re-use the parsed SPS data - just like it's done for H.264.

These changes should work just as well for regular MP4 files with changing aspect ratios.

As mentioned above, this PR duplicates the HEVC parsing code from `H265Reader.java`, just like `NalUnitUtil.java` already contained duplicated H.264 parsing code from `H264Reader.java`. This is not optimal and could probably be improved, but I thought that removing redundancies in existing code should not be in the scope of this PR. And also would be a bit more work refactoring work. Instead I tried to keep my new code as close and consistent as possible to how things are currently implemented for H.264.