### PR TITLE
Fix metadata being reset when media is repeated

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImpl.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImpl.java
@@ -1265,7 +1265,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
                 .windowIndex;
         mediaItem = newPlaybackInfo.timeline.getWindow(windowIndex, window).mediaItem;
       }
-      newMediaMetadata = mediaItem != null ? mediaItem.mediaMetadata : MediaMetadata.EMPTY;
+      mediaMetadata = mediaItem != null ? mediaItem.mediaMetadata : MediaMetadata.EMPTY;
     }
     if (!previousPlaybackInfo.staticMetadata.equals(newPlaybackInfo.staticMetadata)) {
       newMediaMetadata =


### PR DESCRIPTION
This will fix #9458

When player is set to REPEAT Mode and goes back to position 00:01, all metadata are gone. 

This is working in r2.14.2 and commit `d47d1ebf19a15f59629b220ef9c82b24209e89a7` broke it.