### PR TITLE
Changing library loader, so we could use dynamic delivery.

### DIFF
--- a/extensions/av1/src/main/java/com/google/android/exoplayer2/ext/av1/Gav1Library.java
+++ b/extensions/av1/src/main/java/com/google/android/exoplayer2/ext/av1/Gav1Library.java
@@ -25,7 +25,12 @@ public final class Gav1Library {
     ExoPlayerLibraryInfo.registerModule("goog.exo.gav1");
   }
 
-  private static final LibraryLoader LOADER = new LibraryLoader("gav1JNI");
+  private static final LibraryLoader LOADER = new LibraryLoader("gav1JNI") {
+    @Override
+    protected void loadLibrary(String name) {
+      System.loadLibrary(name);
+    }
+  };
 
   private Gav1Library() {}
 

--- a/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegLibrary.java
+++ b/extensions/ffmpeg/src/main/java/com/google/android/exoplayer2/ext/ffmpeg/FfmpegLibrary.java
@@ -32,7 +32,13 @@ public final class FfmpegLibrary {
 
   private static final String TAG = "FfmpegLibrary";
 
-  private static final LibraryLoader LOADER = new LibraryLoader("ffmpegJNI");
+  private static final LibraryLoader LOADER =
+      new LibraryLoader("ffmpegJNI") {
+        @Override
+        protected void loadLibrary(String name) {
+          System.loadLibrary(name);
+        }
+      };
 
   private static @MonotonicNonNull String version;
   private static int inputBufferPaddingSize = C.LENGTH_UNSET;

--- a/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacLibrary.java
+++ b/extensions/flac/src/main/java/com/google/android/exoplayer2/ext/flac/FlacLibrary.java
@@ -25,7 +25,12 @@ public final class FlacLibrary {
     ExoPlayerLibraryInfo.registerModule("goog.exo.flac");
   }
 
-  private static final LibraryLoader LOADER = new LibraryLoader("flacJNI");
+  private static final LibraryLoader LOADER = new LibraryLoader("flacJNI") {
+    @Override
+    protected void loadLibrary(String name) {
+      System.loadLibrary(name);
+    }
+  };
 
   private FlacLibrary() {}
 

--- a/extensions/opus/src/main/java/com/google/android/exoplayer2/ext/opus/OpusLibrary.java
+++ b/extensions/opus/src/main/java/com/google/android/exoplayer2/ext/opus/OpusLibrary.java
@@ -27,7 +27,13 @@ public final class OpusLibrary {
     ExoPlayerLibraryInfo.registerModule("goog.exo.opus");
   }
 
-  private static final LibraryLoader LOADER = new LibraryLoader("opusV2JNI");
+  private static final LibraryLoader LOADER = new LibraryLoader("opusV2JNI") {
+    @Override
+    protected void loadLibrary(String name) {
+      System.loadLibrary(name);
+    }
+  };
+
   @C.CryptoType private static int cryptoType = C.CRYPTO_TYPE_UNSUPPORTED;
 
   private OpusLibrary() {}

--- a/extensions/vp9/src/main/java/com/google/android/exoplayer2/ext/vp9/VpxLibrary.java
+++ b/extensions/vp9/src/main/java/com/google/android/exoplayer2/ext/vp9/VpxLibrary.java
@@ -27,7 +27,13 @@ public final class VpxLibrary {
     ExoPlayerLibraryInfo.registerModule("goog.exo.vpx");
   }
 
-  private static final LibraryLoader LOADER = new LibraryLoader("vpx", "vpxV2JNI");
+  private static final LibraryLoader LOADER = new LibraryLoader("vpx", "vpxV2JNI") {
+    @Override
+    protected void loadLibrary(String name) {
+      System.loadLibrary(name);
+    }
+  };
+
   @C.CryptoType private static int cryptoType = C.CRYPTO_TYPE_UNSUPPORTED;
 
   private VpxLibrary() {}

--- a/library/common/src/main/java/com/google/android/exoplayer2/util/LibraryLoader.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/LibraryLoader.java
@@ -18,7 +18,7 @@ package com.google.android.exoplayer2.util;
 import java.util.Arrays;
 
 /** Configurable loader for native libraries. */
-public final class LibraryLoader {
+public abstract class LibraryLoader {
 
   private static final String TAG = "LibraryLoader";
 
@@ -40,6 +40,15 @@ public final class LibraryLoader {
     nativeLibraries = libraries;
   }
 
+  /**
+   * For dynamic delivery to work this method has to be overriden
+   * Dynamic delivery identify the classloader by the stacktrace frame.
+   *
+   * We need to make sure that classes with native methods are loaded by the same classloader that
+   * had been used to load the native library.
+   */
+  abstract protected void loadLibrary(String name);
+
   /** Returns whether the underlying libraries are available, loading them if necessary. */
   public synchronized boolean isAvailable() {
     if (loadAttempted) {
@@ -48,7 +57,7 @@ public final class LibraryLoader {
     loadAttempted = true;
     try {
       for (String lib : nativeLibraries) {
-        System.loadLibrary(lib);
+        loadLibrary(lib);
       }
       isAvailable = true;
     } catch (UnsatisfiedLinkError exception) {


### PR DESCRIPTION
**Background**
Dynamic delivery uses secondary class loader to load the classes.
According to JNI specification the native library should be downloaded by the same classloader that was used to load the classes with the native method.

The way android detects the class loader to use for the
System.loadLibrary call is a bit spooky:
It uses `Reflection.getCallerClass()` method which is basically takes the stack frame #2 from the call stack to find the caller class.

The caller class is always the LibraryLoader in this scenario. As this is the class loaded by the default system class loader the native library can't be used.

**Change**
- LibraryLoader is abstract class now
- There is an abstract method that should be overridden by every user of the class
- all call-sites updated