### PR TITLE
Added support for RTSPS

### DIFF
--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspClient.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspClient.java
@@ -289,13 +289,18 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
   /** Returns a {@link Socket} that is connected to the {@code uri}. */
   private static Socket getSocket(Uri uri) throws IOException {
-    checkArgument(uri.getHost() != null);
-    if (uri.getScheme().equals("rtsps")) {
-      int rtspsPort = uri.getPort() > 0 ? uri.getPort() : DEFAULT_RTSPS_PORT;
-      return SSLSocketFactory.getDefault().createSocket(checkNotNull(uri.getHost()), rtspsPort);
-    }
-    int rtspPort = uri.getPort() > 0 ? uri.getPort() : DEFAULT_RTSP_PORT;
-    return SocketFactory.getDefault().createSocket(checkNotNull(uri.getHost()), rtspPort);
+    boolean isRtsps = uri.getScheme().equals("rtsps");
+    int port = uri.getPort() > 0
+        ? uri.getPort()
+        : isRtsps
+        ? DEFAULT_RTSPS_PORT
+        : DEFAULT_RTSP_PORT;
+
+    SocketFactory factory = isRtsps
+        ? SSLSocketFactory.getDefault()
+        : SocketFactory.getDefault();
+
+    return factory.createSocket(checkNotNull(uri.getHost()), port);
   }
 
   private void dispatchRtspError(Throwable error) {

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspClient.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspClient.java
@@ -16,6 +16,7 @@
 package com.google.android.exoplayer2.source.rtsp;
 
 import static com.google.android.exoplayer2.source.rtsp.RtspMessageChannel.DEFAULT_RTSP_PORT;
+import static com.google.android.exoplayer2.source.rtsp.RtspMessageChannel.DEFAULT_RTSPS_PORT;
 import static com.google.android.exoplayer2.source.rtsp.RtspRequest.METHOD_ANNOUNCE;
 import static com.google.android.exoplayer2.source.rtsp.RtspRequest.METHOD_DESCRIBE;
 import static com.google.android.exoplayer2.source.rtsp.RtspRequest.METHOD_GET_PARAMETER;
@@ -67,6 +68,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /** The RTSP client. */
@@ -288,6 +290,10 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
   /** Returns a {@link Socket} that is connected to the {@code uri}. */
   private static Socket getSocket(Uri uri) throws IOException {
     checkArgument(uri.getHost() != null);
+    if (uri.getScheme().equals("rtsps")) {
+      int rtspsPort = uri.getPort() > 0 ? uri.getPort() : DEFAULT_RTSPS_PORT;
+      return SSLSocketFactory.getDefault().createSocket(checkNotNull(uri.getHost()), rtspsPort);
+    }
     int rtspPort = uri.getPort() > 0 ? uri.getPort() : DEFAULT_RTSP_PORT;
     return SocketFactory.getDefault().createSocket(checkNotNull(uri.getHost()), rtspPort);
   }

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspMessageChannel.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspMessageChannel.java
@@ -100,6 +100,12 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
    */
   public static final int DEFAULT_RTSP_PORT = 554;
 
+  /**
+   * The IANA-registered default port for RTSPS. See <a
+   * href="https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml">here</a>
+   */
+  public static final int DEFAULT_RTSPS_PORT = 322;
+
   private final MessageListener messageListener;
   private final Loader receiverLoader;
   private final Map<Integer, InterleavedBinaryDataListener> interleavedBinaryDataListeners;

--- a/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspTrackTiming.java
+++ b/library/rtsp/src/main/java/com/google/android/exoplayer2/source/rtsp/RtspTrackTiming.java
@@ -122,7 +122,7 @@ import com.google.common.collect.ImmutableList;
    */
   @VisibleForTesting
   /* package */ static Uri resolveUri(String urlString, Uri sessionUri) {
-    checkArgument(checkNotNull(sessionUri.getScheme()).equals("rtsp"));
+    checkArgument(checkNotNull(sessionUri.getScheme()).matches("rtsp|rtsps"));
 
     Uri uri = Uri.parse(urlString);
     if (uri.isAbsolute()) {


### PR DESCRIPTION
Adds support for RTSPS (RTSP over SSL) streams by detecting `rtsps://` URL schemes and handling them by using `javax.net.ssl.SSLSocketFactory`. 
If no port is provided within a `rtsps://` URL, 322 is used as the default port, following IANA-registered default port for RTSPS.

Fixes #9494