### PR TITLE
Fix getCurrentWindowIndex documentation

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/Player.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/Player.java
@@ -2119,7 +2119,7 @@ public interface Player {
   /** Returns the index of the period currently being played. */
   int getCurrentPeriodIndex();
 
-  /** @deprecated Use {@link #getCurrentMediaItem()} instead. */
+  /** @deprecated Use {@link #getCurrentMediaItemIndex()} instead. */
   @Deprecated
   int getCurrentWindowIndex();
 


### PR DESCRIPTION
I think there is a small mistake in the documentation that slipped through