### PR TITLE
Skip Network check for local content 

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadHelper.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadHelper.java
@@ -726,7 +726,7 @@ public final class DownloadHelper {
    * @return The built {@link DownloadRequest}.
    */
   public DownloadRequest getDownloadRequest(@Nullable byte[] data) {
-    return getDownloadRequest(localConfiguration.uri.toString(), data);
+    return getDownloadRequest(localConfiguration.uri.toString(), data, false);
   }
 
   /**
@@ -738,6 +738,29 @@ public final class DownloadHelper {
    * @return The built {@link DownloadRequest}.
    */
   public DownloadRequest getDownloadRequest(String id, @Nullable byte[] data) {
+    return getDownloadRequest(id, data, false);
+  }
+
+  /**
+   * Builds a {@link DownloadRequest} for downloading the selected tracks. Must not be called until
+   * after preparation completes. The uri of the {@link DownloadRequest} will be used as content id.
+   *
+   * @param data Application provided data to store in {@link DownloadRequest#data}.
+   * @return The built {@link DownloadRequest}.
+   */
+  public DownloadRequest getDownloadRequest(@Nullable byte[] data, boolean offlineHint) {
+    return getDownloadRequest(localConfiguration.uri.toString(), data, offlineHint);
+  }
+
+  /**
+   * Builds a {@link DownloadRequest} for downloading the selected tracks. Must not be called until
+   * after preparation completes.
+   *
+   * @param id The unique content id.
+   * @param data Application provided data to store in {@link DownloadRequest#data}.
+   * @return The built {@link DownloadRequest}.
+   */
+  public DownloadRequest getDownloadRequest(String id, @Nullable byte[] data, boolean offlineHint) {
     DownloadRequest.Builder requestBuilder =
         new DownloadRequest.Builder(id, localConfiguration.uri)
             .setMimeType(localConfiguration.mimeType)
@@ -746,6 +769,7 @@ public final class DownloadHelper {
                     ? localConfiguration.drmConfiguration.getKeySetId()
                     : null)
             .setCustomCacheKey(localConfiguration.customCacheKey)
+            .setOfflineContentHint(offlineHint)
             .setData(data);
     if (mediaSource == null) {
       return requestBuilder.build();

--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadManager.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadManager.java
@@ -1016,7 +1016,7 @@ public final class DownloadManager {
         return activeTask;
       }
 
-      if (!canDownloadsRun() || activeDownloadTaskCount >= maxParallelDownloads) {
+      if (!canDownloadsRun(download) || activeDownloadTaskCount >= maxParallelDownloads) {
         return null;
       }
 
@@ -1042,7 +1042,7 @@ public final class DownloadManager {
     private void syncDownloadingDownload(
         Task activeTask, Download download, int accumulatingDownloadTaskCount) {
       Assertions.checkState(!activeTask.isRemove);
-      if (!canDownloadsRun() || accumulatingDownloadTaskCount >= maxParallelDownloads) {
+      if (!canDownloadsRun(download) || accumulatingDownloadTaskCount >= maxParallelDownloads) {
         putDownloadWithState(download, STATE_QUEUED, STOP_REASON_NONE);
         activeTask.cancel(/* released= */ false);
       }
@@ -1203,8 +1203,8 @@ public final class DownloadManager {
 
     // Helper methods.
 
-    private boolean canDownloadsRun() {
-      return !downloadsPaused && notMetRequirements == 0;
+    private boolean canDownloadsRun(Download download) {
+      return !downloadsPaused && (notMetRequirements == 0 || ((notMetRequirements == Requirements.NETWORK || notMetRequirements == Requirements.NETWORK_UNMETERED) && download.request.offlineContentHint));
     }
 
     private Download putDownloadWithState(

--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadRequest.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadRequest.java
@@ -47,11 +47,16 @@ public final class DownloadRequest implements Parcelable {
     @Nullable private byte[] keySetId;
     @Nullable private String customCacheKey;
     @Nullable private byte[] data;
-
+    private Boolean offlineContentHint;
     /** Creates a new instance with the specified id and uri. */
     public Builder(String id, Uri uri) {
       this.id = id;
       this.uri = uri;
+    }
+
+    public Builder setOfflineContentHint(Boolean offlineContentHint){
+      this.offlineContentHint = offlineContentHint;
+      return this;
     }
 
     /** Sets the {@link DownloadRequest#mimeType}. */
@@ -92,7 +97,8 @@ public final class DownloadRequest implements Parcelable {
           streamKeys != null ? streamKeys : ImmutableList.of(),
           keySetId,
           customCacheKey,
-          data);
+          data,
+          offlineContentHint);
     }
   }
 
@@ -117,6 +123,7 @@ public final class DownloadRequest implements Parcelable {
   @Nullable public final String customCacheKey;
   /** Application defined data associated with the download. May be empty. */
   public final byte[] data;
+  public final Boolean offlineContentHint;
 
   /**
    * @param id See {@link #id}.
@@ -133,7 +140,8 @@ public final class DownloadRequest implements Parcelable {
       List<StreamKey> streamKeys,
       @Nullable byte[] keySetId,
       @Nullable String customCacheKey,
-      @Nullable byte[] data) {
+      @Nullable byte[] data,
+      Boolean offlineContentHint) {
     @C.ContentType int contentType = Util.inferContentTypeForUriAndMimeType(uri, mimeType);
     if (contentType == C.TYPE_DASH || contentType == C.TYPE_HLS || contentType == C.TYPE_SS) {
       Assertions.checkArgument(
@@ -148,6 +156,7 @@ public final class DownloadRequest implements Parcelable {
     this.keySetId = keySetId != null ? Arrays.copyOf(keySetId, keySetId.length) : null;
     this.customCacheKey = customCacheKey;
     this.data = data != null ? Arrays.copyOf(data, data.length) : Util.EMPTY_BYTE_ARRAY;
+    this.offlineContentHint = offlineContentHint;
   }
 
   /* package */ DownloadRequest(Parcel in) {
@@ -163,6 +172,7 @@ public final class DownloadRequest implements Parcelable {
     keySetId = in.createByteArray();
     customCacheKey = in.readString();
     data = castNonNull(in.createByteArray());
+    offlineContentHint = in.readByte() != 0;;
   }
 
   /**
@@ -172,7 +182,7 @@ public final class DownloadRequest implements Parcelable {
    * @return The copy with the specified ID.
    */
   public DownloadRequest copyWithId(String id) {
-    return new DownloadRequest(id, uri, mimeType, streamKeys, keySetId, customCacheKey, data);
+    return new DownloadRequest(id, uri, mimeType, streamKeys, keySetId, customCacheKey, data, offlineContentHint);
   }
 
   /**
@@ -182,7 +192,7 @@ public final class DownloadRequest implements Parcelable {
    * @return The copy with the specified key set ID.
    */
   public DownloadRequest copyWithKeySetId(@Nullable byte[] keySetId) {
-    return new DownloadRequest(id, uri, mimeType, streamKeys, keySetId, customCacheKey, data);
+    return new DownloadRequest(id, uri, mimeType, streamKeys, keySetId, customCacheKey, data, offlineContentHint);
   }
 
   /**
@@ -218,7 +228,7 @@ public final class DownloadRequest implements Parcelable {
         mergedKeys,
         newRequest.keySetId,
         newRequest.customCacheKey,
-        newRequest.data);
+        newRequest.data, newRequest.offlineContentHint);
   }
 
   /** Returns a {@link MediaItem} for the content defined by the request. */
@@ -249,7 +259,8 @@ public final class DownloadRequest implements Parcelable {
         && streamKeys.equals(that.streamKeys)
         && Arrays.equals(keySetId, that.keySetId)
         && Util.areEqual(customCacheKey, that.customCacheKey)
-        && Arrays.equals(data, that.data);
+        && Arrays.equals(data, that.data)
+        && offlineContentHint==that.offlineContentHint;
   }
 
   @Override
@@ -261,6 +272,7 @@ public final class DownloadRequest implements Parcelable {
     result = 31 * result + Arrays.hashCode(keySetId);
     result = 31 * result + (customCacheKey != null ? customCacheKey.hashCode() : 0);
     result = 31 * result + Arrays.hashCode(data);
+    result = 31 * result + offlineContentHint.hashCode();
     return result;
   }
 
@@ -283,6 +295,7 @@ public final class DownloadRequest implements Parcelable {
     dest.writeByteArray(keySetId);
     dest.writeString(customCacheKey);
     dest.writeByteArray(data);
+    dest.writeByte((byte) (offlineContentHint ? 1 : 0));
   }
 
   public static final Parcelable.Creator<DownloadRequest> CREATOR =


### PR DESCRIPTION
Ability to continue downloading content from local storage while not connected to internet for example migrating existing downloaded content to exoplayer by skipping network requirement  check. 