### PR TITLE
Unused parameter chunkExtractorFactory in the constructor of DefaultDashChunkSource

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java
@@ -217,7 +217,7 @@ public class DefaultDashChunkSource implements DashChunkSource {
               periodDurationUs,
               representation,
               selectedBaseUrl != null ? selectedBaseUrl : representation.baseUrls.get(0),
-              BundledChunkExtractor.FACTORY.createProgressiveMediaExtractor(
+              chunkExtractorFactory.createProgressiveMediaExtractor(
                   trackType,
                   representation.format,
                   enableEventMessageTrack,


### PR DESCRIPTION
The parameter chunkExtractorFactory is not used in the constructor of DefaultDashChunkSource, which prevents the usage of a custom extractor.

This parameter is first passed to the DefaultDashChunkSource.Factory [here](https://github.com/google/ExoPlayer/blob/release-v2/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashChunkSource.java#L92).