### PR TITLE
[BUGFIX] RTSP: RTP-Info response validation

### DIFF
--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspMediaPeriod.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspMediaPeriod.java
@@ -512,13 +512,15 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
           trackUrisWithTiming.add(checkNotNull(uriPath));
         }
       }
-      for (int i = 0; i < selectedLoadInfos.size(); i++) {
-        RtpLoadInfo loadInfo = selectedLoadInfos.get(i);
-        if (!trackUrisWithTiming.contains(loadInfo.getTrackUri().getPath())) {
-          playbackException =
-              new RtspPlaybackException(
-                  "Server did not provide timing for track " + loadInfo.getTrackUri());
-          return;
+      if (trackUrisWithTiming.size() > 0) {
+        for (int i = 0; i < selectedLoadInfos.size(); i++) {
+          RtpLoadInfo loadInfo = selectedLoadInfos.get(i);
+          if (!trackUrisWithTiming.contains(loadInfo.getTrackUri().getPath())) {
+            playbackException =
+                    new RtspPlaybackException(
+                            "Server did not provide timing for track " + loadInfo.getTrackUri());
+            return;
+          }
         }
       }
 

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspMediaPeriod.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspMediaPeriod.java
@@ -506,7 +506,11 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       // Validate that the trackTimingList contains timings for the selected tracks.
       ArrayList<String> trackUrisWithTiming = new ArrayList<>(trackTimingList.size());
       for (int i = 0; i < trackTimingList.size(); i++) {
-        trackUrisWithTiming.add(checkNotNull(trackTimingList.get(i).uri.getPath()));
+        String uriPath = trackTimingList.get(i).uri.getPath();
+        // Skip URIs that match trackID=\d+
+        if (!uriPath.matches(RtspResponse.RTP_INFO_URL_TEST)) {
+          trackUrisWithTiming.add(checkNotNull(uriPath));
+        }
       }
       for (int i = 0; i < selectedLoadInfos.size(); i++) {
         RtpLoadInfo loadInfo = selectedLoadInfos.get(i);

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspResponse.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspResponse.java
@@ -26,6 +26,9 @@ package com.google.android.exoplayer2.source.rtsp;
   /** The body of this RTSP message, or empty string if absent. */
   public final String messageBody;
 
+  /** Regex test to match the quirky RTP-Info url responses */
+  public static final String RTP_INFO_URL_TEST = "^(?i)track(id=)?\\d+$";
+
   /**
    * Creates a new instance.
    *

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspTrackTiming.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspTrackTiming.java
@@ -86,7 +86,8 @@ import com.google.common.collect.ImmutableList;
       }
 
       if (uri == null
-          || uri.getScheme() == null // Checks if the URI is a URL.
+          || (uri.getScheme() == null // Checks if the URI is a URL and
+              && !uri.toString().matches(RtspResponse.RTP_INFO_URL_TEST)) // URI is not a quirky one
           || (sequenceNumber == C.INDEX_UNSET && rtpTime == C.TIME_UNSET)) {
         throw ParserException.createForMalformedManifest(perTrackTimingString, /* cause= */ null);
       }


### PR DESCRIPTION
This commit adds a regex test to validate quirky camera server
reponses, that do not return the full URL, but rather a single
parameter, i.e. 'track1' is returned instead of
'rtsp://113.163.157.230:9717/rtsph2641080p/track1'.

The regex test is currently valid for responses like
track1, track222, trackID=1, trackid=222, etc.

The test itself is held as a static constant placed in RtspResponse
class.

Related: #9264