### PR TITLE
Convert tag name to lowercase in webvtt

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/webvtt/WebvttCueParser.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/webvtt/WebvttCueParser.java
@@ -743,7 +743,7 @@ public final class WebvttCueParser {
   private static String getTagName(String tagExpression) {
     tagExpression = tagExpression.trim();
     Assertions.checkArgument(!tagExpression.isEmpty());
-    return Util.splitAtFirst(tagExpression, "[ \\.]")[0];
+    return Util.splitAtFirst(tagExpression, "[ \\.]")[0].toLowerCase();
   }
 
   private static List<StyleMatch> getApplicableStyles(


### PR DESCRIPTION
This commit converts `getTagName()`'s value to lowercase to support `isSupportedTag()` which is case-sensitive function.

https://github.com/google/ExoPlayer/blob/02f7aafe67b4893134a31ea55a3ba0f0535df145/library/core/src/main/java/com/google/android/exoplayer2/text/webvtt/WebvttCueParser.java#L513-L525

https://github.com/google/ExoPlayer/blob/02f7aafe67b4893134a31ea55a3ba0f0535df145/library/core/src/main/java/com/google/android/exoplayer2/text/webvtt/WebvttCueParser.java#L130-L137