### PR TITLE
Build any pull request with Github action

### DIFF
--- a/.github/workflows/Android-CI.yml
+++ b/.github/workflows/Android-CI.yml
@@ -1,0 +1,20 @@
+name: PullRequest
+
+on: [ pull_request ]
+
+jobs:
+  buildTest:
+    name: Build SDK for Android
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.2
+        with:
+          fetch-depth: 0
+      - name: Install JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Build ExoPlayer
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
Currently only assemble works properly.
When this is merged, a greadle task `check` or `test` could be added as well. But it needs some fixes.
Best would be a call of `build` task