### PR TITLE
Add support for SSA OutlineColour (only background)

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -320,7 +320,7 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
             /* end= */ spannableText.length(),
             SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);
       }
-      if (style.outlineColor != null) {
+      if (style.borderStyle == SsaStyle.SSA_BORDER_STYLE_BOX && style.outlineColor != null) {
         spannableText.setSpan(
             new BackgroundColorSpan(style.outlineColor),
             /* start= */ 0,

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -21,6 +21,7 @@ import static com.google.android.exoplayer2.util.Util.castNonNull;
 import android.graphics.Typeface;
 import android.text.Layout;
 import android.text.SpannableString;
+import android.text.style.BackgroundColorSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StrikethroughSpan;
 import android.text.style.StyleSpan;
@@ -315,6 +316,13 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
       if (style.primaryColor != null) {
         spannableText.setSpan(
             new ForegroundColorSpan(style.primaryColor),
+            /* start= */ 0,
+            /* end= */ spannableText.length(),
+            SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);
+      }
+      if (style.outlineColor != null) {
+        spannableText.setSpan(
+            new BackgroundColorSpan(style.outlineColor),
             /* start= */ 0,
             /* end= */ spannableText.length(),
             SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
@@ -95,6 +95,7 @@ import java.util.regex.Pattern;
   public final String name;
   public final @SsaAlignment int alignment;
   @Nullable @ColorInt public final Integer primaryColor;
+  @Nullable @ColorInt public final Integer outlineColor;
   public final float fontSize;
   public final boolean bold;
   public final boolean italic;
@@ -105,6 +106,7 @@ import java.util.regex.Pattern;
       String name,
       @SsaAlignment int alignment,
       @Nullable @ColorInt Integer primaryColor,
+      @Nullable @ColorInt Integer outlineColor,
       float fontSize,
       boolean bold,
       boolean italic,
@@ -113,6 +115,7 @@ import java.util.regex.Pattern;
     this.name = name;
     this.alignment = alignment;
     this.primaryColor = primaryColor;
+    this.outlineColor = outlineColor;
     this.fontSize = fontSize;
     this.bold = bold;
     this.italic = italic;
@@ -140,6 +143,9 @@ import java.util.regex.Pattern;
               : SSA_ALIGNMENT_UNKNOWN,
           format.primaryColorIndex != C.INDEX_UNSET
               ? parseColor(styleValues[format.primaryColorIndex].trim())
+              : null,
+          format.outlineColorIndex != C.INDEX_UNSET
+              ? parseColor(styleValues[format.outlineColorIndex].trim())
               : null,
           format.fontSizeIndex != C.INDEX_UNSET
               ? parseFontSize(styleValues[format.fontSizeIndex].trim())
@@ -257,6 +263,7 @@ import java.util.regex.Pattern;
     public final int nameIndex;
     public final int alignmentIndex;
     public final int primaryColorIndex;
+    public final int outlineColorIndex;
     public final int fontSizeIndex;
     public final int boldIndex;
     public final int italicIndex;
@@ -268,6 +275,7 @@ import java.util.regex.Pattern;
         int nameIndex,
         int alignmentIndex,
         int primaryColorIndex,
+        int outlineColorIndex,
         int fontSizeIndex,
         int boldIndex,
         int italicIndex,
@@ -277,6 +285,7 @@ import java.util.regex.Pattern;
       this.nameIndex = nameIndex;
       this.alignmentIndex = alignmentIndex;
       this.primaryColorIndex = primaryColorIndex;
+      this.outlineColorIndex = outlineColorIndex;
       this.fontSizeIndex = fontSizeIndex;
       this.boldIndex = boldIndex;
       this.italicIndex = italicIndex;
@@ -295,6 +304,7 @@ import java.util.regex.Pattern;
       int nameIndex = C.INDEX_UNSET;
       int alignmentIndex = C.INDEX_UNSET;
       int primaryColorIndex = C.INDEX_UNSET;
+      int outlineColorIndex = C.INDEX_UNSET;
       int fontSizeIndex = C.INDEX_UNSET;
       int boldIndex = C.INDEX_UNSET;
       int italicIndex = C.INDEX_UNSET;
@@ -312,6 +322,9 @@ import java.util.regex.Pattern;
             break;
           case "primarycolour":
             primaryColorIndex = i;
+            break;
+          case "outlinecolour":
+            outlineColorIndex = i;
             break;
           case "fontsize":
             fontSizeIndex = i;
@@ -335,6 +348,7 @@ import java.util.regex.Pattern;
               nameIndex,
               alignmentIndex,
               primaryColorIndex,
+              outlineColorIndex,
               fontSizeIndex,
               boldIndex,
               italicIndex,

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
@@ -301,7 +301,7 @@ public final class SsaDecoderTest {
     SsaDecoder decoder = new SsaDecoder();
     byte[] bytes = TestUtil.getByteArray(ApplicationProvider.getApplicationContext(), STYLE_COLORS);
     Subtitle subtitle = decoder.decode(bytes, bytes.length, false);
-    assertThat(subtitle.getEventTimeCount()).isEqualTo(16);
+    assertThat(subtitle.getEventTimeCount()).isEqualTo(18);
     // &H000000FF (AABBGGRR) -> #FFFF0000 (AARRGGBB)
     Spanned firstCueText =
         (Spanned) Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(0))).text;
@@ -342,11 +342,15 @@ public final class SsaDecoderTest {
         (Spanned) Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(12))).text;
     SpannedSubject.assertThat(seventhCueText)
         .hasNoForegroundColorSpanBetween(0, seventhCueText.length());
+    // OutlineColour should be treated as background only when BorderStyle=3
     Spanned eighthCueText =
         (Spanned) Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(14))).text;
     SpannedSubject.assertThat(eighthCueText)
         .hasBackgroundColorSpanBetween(0, eighthCueText.length())
         .withColor(Color.BLUE);
+    Spanned ninthCueText =
+        (Spanned) Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(16))).text;
+    SpannedSubject.assertThat(ninthCueText).hasNoBackgroundColorSpanBetween(0, ninthCueText.length());
   }
 
   @Test

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
@@ -301,7 +301,7 @@ public final class SsaDecoderTest {
     SsaDecoder decoder = new SsaDecoder();
     byte[] bytes = TestUtil.getByteArray(ApplicationProvider.getApplicationContext(), STYLE_COLORS);
     Subtitle subtitle = decoder.decode(bytes, bytes.length, false);
-    assertThat(subtitle.getEventTimeCount()).isEqualTo(14);
+    assertThat(subtitle.getEventTimeCount()).isEqualTo(16);
     // &H000000FF (AABBGGRR) -> #FFFF0000 (AARRGGBB)
     Spanned firstCueText =
         (Spanned) Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(0))).text;
