### PR TITLE
Add Dialog Enhancement Control support for AC4 audio tracks

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -37,6 +37,7 @@ import com.google.android.exoplayer2.Player.PlaybackSuppressionReason;
 import com.google.android.exoplayer2.Player.RepeatMode;
 import com.google.android.exoplayer2.analytics.AnalyticsCollector;
 import com.google.android.exoplayer2.analytics.PlayerId;
+import com.google.android.exoplayer2.audio.MediaCodecAudioRenderer;
 import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.metadata.MetadataRenderer;
@@ -2302,6 +2303,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
       if (renderer != null) {
         renderer.setPlaybackSpeed(
             currentPlaybackSpeed, /* targetPlaybackSpeed= */ playbackParameters.speed);
+
+        if (renderer.getName().equals("MediaCodecAudioRenderer")) {
+          MediaCodecAudioRenderer ar = (MediaCodecAudioRenderer) renderer;
+          ar.ConfigureAC4(playbackParameters.dialogEnhancementGain);
+        }
       }
     }
   }

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java
@@ -15,6 +15,8 @@
  */
 package com.google.android.exoplayer2.audio;
 
+import static com.google.android.exoplayer2.PlaybackParameters.MAX_AC4_DE;
+import static com.google.android.exoplayer2.PlaybackParameters.MIN_AC4_DE;
 import static com.google.android.exoplayer2.audio.AudioCapabilities.DEFAULT_AUDIO_CAPABILITIES;
 import static com.google.android.exoplayer2.util.Assertions.checkNotNull;
 import static com.google.android.exoplayer2.util.Util.constrainValue;
@@ -377,6 +379,7 @@ public final class DefaultAudioSink implements AudioSink {
   public static final float MIN_PITCH = 0.1f;
   /** The maximum allowed pitch factor. Higher values will be constrained to fall in range. */
   public static final float MAX_PITCH = 8f;
+
 
   /** The default skip silence flag. */
   private static final boolean DEFAULT_SKIP_SILENCE = false;
@@ -1279,7 +1282,8 @@ public final class DefaultAudioSink implements AudioSink {
     playbackParameters =
         new PlaybackParameters(
             constrainValue(playbackParameters.speed, MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED),
-            constrainValue(playbackParameters.pitch, MIN_PITCH, MAX_PITCH));
+            constrainValue(playbackParameters.pitch, MIN_PITCH, MAX_PITCH),
+            constrainValue(playbackParameters.dialogEnhancementGain, MIN_AC4_DE, MAX_AC4_DE));
     if (enableAudioTrackPlaybackParams && Util.SDK_INT >= 23) {
       setAudioTrackPlaybackParametersV23(playbackParameters);
     } else {

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/MediaCodecAudioRenderer.java
@@ -27,6 +27,8 @@ import android.media.AudioFormat;
 import android.media.MediaCodec;
 import android.media.MediaCrypto;
 import android.media.MediaFormat;
+import android.os.Build;
+import android.os.Bundle;
 import android.os.Handler;
 import androidx.annotation.CallSuper;
 import androidx.annotation.Nullable;
@@ -166,6 +168,18 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
                 firstNonNull(audioCapabilities, AudioCapabilities.DEFAULT_AUDIO_CAPABILITIES))
             .setAudioProcessors(audioProcessors)
             .build());
+  }
+
+  public void ConfigureAC4(int dialogEnhancementGain) {
+
+      if (audioCodecInfo != null && audioCodecInfo.name.contains("ac4")) {
+        Bundle bundle = new Bundle(1);
+        bundle.putInt("vendor.dolby.dialog-enhancement-gain.value", dialogEnhancementGain);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+          super.getCodec().setParameters(bundle);
+        }
+      }
   }
 
   /**
@@ -348,6 +362,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
         decoderSupport);
   }
 
+  MediaCodecInfo audioCodecInfo;
   @Override
   protected List<MediaCodecInfo> getDecoderInfos(
       MediaCodecSelector mediaCodecSelector, Format format, boolean requiresSecureDecoder)
@@ -416,6 +431,7 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       Format format,
       @Nullable MediaCrypto crypto,
       float codecOperatingRate) {
+    audioCodecInfo = codecInfo;
     codecMaxInputSize = getCodecMaxInputSize(codecInfo, format, getStreamFormats());
     codecNeedsDiscardChannelsWorkaround = codecNeedsDiscardChannelsWorkaround(codecInfo.name);
     MediaFormat mediaFormat =
@@ -494,6 +510,9 @@ public class MediaCodecAudioRenderer extends MediaCodecRenderer implements Media
       throws ExoPlaybackException {
     @Nullable DecoderReuseEvaluation evaluation = super.onInputFormatChanged(formatHolder);
     eventDispatcher.inputFormatChanged(formatHolder.format, evaluation);
+
+    /* To DO: set the last applied preference */
+    ConfigureAC4(0);
     return evaluation;
   }
 

--- a/library/ui/src/main/res/values/strings.xml
+++ b/library/ui/src/main/res/values/strings.xml
@@ -83,6 +83,21 @@
     <item>1.5x</item>
     <item>2x</item>
   </string-array>
+
+  <integer-array name="exo_ac4_de_gains_db">
+    <item>0</item>
+    <item>3</item>
+    <item>6</item>
+    <item>9</item>
+  </integer-array>
+
+  <string-array translatable="false" name="exo_ac4_de_gains">
+    <item> Off </item>
+    <item> Low </item>
+    <item> Mid </item>
+    <item> High </item>
+  </string-array>
+
   <!-- LINT.ThenChange(../../java/com/google/android/exoplayer2/ui/StyledPlayerControlView.java:playback_speeds) -->
   <!-- Shown to indicate a custom playback speed. [CHAR_LIMIT=16] -->
   <string translatable="false" name="exo_controls_custom_playback_speed"><xliff:g id="playback_speed" example="1.05">%1$.2f</xliff:g>x</string>


### PR DESCRIPTION
The AC4 audio decoder features a dialog enhancement mode
that allows the user to boost the dialog from the played
content.
The boost of the dialog can be tuned to the listener's
need.
This patch maps the control of the dialog boost as a
user controllable playback parameter (like playback speed or
pitch) and proposes a possible implementation in the  UI
in the form of "off, low, mid, high" presets.

- tested on Lenovo P11 tablet and samsung phones

Signed-off-by: glass <glass@dolby.com>