### PR TITLE
TrackSelection does not jump to live with HlsMediaPeriod

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/source/MaskingMediaPeriod.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/MaskingMediaPeriod.java
@@ -178,10 +178,6 @@ public final class MaskingMediaPeriod implements MediaPeriod, MediaPeriod.Callba
       @NullableType SampleStream[] streams,
       boolean[] streamResetFlags,
       long positionUs) {
-    if (preparePositionOverrideUs != C.TIME_UNSET && positionUs == preparePositionUs) {
-      positionUs = preparePositionOverrideUs;
-      preparePositionOverrideUs = C.TIME_UNSET;
-    }
     return castNonNull(mediaPeriod)
         .selectTracks(selections, mayRetainStreamFlags, streams, streamResetFlags, positionUs);
   }

--- a/library/core/src/main/java/com/google/android/exoplayer2/source/MaskingMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/MaskingMediaSource.java
@@ -140,11 +140,6 @@ public final class MaskingMediaSource extends CompositeMediaSource<Void> {
     @Nullable MediaPeriodId idForMaskingPeriodPreparation = null;
     if (isPrepared) {
       timeline = timeline.cloneWithUpdatedTimeline(newTimeline);
-      if (unpreparedMaskingMediaPeriod != null) {
-        // Reset override in case the duration changed and we need to update our override.
-        setPreparePositionOverrideToUnpreparedMaskingPeriod(
-            unpreparedMaskingMediaPeriod.getPreparePositionOverrideUs());
-      }
     } else if (newTimeline.isEmpty()) {
       timeline =
           hasRealTimeline


### PR DESCRIPTION
This is a fix for issue #9347

Once the MaskingMediaPeriod completes `prepare()` (when the masked HlsMediaPeriod reports the
first real Timeline with a duration and window start position) and the `preparePositionUs` is used
by the player in the `onPrepared()` callback to set the render position it should not use it again.

The bug is a track selection causes a jump to live if you are at position 0
in the timeline, even after playback was started from the live point (the prepare position override).