### PR TITLE
Check direct playback capabilities for automotive devices

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -2306,6 +2306,16 @@ public final class Util {
   }
 
   /**
+   * Returns whether the app is running on an Automotive device.
+   *
+   * @param context Any context.
+   * @return Whether the app is running on an Automotive device.
+   */
+  public static boolean isAutomotive(Context context) {
+    return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE);
+  }
+
+  /**
    * Gets the size of the current mode of the default display, in pixels.
    *
    * <p>Note that due to application UI scaling, the number of pixels made available to applications

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
@@ -90,8 +90,9 @@ public final class AudioCapabilities {
     }
     // AudioTrack.isDirectPlaybackSupported returns true for encodings that are supported for audio
     // offload, as well as for encodings we want to list for passthrough mode. Therefore we only use
-    // it on TV devices, which generally shouldn't support audio offload for surround encodings.
-    if (Util.SDK_INT >= 29 && Util.isTv(context)) {
+    // it on TV and Automotive devices, which generally shouldn't support audio offload for surround
+    // encodings.
+    if (Util.SDK_INT >= 29 && (Util.isTv(context) || Util.isAutomotive(context))) {
       return new AudioCapabilities(
           Api29.getDirectPlaybackSupportedEncodings(), DEFAULT_MAX_CHANNEL_COUNT);
     }


### PR DESCRIPTION
For Automotive devices, surround encodings can be supported via
the passthrough path. Therefore, include automotive in the allowed
device types in the isDirectPlaybackSupported checks. The automotive
system feature is checked, rather then UI_MODE_TYPE_CAR, because
the UI_MODE_TYPE_CAR can be force enabled via
android.app.UiModeManager.enableCarMode(), whereas FEATURE_AUTOMOTIVE
cannot be forced.