### PR TITLE
fix ArrayIndexOutOfBoundsException when playing flv

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/flv/ScriptTagPayloadReader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/flv/ScriptTagPayloadReader.java
@@ -89,6 +89,9 @@ import java.util.Map;
       // We're only interested in metadata.
       return false;
     }
+    if (data.getData().length <= data.getPosition()) {
+      return false;
+    }
     int type = readAmfType(data);
     if (type != AMF_TYPE_ECMA_ARRAY) {
       // We're not interested in this metadata.


### PR DESCRIPTION
An ArrayIndexOutOfBoundsException happened to me when I used exoplayer on my android app.
```
java.lang.ArrayIndexOutOfBoundsException: length=13; index=13
        at com.google.android.exoplayer2.util.ParsableByteArray.readUnsignedByte(ParsableByteArray.java:233)
        at com.google.android.exoplayer2.extractor.flv.ScriptTagPayloadReader.readAmfType(ScriptTagPayloadReader.java:139)
        at com.google.android.exoplayer2.extractor.flv.ScriptTagPayloadReader.parsePayload(ScriptTagPayloadReader.java:95)
        at com.google.android.exoplayer2.extractor.flv.TagPayloadReader.consume(TagPayloadReader.java:59)
        at com.google.android.exoplayer2.extractor.flv.FlvExtractor.readTagData(FlvExtractor.java:270)
        at com.google.android.exoplayer2.extractor.flv.FlvExtractor.read(FlvExtractor.java:170)
        at com.google.android.exoplayer2.source.BundledExtractorsAdapter.read(BundledExtractorsAdapter.java:127)
        at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:1046)
        at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:409)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
```
You will see it when you playing rtmp://rtmpwslive.newscctv.net/live/459e80daf6994cac803d258df5c74eb2 (This stream comes from China. Maybe there are some problems when playing it out of China. But this bug surely exists.). It's an flv inside the stream. Oddly, there is only "onMetaData" marker inside the script tag of the flv. Nothing else. No sream properties. So when the method readAmfType is called, ArrayIndexOutOfBoundsException will be thrown.