### PR TITLE
Add Dialog Enhancement Control support for AC4 audio tracks

### DIFF
--- a/extensions/cast/src/main/java/com/google/android/exoplayer2/ext/cast/CastPlayer.java
+++ b/extensions/cast/src/main/java/com/google/android/exoplayer2/ext/cast/CastPlayer.java
@@ -31,6 +31,7 @@ import com.google.android.exoplayer2.BasePlayer;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.DeviceInfo;
 import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
+import com.google.android.exoplayer2.MediaCodecParameters;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.MediaMetadata;
 import com.google.android.exoplayer2.PlaybackException;
@@ -744,6 +745,16 @@ public final class CastPlayer extends BasePlayer {
   @Override
   public void setDeviceMuted(boolean muted) {}
 
+  @Override
+  public void setMediaCodecParameters(MediaCodecParameters mediaCodecParameters) {
+
+  }
+
+  @Override
+  public MediaCodecParameters getMediaCodecParameters() {
+    MediaCodecParameters mediaCodecParameters = new MediaCodecParameters();
+    return mediaCodecParameters;
+  }
   // Internal methods.
 
   // Call deprecated callbacks.

--- a/library/common/src/main/java/com/google/android/exoplayer2/ForwardingPlayer.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/ForwardingPlayer.java
@@ -800,6 +800,16 @@ public class ForwardingPlayer implements Player {
     player.setDeviceMuted(muted);
   }
 
+  @Override
+  public void setMediaCodecParameters(MediaCodecParameters mediaCodecParameters) {
+    player.setMediaCodecParameters(mediaCodecParameters);
+  }
+
+  @Override
+  public MediaCodecParameters getMediaCodecParameters() {
+    return player.getMediaCodecParameters();
+  }
+
   /** Returns the {@link Player} to which operations are forwarded. */
   public Player getWrappedPlayer() {
     return player;

--- a/library/common/src/main/java/com/google/android/exoplayer2/MediaCodecParameters.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/MediaCodecParameters.java
@@ -1,0 +1,44 @@
+package com.google.android.exoplayer2;
+
+import android.os.Build;
+import androidx.annotation.Nullable;
+import java.util.HashMap;
+
+/**
+ * MediaCodec parameters configuring the {@link android.media.MediaCodec} instances.
+ *
+ * once instantiated, the application can add key-value pairs calling {@link MediaCodecParameters#set}
+ * and send a message of type {@code Renderer#MSG_SET_CODEC_PARAMETERS} to the renderers.
+ *
+ */
+public class MediaCodecParameters {
+
+  public static final String KEY_DIALOG_ENHANCEMENT = "dialog-enhancement-gain";
+  public static final String DIALOG_ENHANCEMENT_OFF = "Off";
+  public static final String DIALOG_ENHANCEMENT_LEVEL_LOW = "Low";
+  public static final String DIALOG_ENHANCEMENT_LEVEL_MID = "Mid";
+  public static final String DIALOG_ENHANCEMENT_LEVEL_HIGH = "High";
+
+  private HashMap<String, Object> mediaCodecParameters;
+
+  public MediaCodecParameters() {
+    mediaCodecParameters = new HashMap<String, Object>();
+  }
+
+  public void set(HashMap<String, Object> parameters) {
+    mediaCodecParameters.putAll(parameters);
+  }
+  public void set(String key, Object value) {
+    mediaCodecParameters.put(key, value);
+  }
+  public HashMap<String, Object> get() { return mediaCodecParameters; }
+
+  public Object getOrDefault(String key, Object def) {
+    if (Build.VERSION.SDK_INT >= 24) {
+      return mediaCodecParameters.getOrDefault(key, def);
+    } else {
+      @Nullable Object o = mediaCodecParameters.get(key);
+      return (o == null)  ? def : o;
+    }
+  }
+}

--- a/library/common/src/main/java/com/google/android/exoplayer2/Player.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/Player.java
@@ -2476,4 +2476,10 @@ public interface Player {
 
   /** Sets the mute state of the device. */
   void setDeviceMuted(boolean muted);
+
+  /** Set the CodecParameters */
+  void setMediaCodecParameters(MediaCodecParameters mediaCodecParameters);
+  /** Get the CodecParameters */
+  MediaCodecParameters getMediaCodecParameters();
+
 }

--- a/library/core/src/main/java/com/google/android/exoplayer2/BaseRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/BaseRenderer.java
@@ -42,6 +42,7 @@ public abstract class BaseRenderer implements Renderer, RendererCapabilities {
   private int state;
   @Nullable private SampleStream stream;
   @Nullable private Format[] streamFormats;
+  protected MediaCodecParameters mediaCodecParameters;
   private long streamOffsetUs;
   private long lastResetPositionUs;
   private long readingPositionUs;
@@ -56,6 +57,7 @@ public abstract class BaseRenderer implements Renderer, RendererCapabilities {
     this.trackType = trackType;
     formatHolder = new FormatHolder();
     readingPositionUs = C.TIME_END_OF_SOURCE;
+    mediaCodecParameters = new MediaCodecParameters();
   }
 
   @Override

--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImpl.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImpl.java
@@ -23,6 +23,7 @@ import static com.google.android.exoplayer2.Renderer.MSG_SET_AUDIO_SESSION_ID;
 import static com.google.android.exoplayer2.Renderer.MSG_SET_AUX_EFFECT_INFO;
 import static com.google.android.exoplayer2.Renderer.MSG_SET_CAMERA_MOTION_LISTENER;
 import static com.google.android.exoplayer2.Renderer.MSG_SET_CHANGE_FRAME_RATE_STRATEGY;
+import static com.google.android.exoplayer2.Renderer.MSG_SET_CODEC_PARAMETERS;
 import static com.google.android.exoplayer2.Renderer.MSG_SET_SCALING_MODE;
 import static com.google.android.exoplayer2.Renderer.MSG_SET_SKIP_SILENCE_ENABLED;
 import static com.google.android.exoplayer2.Renderer.MSG_SET_VIDEO_FRAME_METADATA_LISTENER;
@@ -208,6 +209,10 @@ import java.util.concurrent.TimeoutException;
   private int maskingPeriodIndex;
   private long maskingWindowPositionMs;
 
+  // MediaCodec parameters
+  private MediaCodecParameters mediaCodecParameters;
+
+
   @SuppressLint("HandlerLeak")
   public ExoPlayerImpl(ExoPlayer.Builder builder, @Nullable Player wrappingPlayer) {
     constructorFinished = new ConditionVariable();
@@ -366,6 +371,8 @@ import java.util.concurrent.TimeoutException;
       wifiLockManager.setEnabled(builder.wakeMode == C.WAKE_MODE_NETWORK);
       deviceInfo = createDeviceInfo(streamVolumeManager);
       videoSize = VideoSize.UNKNOWN;
+
+      mediaCodecParameters = new MediaCodecParameters();
 
       sendRendererMessage(TRACK_TYPE_AUDIO, MSG_SET_AUDIO_SESSION_ID, audioSessionId);
       sendRendererMessage(TRACK_TYPE_VIDEO, MSG_SET_AUDIO_SESSION_ID, audioSessionId);
@@ -914,6 +921,20 @@ import java.util.concurrent.TimeoutException;
     }
   }
 
+  @Override
+  public void setMediaCodecParameters(MediaCodecParameters mediaCodecParameters) {
+    verifyApplicationThread();
+    this.mediaCodecParameters.set(mediaCodecParameters.get());
+    for (Renderer renderer : renderers) {
+      createMessageInternal(renderer).setType(MSG_SET_CODEC_PARAMETERS).setPayload(mediaCodecParameters).send();
+    }
+  }
+
+  @Override
+  public MediaCodecParameters getMediaCodecParameters() {
+    verifyApplicationThread();
+    return mediaCodecParameters;
+  }
   @Override
   public void stop() {
     verifyApplicationThread();
@@ -3017,6 +3038,7 @@ import java.util.concurrent.TimeoutException;
         case Renderer.MSG_SET_VIDEO_OUTPUT:
         case Renderer.MSG_SET_VOLUME:
         case Renderer.MSG_SET_WAKEUP_LISTENER:
+        case MSG_SET_CODEC_PARAMETERS:
         default:
           break;
       }

--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -37,6 +37,7 @@ import com.google.android.exoplayer2.Player.PlaybackSuppressionReason;
 import com.google.android.exoplayer2.Player.RepeatMode;
 import com.google.android.exoplayer2.analytics.AnalyticsCollector;
 import com.google.android.exoplayer2.analytics.PlayerId;
+import com.google.android.exoplayer2.audio.MediaCodecAudioRenderer;
 import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.metadata.MetadataRenderer;

--- a/library/core/src/main/java/com/google/android/exoplayer2/Renderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/Renderer.java
@@ -83,7 +83,7 @@ public interface Renderer extends PlayerMessage.Target {
    * #MSG_SET_SCALING_MODE}, {@link #MSG_SET_CHANGE_FRAME_RATE_STRATEGY}, {@link
    * #MSG_SET_AUX_EFFECT_INFO}, {@link #MSG_SET_VIDEO_FRAME_METADATA_LISTENER}, {@link
    * #MSG_SET_CAMERA_MOTION_LISTENER}, {@link #MSG_SET_SKIP_SILENCE_ENABLED}, {@link
-   * #MSG_SET_AUDIO_SESSION_ID} or {@link #MSG_SET_WAKEUP_LISTENER}. May also be an app-defined
+   * #MSG_SET_AUDIO_SESSION_ID}, {@link #MSG_SET_WAKEUP_LISTENER} or {@link #MSG_SET_CODEC_PARAMETERS}. May also be an app-defined
    * value (see {@link #MSG_CUSTOM_BASE}).
    */
   @Documented
@@ -102,9 +102,11 @@ public interface Renderer extends PlayerMessage.Target {
         MSG_SET_CAMERA_MOTION_LISTENER,
         MSG_SET_SKIP_SILENCE_ENABLED,
         MSG_SET_AUDIO_SESSION_ID,
-        MSG_SET_WAKEUP_LISTENER
+        MSG_SET_WAKEUP_LISTENER,
+        MSG_SET_CODEC_PARAMETERS
       })
   public @interface MessageType {}
+
   /**
    * The type of a message that can be passed to a video renderer via {@link
    * ExoPlayer#createMessage(PlayerMessage.Target)}. The message payload is normally a {@link
@@ -197,6 +199,15 @@ public interface Renderer extends PlayerMessage.Target {
    * <p>The message payload must be a {@link WakeupListener} instance.
    */
   int MSG_SET_WAKEUP_LISTENER = 11;
+
+  /**
+   * The type of a message that can be passed to renderers via {@link
+   * ExoPlayer#createMessage(PlayerMessage.Target)}. The message payload is normally a bundle of
+   * MediaCodec KeyValue pairs
+   *
+   * <p>If the receiving renderer does not support the KV pair, then it should ignore it
+   */
+  int MSG_SET_CODEC_PARAMETERS  = 12;
   /**
    * Applications or extensions may define custom {@code MSG_*} constants that can be passed to
    * renderers. These custom constants must be greater than or equal to this value.

--- a/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/SimpleExoPlayer.java
@@ -1211,6 +1211,16 @@ public class SimpleExoPlayer extends BasePlayer
     player.setDeviceMuted(muted);
   }
 
+  @Override
+  public void setMediaCodecParameters(MediaCodecParameters parameters) {
+    player.setMediaCodecParameters(parameters);
+  }
+
+  @Override
+  public MediaCodecParameters getMediaCodecParameters() {
+    return player.getMediaCodecParameters();
+  }
+
   /* package */ void setThrowsWhenUsingWrongThread(boolean throwsWhenUsingWrongThread) {
     blockUntilConstructorFinished();
     player.setThrowsWhenUsingWrongThread(throwsWhenUsingWrongThread);

--- a/library/ui/src/main/java/com/google/android/exoplayer2/ui/StyledPlayerControlView.java
+++ b/library/ui/src/main/java/com/google/android/exoplayer2/ui/StyledPlayerControlView.java
@@ -60,6 +60,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlayerLibraryInfo;
 import com.google.android.exoplayer2.ForwardingPlayer;
+import com.google.android.exoplayer2.MediaCodecParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Player.Events;
 import com.google.android.exoplayer2.Player.State;
@@ -244,6 +245,7 @@ public class StyledPlayerControlView extends FrameLayout {
 
   private static final int SETTINGS_PLAYBACK_SPEED_POSITION = 0;
   private static final int SETTINGS_AUDIO_TRACK_SELECTION_POSITION = 1;
+  private static final int SETTINGS_DIALOG_ENHANCEMENT = 2;
 
   private final ComponentListener componentListener;
   private final CopyOnWriteArrayList<VisibilityListener> visibilityListeners;
@@ -311,6 +313,7 @@ public class StyledPlayerControlView extends FrameLayout {
   private RecyclerView settingsView;
   private SettingsAdapter settingsAdapter;
   private PlaybackSpeedAdapter playbackSpeedAdapter;
+  private DialogEnhancementAdapter dialogEnhancementAdapter;
   private PopupWindow settingsWindow;
   private boolean needToHideBars;
   private int settingsWindowMargin;
@@ -528,8 +531,8 @@ public class StyledPlayerControlView extends FrameLayout {
     controlViewLayoutManager = new StyledPlayerControlViewLayoutManager(this);
     controlViewLayoutManager.setAnimationEnabled(animationEnabled);
 
-    String[] settingTexts = new String[2];
-    Drawable[] settingIcons = new Drawable[2];
+    String[] settingTexts = new String[3];
+    Drawable[] settingIcons = new Drawable[3];
     settingTexts[SETTINGS_PLAYBACK_SPEED_POSITION] =
         resources.getString(R.string.exo_controls_playback_speed);
     settingIcons[SETTINGS_PLAYBACK_SPEED_POSITION] =
@@ -538,6 +541,12 @@ public class StyledPlayerControlView extends FrameLayout {
         resources.getString(R.string.exo_track_selection_title_audio);
     settingIcons[SETTINGS_AUDIO_TRACK_SELECTION_POSITION] =
         resources.getDrawable(R.drawable.exo_styled_controls_audiotrack);
+
+    // ADD DialogEnhancement Gain support
+    settingTexts[SETTINGS_DIALOG_ENHANCEMENT] = "AC-4 Dialog Enhancement";
+    settingIcons[SETTINGS_DIALOG_ENHANCEMENT] =
+        resources.getDrawable(R.drawable.exo_styled_controls_audiotrack);
+
     settingsAdapter = new SettingsAdapter(settingTexts, settingIcons);
     settingsWindowMargin = resources.getDimensionPixelSize(R.dimen.exo_settings_offset);
     settingsView =
@@ -568,6 +577,9 @@ public class StyledPlayerControlView extends FrameLayout {
     playbackSpeedAdapter =
         new PlaybackSpeedAdapter(
             resources.getStringArray(R.array.exo_controls_playback_speeds), PLAYBACK_SPEEDS);
+
+    dialogEnhancementAdapter =
+        new DialogEnhancementAdapter();
 
     fullScreenExitDrawable = resources.getDrawable(R.drawable.exo_styled_controls_fullscreen_exit);
     fullScreenEnterDrawable =
@@ -946,6 +958,7 @@ public class StyledPlayerControlView extends FrameLayout {
     updateShuffleButton();
     updateTrackLists();
     updatePlaybackSpeedList();
+    updateDialogEnhancementList();
     updateTimeline();
   }
 
@@ -1265,6 +1278,17 @@ public class StyledPlayerControlView extends FrameLayout {
         SETTINGS_PLAYBACK_SPEED_POSITION, playbackSpeedAdapter.getSelectedText());
   }
 
+  private void updateDialogEnhancementList() {
+    if (player == null) {
+      return;
+    }
+    MediaCodecParameters mediaCodecParameters = player.getMediaCodecParameters();
+
+    dialogEnhancementAdapter.updateSelectedIndex((String) mediaCodecParameters.getOrDefault(MediaCodecParameters.KEY_DIALOG_ENHANCEMENT,dialogEnhancementAdapter.dialogEnhancementLevels[0]));
+    settingsAdapter.setSubTextAtPosition(
+        SETTINGS_DIALOG_ENHANCEMENT, dialogEnhancementAdapter.getSelectedText());
+  }
+
   private void updateSettingsWindowSize() {
     settingsView.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED);
 
@@ -1292,6 +1316,18 @@ public class StyledPlayerControlView extends FrameLayout {
     int yoff = -settingsWindow.getHeight() - settingsWindowMargin;
 
     settingsWindow.showAsDropDown(this, xoff, yoff);
+  }
+
+  private void setDialogEnhancementLevel(String level) {
+    if (player == null) {
+      return;
+    }
+
+    MediaCodecParameters mediaCodecParameters = new MediaCodecParameters();
+    mediaCodecParameters.set(MediaCodecParameters.KEY_DIALOG_ENHANCEMENT,level);
+
+    player.setMediaCodecParameters(mediaCodecParameters);
+    updateDialogEnhancementList();
   }
 
   private void setPlaybackSpeed(float speed) {
@@ -1376,6 +1412,8 @@ public class StyledPlayerControlView extends FrameLayout {
       displaySettingsWindow(playbackSpeedAdapter);
     } else if (position == SETTINGS_AUDIO_TRACK_SELECTION_POSITION) {
       displaySettingsWindow(audioTrackSelectionAdapter);
+    } else if (position == SETTINGS_DIALOG_ENHANCEMENT) {
+      displaySettingsWindow(dialogEnhancementAdapter);
     } else {
       settingsWindow.dismiss();
     }
@@ -1811,6 +1849,56 @@ public class StyledPlayerControlView extends FrameLayout {
       return playbackSpeedTexts.length;
     }
   }
+
+  private final class DialogEnhancementAdapter extends RecyclerView.Adapter<SubSettingViewHolder> {
+
+    private final String[] dialogEnhancementLevels = {
+        MediaCodecParameters.DIALOG_ENHANCEMENT_OFF,
+        MediaCodecParameters.DIALOG_ENHANCEMENT_LEVEL_LOW,
+        MediaCodecParameters.DIALOG_ENHANCEMENT_LEVEL_MID,
+        MediaCodecParameters.DIALOG_ENHANCEMENT_LEVEL_HIGH
+    };
+    private int            selectedIndex;
+
+    public DialogEnhancementAdapter() {}
+
+    public void updateSelectedIndex(String dialogEnhancement) {
+      selectedIndex = Arrays.asList(dialogEnhancementLevels).indexOf(dialogEnhancement);
+    }
+
+    public String getSelectedText() {
+      return dialogEnhancementLevels[selectedIndex];
+    }
+
+    @Override
+    public SubSettingViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+      View v =
+          LayoutInflater.from(getContext())
+              .inflate(R.layout.exo_styled_sub_settings_list_item, null);
+      return new SubSettingViewHolder(v);
+    }
+
+    @Override
+    public void onBindViewHolder(SubSettingViewHolder holder, int position) {
+      if (position < dialogEnhancementLevels.length) {
+        holder.textView.setText(dialogEnhancementLevels[position]);
+      }
+      holder.checkView.setVisibility(position == selectedIndex ? VISIBLE : INVISIBLE);
+      holder.itemView.setOnClickListener(
+          v -> {
+            if (position != selectedIndex) {
+              setDialogEnhancementLevel(dialogEnhancementLevels[position]);
+            }
+            settingsWindow.dismiss();
+          });
+    }
+
+    @Override
+    public int getItemCount() {
+      return dialogEnhancementLevels.length;
+    }
+  }
+
 
   private static final class TrackInformation {
 


### PR DESCRIPTION
The AC4 audio decoder features a dialog enhancement mode
that allows the user to boost the dialog from the played
content.
The boost of the dialog can be tuned to the listener's
need.
This patch maps the control of the dialog boost as a
user controllable playback parameter (like playback speed or
pitch) and proposes a possible implementation in the  UI
in the form of "off, low, mid, high" presets.

- tested on Lenovo P11 tablet and samsung phones

Signed-off-by: glass <glass@dolby.com>