@@ -342,6 +342,11 @@ public final class SsaDecoderTest {
         (Spanned) Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(12))).text;
     SpannedSubject.assertThat(seventhCueText)
         .hasNoForegroundColorSpanBetween(0, seventhCueText.length());
+    Spanned eighthCueText =
+        (Spanned) Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(14))).text;
+    SpannedSubject.assertThat(eighthCueText)
+        .hasBackgroundColorSpanBetween(0, eighthCueText.length())
+        .withColor(Color.BLUE);
   }
 
   @Test

--- a/testdata/src/test/assets/media/ssa/style_colors
+++ b/testdata/src/test/assets/media/ssa/style_colors
@@ -5,14 +5,15 @@ PlayResX: 1280
 PlayResY: 720
 
 [V4+ Styles]
-Format: Name                         ,PrimaryColour
-Style: PrimaryColourStyleHexRed      ,&H000000FF
-Style: PrimaryColourStyleHexYellow   ,&H0000FFFF
-Style: PrimaryColourStyleHexGreen    ,&HFF00
-Style: PrimaryColourStyleHexAlpha    ,&HA00000FF
-Style: PrimaryColourStyleDecimal     ,16711680
-Style: PrimaryColourStyleDecimalAlpha,2164195328
-Style: PrimaryColourStyleInvalid     ,blue
+Format: Name                         ,PrimaryColour,OutlineColour
+Style: PrimaryColourStyleHexRed      ,&H000000FF   ,&H00000000
+Style: PrimaryColourStyleHexYellow   ,&H0000FFFF   ,&H00000000
+Style: PrimaryColourStyleHexGreen    ,&HFF00       ,&H00000000
+Style: PrimaryColourStyleHexAlpha    ,&HA00000FF   ,&H00000000
+Style: PrimaryColourStyleDecimal     ,16711680     ,&H00000000
+Style: PrimaryColourStyleDecimalAlpha,2164195328   ,&H00000000
+Style: PrimaryColourStyleInvalid     ,blue         ,&H00000000
+Style: OutlineColourStyleBlue        ,&H00000000   ,&H00FF0000
 
 
 [Events]
