### PR TITLE
Cea708Decoder: Honor service block size

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/cea/Cea708Decoder.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/cea/Cea708Decoder.java
@@ -327,7 +327,10 @@ public final class Cea708Decoder extends CeaDecoder {
     // 8.10.4 for more details.
     boolean cuesNeedUpdate = false;
 
-    while (serviceBlockPacket.bitsLeft() > 0) {
+    // Check we are protocol and buffer boundaries (buffer boundaries should never exceed
+    // protocol defined boundaries, but check to avoid crashes in case block is bad encoded)
+    int endBlockPosition = serviceBlockPacket.getPosition() + (blockSize * 8);
+    while (serviceBlockPacket.bitsLeft() > 0 && serviceBlockPacket.getPosition() < endBlockPosition) {
       int command = serviceBlockPacket.readBits(8);
       if (command != COMMAND_EXT1) {
         if (command <= GROUP_C0_END) {


### PR DESCRIPTION
The current implementation of ExoPlayer Cea708 is processing the whole service block without taking into account the defined service block size, which could cause the execution of unwanted command.

The following set of Cea708 represents a real use case of the above.

``` hex
FC9420FD152FFF0929FE8CFCFE9818FEE332FE731FFE1044FE8B03FE8CFCFE0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FC942CFD1520FF4649FE8CFEFE9918FEE332FE731FFE1000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FC942FFD9470FF8924FE8B03FE8CFCFE4A92FE0300FE9005FE0091FE2A00FE0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FC9420FD97A1FFC829FE8CFEFE9918FEE332FE731FFE1043FE9203FE0100FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FC94D6FDCEEFFF082AFE9202FE0C90FE0500FE912AFE0000FE424EFE6F00FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FCC168FD20F4FF4422FE4168FE4220FE7400FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FC2C20FDE520FF8422FE2C20FE4265FE2000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FC64EFFD70EFFFC422FE646FFE4270FE6F00FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FC6EA7FD6E67FF0422FE6E27FE426EFE6700FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FCF420FD6173FF4422FE7420FE4261FE7300FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FC67E5FD206DFF8422FE6765FE4220FE6D00FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
FCF480FD7579FFC422FE7403FE4275FE7900FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000FA0000
```

The above frames should be displaying the following text on the screen (or at least the first part of it).

```
Ah, don't get
all sappy about it
```

ExoPlayer is currently parsing this block as follow (in parentheses the defined service block size):

```
(2) 22416842207400
G0 A
G0 h
G0 B
G0 \u0020
G0 t
C0 COMMAND_NUL

(2) 222C2042652000
G0 ,
G0 \u0020
G0 B
G0 e
G0 \u0020
C0 COMMAND_NUL

(2) 22646F42706F00
G0 d
G0 o
G0 B
G0 p
G0 o
C0 COMMAND_NUL

(2) 226E27426E6700
G0 n
G0 '
G0 B
G0 n
G0 g
C0 COMMAND_NUL

(2) 22742042617300
G0 t
G0 \u0020
G0 B
G0 a
G0 s
C0 COMMAND_NUL

(2) 22676542206D00
G0 g
G0 e
G0 B
G0 \u0020
G0 m
C0 COMMAND_NUL

(2) 22740342757900
G0 t
C0 COMMAND_ETX
G0 B
G0 u
G0 y
C0 COMMAND_NUL

(2) 2392030C4220730000
C1 COMMAND_SPL
G0 B
G0 \u0020
G0 s
C0 COMMAND_NUL
C0 COMMAND_NUL

(2) 22616C42656E00
G0 a
G0 l
G0 B
G0 e
G0 n
C0 COMMAND_NUL
```

So it ended up processing the following cue text (additional unwanted commands could be executed as well)

```
AhB t, Be doBpon'Bngt BasgeB mt
BuyB salBen
```

If instead the parsing logic take into account the service block size

```
(2) 22416842207400
G0 A
G0 h

(2) 222C2042652000
G0 ,
G0 \u0020

(2) 22646F42706F00
G0 d
G0 o

(2) 226E27426E6700
G0 n
G0 '

(2) 22742042617300
G0 t
G0 \u0020

(2) 22676542206D00
G0 g
G0 e

(2) 22740342757900
G0 t
C0 COMMAND_ETX

(2) 2392030C4220730000
C1 COMMAND_SPL

(2) 22616C42656E00
G0 a
G0 l
```
which is translated to (again I didn't processed all the frames, just a few of them)

```
Ah, don't get
al
```
which is what we are looking for.

This PR modifies service block parsing logic to honor service block size instead of read the full service block buffer.