### PR TITLE
Uses correct index for playlist URL

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -255,7 +255,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     HlsMediaPlaylist mediaPlaylist =
         selectedIndex < playlistUrls.length && selectedIndex != C.INDEX_UNSET
             ? playlistTracker.getPlaylistSnapshot(
-                playlistUrls[selectedIndex], /* isForPlayback= */ true)
+                playlistUrls[trackSelection.getIndexInTrackGroup(selectedIndex)], /* isForPlayback= */ true)
             : null;
 
     if (mediaPlaylist == null

--- a/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsChunkSourceTest.java
+++ b/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsChunkSourceTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.when;
 import android.net.Uri;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.SeekParameters;
 import com.google.android.exoplayer2.analytics.PlayerId;
@@ -32,6 +34,8 @@ import com.google.android.exoplayer2.source.hls.playlist.HlsPlaylistTracker;
 import com.google.android.exoplayer2.testutil.ExoPlayerTestRunner;
 import com.google.android.exoplayer2.testutil.FakeDataSource;
 import com.google.android.exoplayer2.testutil.TestUtil;
+import com.google.android.exoplayer2.util.MimeTypes;
+
 import java.io.IOException;
 import java.io.InputStream;
 import org.junit.Before;
@@ -49,7 +53,15 @@ public class HlsChunkSourceTest {
       "media/m3u8/media_playlist_independent_segments";
   private static final String PLAYLIST_EMPTY = "media/m3u8/media_playlist_empty";
   private static final Uri PLAYLIST_URI = Uri.parse("http://example.com/");
-  private static final long PLAYLIST_START_PERIOD_OFFSET_US = 8_000_000L;
+  private static final Uri IFRAME_URI = Uri.parse("http://example.com/iframe");
+  private static final Format IFRAME_FORMAT =
+      new Format.Builder()
+          .setSampleMimeType(MimeTypes.VIDEO_H264)
+          .setAverageBitrate(30_000)
+          .setWidth(1280)
+          .setHeight(720)
+          .setRoleFlags(C.ROLE_FLAG_TRICK_PLAY)
+          .build();  private static final long PLAYLIST_START_PERIOD_OFFSET_US = 8_000_000L;
 
   private final HlsExtractorFactory mockExtractorFactory = HlsExtractorFactory.DEFAULT;
 
@@ -72,8 +84,8 @@ public class HlsChunkSourceTest {
         new HlsChunkSource(
             mockExtractorFactory,
             mockPlaylistTracker,
-            new Uri[] {PLAYLIST_URI},
-            new Format[] {ExoPlayerTestRunner.VIDEO_FORMAT},
+            new Uri[] {IFRAME_URI, PLAYLIST_URI},
+            new Format[] {IFRAME_FORMAT, ExoPlayerTestRunner.VIDEO_FORMAT},
             new DefaultHlsDataSourceFactory(new FakeDataSource.Factory()),
             /* mediaTransferListener= */ null,
             new TimestampAdjusterProvider(),


### PR DESCRIPTION
The TrackSelection API returns two indexes, the index of the selected
track (`getSelectedIndex()`) and the index in the `TrackGroup`.  The `HlsChunkSource`
and  `HlsSampleStreamWrapper` should only work with the later.

Actually the `getSelectedIndex()`, current selected track index is really only useful on
the API to determine if there is a valid selection or not.  The index is
really internal to `TrackSelection`