@@ -24,3 +25,4 @@ Dialogue: 0:00:07.00,0:00:08.00,PrimaryColourStyleHexAlpha    ,Fourth line in RE
 Dialogue: 0:00:09.00,0:00:10.00,PrimaryColourStyleDecimal     ,Fifth line in BLUE (16711680).
 Dialogue: 0:00:11.00,0:00:12.00,PrimaryColourStyleDecimalAlpha,Sixth line in BLUE with alpha (2164195328).
 Dialogue: 0:00:13.00,0:00:14.00,PrimaryColourInvalid          ,Seventh line with invalid color.
+Dialogue: 0:00:15.00,0:00:16.00,OutlineColourStyleBlue        ,Eighth line with BLUE (&H00FF0000) outline.

--- a/testdata/src/test/assets/media/ssa/style_colors
+++ b/testdata/src/test/assets/media/ssa/style_colors
@@ -5,15 +5,16 @@ PlayResX: 1280
 PlayResY: 720
 
 [V4+ Styles]
-Format: Name                         ,PrimaryColour,OutlineColour
-Style: PrimaryColourStyleHexRed      ,&H000000FF   ,&H00000000
-Style: PrimaryColourStyleHexYellow   ,&H0000FFFF   ,&H00000000
-Style: PrimaryColourStyleHexGreen    ,&HFF00       ,&H00000000
-Style: PrimaryColourStyleHexAlpha    ,&HA00000FF   ,&H00000000
-Style: PrimaryColourStyleDecimal     ,16711680     ,&H00000000
-Style: PrimaryColourStyleDecimalAlpha,2164195328   ,&H00000000
-Style: PrimaryColourStyleInvalid     ,blue         ,&H00000000
-Style: OutlineColourStyleBlue        ,&H00000000   ,&H00FF0000
+Format: Name                         ,PrimaryColour,OutlineColour,BorderStyle
+Style: PrimaryColourStyleHexRed      ,&H000000FF   ,&H00000000   ,3
+Style: PrimaryColourStyleHexYellow   ,&H0000FFFF   ,&H00000000   ,3
+Style: PrimaryColourStyleHexGreen    ,&HFF00       ,&H00000000   ,3
+Style: PrimaryColourStyleHexAlpha    ,&HA00000FF   ,&H00000000   ,3
+Style: PrimaryColourStyleDecimal     ,16711680     ,&H00000000   ,3
+Style: PrimaryColourStyleDecimalAlpha,2164195328   ,&H00000000   ,3
+Style: PrimaryColourStyleInvalid     ,blue         ,&H00000000   ,3
+Style: OutlineColourStyleBlue        ,&H00000000   ,&H00FF0000   ,3
+Style: OutlineColourStyleIgnored     ,&H00000000   ,&H00FF0000   ,1
 
 
 [Events]
@@ -26,3 +27,4 @@ Dialogue: 0:00:09.00,0:00:10.00,PrimaryColourStyleDecimal     ,Fifth line in BLU
 Dialogue: 0:00:11.00,0:00:12.00,PrimaryColourStyleDecimalAlpha,Sixth line in BLUE with alpha (2164195328).
 Dialogue: 0:00:13.00,0:00:14.00,PrimaryColourInvalid          ,Seventh line with invalid color.
 Dialogue: 0:00:15.00,0:00:16.00,OutlineColourStyleBlue        ,Eighth line with BLUE (&H00FF0000) outline.
+Dialogue: 0:00:17.00,0:00:18.00,OutlineColourStyleIgnored     ,Ninth line with ignored outline because BorderStyle is not 3.


### PR DESCRIPTION
https://github.com/google/ExoPlayer/issues/8435

`OutlineColour` should be treated as the background color if `BorderStyle=3`.

~Since currently `BorderStyle` is ignored, we can always treat `OutlineColor` as the background color.~ **EDIT:** with the suggestions from @icbaker, the code no longer ignores `BorderStyle`. Instead, the background color is applied _only_ if `BorderStyle=3`.