### PR TITLE
Add support for SSA (v4+) MarginL, MarginR, MarginV style

### DIFF
--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -626,6 +626,13 @@
         "subtitle_language": "en"
       },
       {
+        "name": "SubStation Margin",
+        "uri": "https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-avc-baseline-480.mp4",
+        "subtitle_uri": "https://gist.githubusercontent.com/szaboa/bca7cdc90c1492eb747032f267a5de19/raw/ef81209e8a50874179672173dc106120a7ee8814/test-subs-margin.ass",
+        "subtitle_mime_type": "text/x-ssa",
+        "subtitle_language": "en"
+      },
+      {
         "name": "MPEG-4 Timed Text",
         "uri": "https://storage.googleapis.com/exoplayer-test-media-1/mp4/dizzy-with-tx3g.mp4"
       }

--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -626,9 +626,9 @@
         "subtitle_language": "en"
       },
       {
-        "name": "SubStation Alpha Margin",
+        "name": "SubStation Alpha margin",
         "uri": "https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-avc-baseline-480.mp4",
-        "subtitle_uri": "https://gist.githubusercontent.com/szaboa/bca7cdc90c1492eb747032f267a5de19/raw/b93916ec9ca9145b6e47107c4c357abe43bc5641/test-subs-margin.ass",
+        "subtitle_uri": "https://gist.githubusercontent.com/szaboa/bca7cdc90c1492eb747032f267a5de19/raw/8985eeb544641e174da22a1dafe50cd87393512f/test-subs-margin.ass",
         "subtitle_mime_type": "text/x-ssa",
         "subtitle_language": "en"
       },

--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -628,7 +628,7 @@
       {
         "name": "SubStation Alpha Margin",
         "uri": "https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-avc-baseline-480.mp4",
-        "subtitle_uri": "https://gist.githubusercontent.com/szaboa/bca7cdc90c1492eb747032f267a5de19/raw/c376e7c67946a3e350473bfb3869554d2125c9ef/test-subs-margin.ass",
+        "subtitle_uri": "https://gist.githubusercontent.com/szaboa/bca7cdc90c1492eb747032f267a5de19/raw/b93916ec9ca9145b6e47107c4c357abe43bc5641/test-subs-margin.ass",
         "subtitle_mime_type": "text/x-ssa",
         "subtitle_language": "en"
       },

--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -626,9 +626,9 @@
         "subtitle_language": "en"
       },
       {
-        "name": "SubStation Margin",
+        "name": "SubStation Alpha Margin",
         "uri": "https://storage.googleapis.com/exoplayer-test-media-1/gen-3/screens/dash-vod-single-segment/video-avc-baseline-480.mp4",
-        "subtitle_uri": "https://gist.githubusercontent.com/szaboa/bca7cdc90c1492eb747032f267a5de19/raw/ef81209e8a50874179672173dc106120a7ee8814/test-subs-margin.ass",
+        "subtitle_uri": "https://gist.githubusercontent.com/szaboa/bca7cdc90c1492eb747032f267a5de19/raw/c376e7c67946a3e350473bfb3869554d2125c9ef/test-subs-margin.ass",
         "subtitle_mime_type": "text/x-ssa",
         "subtitle_language": "en"
       },

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDecoder.java
@@ -364,9 +364,14 @@ public final class SsaDecoder extends SimpleSubtitleDecoder {
       cue.setPosition(cue.getPosition() - (marginRight != 0f
           ? marginRight / screenWidth
           : style != null ? style.marginRight / screenWidth : 0f));
-      cue.setLine(cue.getLine() - (marginVertical != 0f
-          ? marginVertical / screenHeight
-          : style != null ? style.marginVertical / screenHeight : 0f), LINE_TYPE_FRACTION);
+      // Ignore vertical margin if alignment is middle.
+      if (!SsaStyle.hasMiddleAlignment(style)) {
+        float verticalMargin = marginVertical != 0f ? marginVertical / screenHeight
+            : style != null ? style.marginVertical / screenHeight : 0f;
+        // Apply margin from top if alignment is top.
+        cue.setLine(cue.getLine() - (SsaStyle.hasTopAlignment(style)
+            ? -verticalMargin : verticalMargin), LINE_TYPE_FRACTION);
+      }
     }
 
     if (style == null) {

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDialogueFormat.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDialogueFormat.java
@@ -103,10 +103,7 @@ import com.google.common.base.Ascii;
     }
     return (startTimeIndex != C.INDEX_UNSET
             && endTimeIndex != C.INDEX_UNSET
-            && textIndex != C.INDEX_UNSET
-            && marginLeftIndex != C.INDEX_UNSET
-            && marginRightIndex != C.INDEX_UNSET
-            && marginVerticalIndex != C.INDEX_UNSET)
+            && textIndex != C.INDEX_UNSET)
         ? new SsaDialogueFormat(
             startTimeIndex,
             endTimeIndex,

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDialogueFormat.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaDialogueFormat.java
@@ -36,14 +36,27 @@ import com.google.common.base.Ascii;
   public final int endTimeIndex;
   public final int styleIndex;
   public final int textIndex;
+  public final int marginLeftIndex;
+  public final int marginRightIndex;
+  public final int marginVerticalIndex;
   public final int length;
 
   private SsaDialogueFormat(
-      int startTimeIndex, int endTimeIndex, int styleIndex, int textIndex, int length) {
+      int startTimeIndex,
+      int endTimeIndex,
+      int styleIndex,
+      int textIndex,
+      int marginLeftIndex,
+      int marginRightIndex,
+      int marginVerticalIndex,
+      int length) {
     this.startTimeIndex = startTimeIndex;
     this.endTimeIndex = endTimeIndex;
     this.styleIndex = styleIndex;
     this.textIndex = textIndex;
+    this.marginLeftIndex = marginLeftIndex;
+    this.marginRightIndex = marginRightIndex;
+    this.marginVerticalIndex = marginVerticalIndex;
     this.length = length;
   }
 
@@ -58,6 +71,9 @@ import com.google.common.base.Ascii;
     int endTimeIndex = C.INDEX_UNSET;
     int styleIndex = C.INDEX_UNSET;
     int textIndex = C.INDEX_UNSET;
+    int marginLeftIndex = C.INDEX_UNSET;
+    int marginRightIndex = C.INDEX_UNSET;
+    int marginVerticalIndex = C.INDEX_UNSET;
     Assertions.checkArgument(formatLine.startsWith(FORMAT_LINE_PREFIX));
     String[] keys = TextUtils.split(formatLine.substring(FORMAT_LINE_PREFIX.length()), ",");
     for (int i = 0; i < keys.length; i++) {
@@ -74,12 +90,32 @@ import com.google.common.base.Ascii;
         case "text":
           textIndex = i;
           break;
+        case "marginl":
+          marginLeftIndex = i;
+          break;
+        case "marginr":
+          marginRightIndex = i;
+          break;
+        case "marginv":
+          marginVerticalIndex = i;
+          break;
       }
     }
     return (startTimeIndex != C.INDEX_UNSET
             && endTimeIndex != C.INDEX_UNSET
-            && textIndex != C.INDEX_UNSET)
-        ? new SsaDialogueFormat(startTimeIndex, endTimeIndex, styleIndex, textIndex, keys.length)
+            && textIndex != C.INDEX_UNSET
+            && marginLeftIndex != C.INDEX_UNSET
+            && marginRightIndex != C.INDEX_UNSET
+            && marginVerticalIndex != C.INDEX_UNSET)
+        ? new SsaDialogueFormat(
+            startTimeIndex,
+            endTimeIndex,
+            styleIndex,
+            textIndex,
+            marginLeftIndex,
+            marginRightIndex,
+            marginVerticalIndex,
+            keys.length)
         : null;
   }
 }

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
@@ -176,33 +176,6 @@ import java.util.regex.Pattern;
     }
   }
 
-  public static boolean hasMiddleAlignment(@Nullable SsaStyle style) {
-    if (style == null) {
-      return false;
-    }
-    return style.alignment == SSA_ALIGNMENT_MIDDLE_LEFT
-        || style.alignment == SSA_ALIGNMENT_MIDDLE_CENTER
-        || style.alignment == SSA_ALIGNMENT_MIDDLE_RIGHT;
-  }
-
-  public static boolean hasTopAlignment(@Nullable SsaStyle style) {
-    if (style == null) {
-      return false;
-    }
-    return style.alignment == SSA_ALIGNMENT_TOP_LEFT
-        || style.alignment == SSA_ALIGNMENT_TOP_CENTER
-        || style.alignment == SSA_ALIGNMENT_TOP_RIGHT;
-  }
-
-  public static boolean hasBottomAlignment(@Nullable SsaStyle style) {
-    if (style == null) {
-      return false;
-    }
-    return style.alignment == SSA_ALIGNMENT_BOTTOM_LEFT
-        || style.alignment == SSA_ALIGNMENT_BOTTOM_CENTER
-        || style.alignment == SSA_ALIGNMENT_BOTTOM_RIGHT;
-  }
-
   private static @SsaAlignment int parseAlignment(String alignmentStr) {
     try {
       @SsaAlignment int alignment = Integer.parseInt(alignmentStr.trim());
@@ -298,6 +271,60 @@ import java.util.regex.Pattern;
       Log.w(TAG, "Failed to parse boolean value: '" + booleanValue + "'", e);
       return false;
     }
+  }
+
+  public static boolean hasMiddleAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_MIDDLE_LEFT
+        || style.alignment == SSA_ALIGNMENT_MIDDLE_CENTER
+        || style.alignment == SSA_ALIGNMENT_MIDDLE_RIGHT;
+  }
+
+  public static boolean hasTopAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_TOP_LEFT
+        || style.alignment == SSA_ALIGNMENT_TOP_CENTER
+        || style.alignment == SSA_ALIGNMENT_TOP_RIGHT;
+  }
+
+  public static boolean hasBottomAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_BOTTOM_LEFT
+        || style.alignment == SSA_ALIGNMENT_BOTTOM_CENTER
+        || style.alignment == SSA_ALIGNMENT_BOTTOM_RIGHT;
+  }
+
+  public static boolean hasLeftAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_TOP_LEFT
+        || style.alignment == SSA_ALIGNMENT_MIDDLE_LEFT
+        || style.alignment == SSA_ALIGNMENT_BOTTOM_LEFT;
+  }
+
+  public static boolean hasRightAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_TOP_RIGHT
+        || style.alignment == SSA_ALIGNMENT_MIDDLE_RIGHT
+        || style.alignment == SSA_ALIGNMENT_BOTTOM_RIGHT;
+  }
+
+  public static boolean hasCenterAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_TOP_CENTER
+        || style.alignment == SSA_ALIGNMENT_MIDDLE_CENTER
+        || style.alignment == SSA_ALIGNMENT_BOTTOM_CENTER;
   }
 
   /**

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
@@ -100,6 +100,9 @@ import java.util.regex.Pattern;
   public final boolean italic;
   public final boolean underline;
   public final boolean strikeout;
+  public final float marginLeft;
+  public final float marginRight;
+  public final float marginVertical;
 
   private SsaStyle(
       String name,
@@ -109,7 +112,10 @@ import java.util.regex.Pattern;
       boolean bold,
       boolean italic,
       boolean underline,
-      boolean strikeout) {
+      boolean strikeout,
+      float marginLeft,
+      float marginRight,
+      float marginVertical) {
     this.name = name;
     this.alignment = alignment;
     this.primaryColor = primaryColor;
@@ -118,6 +124,9 @@ import java.util.regex.Pattern;
     this.italic = italic;
     this.underline = underline;
     this.strikeout = strikeout;
+    this.marginLeft = marginLeft;
+    this.marginRight = marginRight;
+    this.marginVertical = marginVertical;
   }
 
   @Nullable
@@ -151,7 +160,16 @@ import java.util.regex.Pattern;
           format.underlineIndex != C.INDEX_UNSET
               && parseBooleanValue(styleValues[format.underlineIndex].trim()),
           format.strikeoutIndex != C.INDEX_UNSET
-              && parseBooleanValue(styleValues[format.strikeoutIndex].trim()));
+              && parseBooleanValue(styleValues[format.strikeoutIndex].trim()),
+          format.marginLeftIndex != C.INDEX_UNSET
+              ? parseMargin(styleValues[format.marginLeftIndex].trim())
+              : Cue.DIMEN_UNSET,
+          format.marginRightIndex != C.INDEX_UNSET
+              ? parseMargin(styleValues[format.marginRightIndex].trim())
+              : Cue.DIMEN_UNSET,
+          format.marginVerticalIndex != C.INDEX_UNSET
+              ? parseMargin(styleValues[format.marginVerticalIndex].trim())
+              : Cue.DIMEN_UNSET);
     } catch (RuntimeException e) {
       Log.w(TAG, "Skipping malformed 'Style:' line: '" + styleLine + "'", e);
       return null;
@@ -227,6 +245,15 @@ import java.util.regex.Pattern;
     return Color.argb(a, r, g, b);
   }
 
+  public static float parseMargin(String floatValue) {
+    try {
+      return Float.parseFloat(floatValue);
+    } catch (NumberFormatException e) {
+      Log.w(TAG, "Failed to parse margin value: '" + floatValue + "'", e);
+      return 0f;
+    }
+  }
+
   private static float parseFontSize(String fontSize) {
     try {
       return Float.parseFloat(fontSize);
@@ -262,6 +289,9 @@ import java.util.regex.Pattern;
     public final int italicIndex;
     public final int underlineIndex;
     public final int strikeoutIndex;
+    public final int marginLeftIndex;
+    public final int marginRightIndex;
+    public final int marginVerticalIndex;
     public final int length;
 
     private Format(
@@ -273,6 +303,9 @@ import java.util.regex.Pattern;
         int italicIndex,
         int underlineIndex,
         int strikeoutIndex,
+        int marginLeftIndex,
+        int marginRightIndex,
+        int marginVerticalIndex,
         int length) {
       this.nameIndex = nameIndex;
       this.alignmentIndex = alignmentIndex;
@@ -282,6 +315,9 @@ import java.util.regex.Pattern;
       this.italicIndex = italicIndex;
       this.underlineIndex = underlineIndex;
       this.strikeoutIndex = strikeoutIndex;
+      this.marginLeftIndex = marginLeftIndex;
+      this.marginRightIndex = marginRightIndex;
+      this.marginVerticalIndex = marginVerticalIndex;
       this.length = length;
     }
 
@@ -300,6 +336,9 @@ import java.util.regex.Pattern;
       int italicIndex = C.INDEX_UNSET;
       int underlineIndex = C.INDEX_UNSET;
       int strikeoutIndex = C.INDEX_UNSET;
+      int marginLeftIndex = C.INDEX_UNSET;
+      int marginRightIndex = C.INDEX_UNSET;
+      int marginVerticalIndex = C.INDEX_UNSET;
       String[] keys =
           TextUtils.split(styleFormatLine.substring(SsaDecoder.FORMAT_LINE_PREFIX.length()), ",");
       for (int i = 0; i < keys.length; i++) {
@@ -328,6 +367,15 @@ import java.util.regex.Pattern;
           case "strikeout":
             strikeoutIndex = i;
             break;
+          case "marginl":
+            marginLeftIndex = i;
+            break;
+          case "marginr":
+            marginRightIndex = i;
+            break;
+          case "marginv":
+            marginVerticalIndex = i;
+            break;
         }
       }
       return nameIndex != C.INDEX_UNSET
@@ -340,6 +388,9 @@ import java.util.regex.Pattern;
               italicIndex,
               underlineIndex,
               strikeoutIndex,
+              marginLeftIndex,
+              marginRightIndex,
+              marginVerticalIndex,
               keys.length)
           : null;
     }

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/text/ssa/SsaStyle.java
@@ -176,6 +176,33 @@ import java.util.regex.Pattern;
     }
   }
 
+  public static boolean hasMiddleAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_MIDDLE_LEFT
+        || style.alignment == SSA_ALIGNMENT_MIDDLE_CENTER
+        || style.alignment == SSA_ALIGNMENT_MIDDLE_RIGHT;
+  }
+
+  public static boolean hasTopAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_TOP_LEFT
+        || style.alignment == SSA_ALIGNMENT_TOP_CENTER
+        || style.alignment == SSA_ALIGNMENT_TOP_RIGHT;
+  }
+
+  public static boolean hasBottomAlignment(@Nullable SsaStyle style) {
+    if (style == null) {
+      return false;
+    }
+    return style.alignment == SSA_ALIGNMENT_BOTTOM_LEFT
+        || style.alignment == SSA_ALIGNMENT_BOTTOM_CENTER
+        || style.alignment == SSA_ALIGNMENT_BOTTOM_RIGHT;
+  }
+
   private static @SsaAlignment int parseAlignment(String alignmentStr) {
     try {
       @SsaAlignment int alignment = Integer.parseInt(alignmentStr.trim());

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
@@ -419,7 +419,7 @@ public final class SsaDecoderTest {
     byte[] bytes = TestUtil.getByteArray(ApplicationProvider.getApplicationContext(), STYLE_MARGIN);
     Subtitle subtitle = decoder.decode(bytes, bytes.length, false);
 
-    // PlayResX=1280px, PlayResY=720px
+    // PlayResX = 1280px, PlayResY = 720px
 
     // Alignment 1, position anchor = start, position = (0.05f, 0.95f)
     // margin_left = 128px = 0.1f, margin_right 256px = 0.2f
@@ -427,15 +427,15 @@ public final class SsaDecoderTest {
     assertThat(firstCue.position).isEqualTo(0.15f); // = 0.05f + margin_left
     assertThat(firstCue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
     assertThat(firstCue.line).isEqualTo(0.95f);
-    assertThat(firstCue.size).isEqualTo(0.7f); // = 1 - margin_right - margin_left
+    assertThat(firstCue.size).isEqualTo(0.7f); // = 1f - margin_right - margin_left
 
     // Alignment 6, position anchor = end, position = (0.95f, 0.5f)
     // margin_left = 128px = 0.1f, margin_right = 256px = 0.2f
     Cue secondClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(2)));
-    assertThat(secondClue.position).isEqualTo(0.75f); // = 1 - margin_right
+    assertThat(secondClue.position).isEqualTo(0.75f); // = 1f - margin_right
     assertThat(secondClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
     assertThat(secondClue.line).isEqualTo(0.5f);
-    assertThat(secondClue.size).isEqualTo(0.7f); // = 1 - margin_right - margin_left
+    assertThat(secondClue.size).isEqualTo(0.7f); // = 1f - margin_right - margin_left
 
     // Alignment 2, position anchor = middle, position = (0.5f, 0.95f)
     // margin_left = 128px = 0.1f, margin_right = 256px = 0.2f
@@ -443,7 +443,7 @@ public final class SsaDecoderTest {
     assertThat(thirdClue.position).isEqualTo(0.45f); // 0.5f + (margin_left - margin_right)/2
     assertThat(thirdClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
     assertThat(thirdClue.line).isEqualTo(0.95f);
-    assertThat(thirdClue.size).isEqualTo(0.7f); // = 1 - margin_right - margin_left
+    assertThat(thirdClue.size).isEqualTo(0.7f); // = 1f - margin_right - margin_left
 
     // Alignment 5, position anchor = middle, position = (0.5f, 0.5f)
     // margin_vertical = 144px = 0.2f but needs to be ignored when alignment is middle [4,5,6]
@@ -462,7 +462,7 @@ public final class SsaDecoderTest {
     // Alignment 9, position anchor = end, position = (0.95f, 0.05f)
     // margin_vertical = 144px = 0.2f, to be applied from top when alignment is top [7,8,9]
     Cue sixthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(10)));
-    assertThat(sixthClue.position).isEqualTo(0.95f); // alignment 9
+    assertThat(sixthClue.position).isEqualTo(0.95f);
     assertThat(sixthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
     assertThat(sixthClue.line).isEqualTo(0.25f); // = 0.05f + margin_vertical
 
@@ -471,8 +471,8 @@ public final class SsaDecoderTest {
     Cue seventhClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(12)));
     assertThat(seventhClue.position).isEqualTo(0.55f); // 0.5f + (margin_left - margin_right)/2
     assertThat(seventhClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(seventhClue.line).isEqualTo(0.75f); // 0.95 - margin_vertical
-    assertThat(seventhClue.size).isEqualTo(0.9f); // 1 - margin_right - margin_left
+    assertThat(seventhClue.line).isEqualTo(0.75f); // 0.95f - margin_vertical
+    assertThat(seventhClue.size).isEqualTo(0.9f); // 1f - margin_right - margin_left
 
     // Position override {\pos(640,180)} -> ignore margins
     Cue eighthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(14)));

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
@@ -453,6 +453,16 @@ public final class SsaDecoderTest {
     assertThat(seventhClue.position).isEqualTo(0.5f);
     assertThat(seventhClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
     assertThat(seventhClue.line).isEqualTo(0.5f);
+    // Margin should be skipped because of middle alignment.
+    Cue eighthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(14)));
+    assertThat(eighthClue.position).isEqualTo(0.95f);
+    assertThat(eighthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(eighthClue.line).isEqualTo(0.5f);
+    // Margin applied from top because of top alignment.
+    Cue ninthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(16)));
+    assertThat(ninthClue.position).isEqualTo(0.95f);
+    assertThat(ninthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(ninthClue.line).isEqualTo(0.25f);
   }
 
   private static void assertTypicalCue1(Subtitle subtitle, int eventIndex) {

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
@@ -53,6 +53,7 @@ public final class SsaDecoderTest {
   private static final String STYLE_BOLD_ITALIC = "media/ssa/style_bold_italic";
   private static final String STYLE_UNDERLINE = "media/ssa/style_underline";
   private static final String STYLE_STRIKEOUT = "media/ssa/style_strikeout";
+  private static final String STYLE_MARGIN = "media/ssa/style_margin";
 
   @Test
   public void decodeEmpty() throws IOException {
@@ -410,6 +411,48 @@ public final class SsaDecoderTest {
         (Spanned) Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(2))).text;
     SpannedSubject.assertThat(secondCueText)
         .hasNoStrikethroughSpanBetween(0, secondCueText.length());
+  }
+
+  @Test
+  public void decodeMargins() throws IOException {
+    SsaDecoder decoder = new SsaDecoder();
+    byte[] bytes = TestUtil.getByteArray(ApplicationProvider.getApplicationContext(), STYLE_MARGIN);
+    Subtitle subtitle = decoder.decode(bytes, bytes.length, false);
+    // Margin left.
+    Cue firstCue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(0)));
+    assertThat(firstCue.position).isEqualTo(0.6f);
+    assertThat(firstCue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(firstCue.line).isEqualTo(0.95f);
+    // Margin right.
+    Cue secondClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(2)));
+    assertThat(secondClue.position).isEqualTo(0.4f);
+    assertThat(secondClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(secondClue.line).isEqualTo(0.95f);
+    // Margin vertical.
+    Cue thirdClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(4)));
+    assertThat(thirdClue.position).isEqualTo(0.5f);
+    assertThat(thirdClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(thirdClue.line).isEqualTo(0.75f);
+    // Margin left + vertical.
+    Cue fourthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(6)));
+    assertThat(fourthClue.position).isEqualTo(0.6f);
+    assertThat(fourthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(fourthClue.line).isEqualTo(0.75f);
+    // Margin left + vertical (defined in Dialogue).
+    Cue fifthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(8)));
+    assertThat(fifthClue.position).isEqualTo(0.4f);
+    assertThat(fifthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(fifthClue.line).isEqualTo(0.75f);
+    // Margin should be skipped because of the {\pos} override.
+    Cue sixthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(10)));
+    assertThat(sixthClue.position).isEqualTo(0.5f);
+    assertThat(sixthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(sixthClue.line).isEqualTo(0.25f);
+    // Margin should be skipped because of the {\an} override.
+    Cue seventhClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(12)));
+    assertThat(seventhClue.position).isEqualTo(0.5f);
+    assertThat(seventhClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
+    assertThat(seventhClue.line).isEqualTo(0.5f);
   }
 
   private static void assertTypicalCue1(Subtitle subtitle, int eventIndex) {

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/text/ssa/SsaDecoderTest.java
@@ -418,51 +418,73 @@ public final class SsaDecoderTest {
     SsaDecoder decoder = new SsaDecoder();
     byte[] bytes = TestUtil.getByteArray(ApplicationProvider.getApplicationContext(), STYLE_MARGIN);
     Subtitle subtitle = decoder.decode(bytes, bytes.length, false);
-    // Margin left.
+
+    // PlayResX=1280px, PlayResY=720px
+
+    // Alignment 1, position anchor = start, position = (0.05f, 0.95f)
+    // margin_left = 128px = 0.1f, margin_right 256px = 0.2f
     Cue firstCue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(0)));
-    assertThat(firstCue.position).isEqualTo(0.6f);
+    assertThat(firstCue.position).isEqualTo(0.15f); // = 0.05f + margin_left
     assertThat(firstCue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
     assertThat(firstCue.line).isEqualTo(0.95f);
-    // Margin right.
+    assertThat(firstCue.size).isEqualTo(0.7f); // = 1 - margin_right - margin_left
+
+    // Alignment 6, position anchor = end, position = (0.95f, 0.5f)
+    // margin_left = 128px = 0.1f, margin_right = 256px = 0.2f
     Cue secondClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(2)));
-    assertThat(secondClue.position).isEqualTo(0.4f);
+    assertThat(secondClue.position).isEqualTo(0.75f); // = 1 - margin_right
     assertThat(secondClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(secondClue.line).isEqualTo(0.95f);
-    // Margin vertical.
+    assertThat(secondClue.line).isEqualTo(0.5f);
+    assertThat(secondClue.size).isEqualTo(0.7f); // = 1 - margin_right - margin_left
+
+    // Alignment 2, position anchor = middle, position = (0.5f, 0.95f)
+    // margin_left = 128px = 0.1f, margin_right = 256px = 0.2f
     Cue thirdClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(4)));
-    assertThat(thirdClue.position).isEqualTo(0.5f);
+    assertThat(thirdClue.position).isEqualTo(0.45f); // 0.5f + (margin_left - margin_right)/2
     assertThat(thirdClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(thirdClue.line).isEqualTo(0.75f);
-    // Margin left + vertical.
+    assertThat(thirdClue.line).isEqualTo(0.95f);
+    assertThat(thirdClue.size).isEqualTo(0.7f); // = 1 - margin_right - margin_left
+
+    // Alignment 5, position anchor = middle, position = (0.5f, 0.5f)
+    // margin_vertical = 144px = 0.2f but needs to be ignored when alignment is middle [4,5,6]
     Cue fourthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(6)));
-    assertThat(fourthClue.position).isEqualTo(0.6f);
+    assertThat(fourthClue.position).isEqualTo(0.5f);
     assertThat(fourthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(fourthClue.line).isEqualTo(0.75f);
-    // Margin left + vertical (defined in Dialogue).
+    assertThat(fourthClue.line).isEqualTo(0.5f);
+
+    // Alignment 2, position anchor = middle, position = (0.5f, 0.95f)
+    // margin_vertical = 144px = 0.2f, to be applied from bottom when alignment is bottom [1,2,3]
     Cue fifthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(8)));
-    assertThat(fifthClue.position).isEqualTo(0.4f);
+    assertThat(fifthClue.position).isEqualTo(0.5f);
     assertThat(fifthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(fifthClue.line).isEqualTo(0.75f);
-    // Margin should be skipped because of the {\pos} override.
+    assertThat(fifthClue.line).isEqualTo(0.75f); // = 0.95f - margin_vertical
+
+    // Alignment 9, position anchor = end, position = (0.95f, 0.05f)
+    // margin_vertical = 144px = 0.2f, to be applied from top when alignment is top [7,8,9]
     Cue sixthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(10)));
-    assertThat(sixthClue.position).isEqualTo(0.5f);
+    assertThat(sixthClue.position).isEqualTo(0.95f); // alignment 9
     assertThat(sixthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(sixthClue.line).isEqualTo(0.25f);
-    // Margin should be skipped because of the {\an} override.
+    assertThat(sixthClue.line).isEqualTo(0.25f); // = 0.05f + margin_vertical
+
+    // Alignment 2, position anchor = middle, position = (0.5f, 0.95f)
+    // margin_left = 128px = 0.1f, margin_vertical = 144px = 0.2f, margin_right = 0f (from Dialogue)
     Cue seventhClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(12)));
-    assertThat(seventhClue.position).isEqualTo(0.5f);
+    assertThat(seventhClue.position).isEqualTo(0.55f); // 0.5f + (margin_left - margin_right)/2
     assertThat(seventhClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(seventhClue.line).isEqualTo(0.5f);
-    // Margin should be skipped because of middle alignment.
+    assertThat(seventhClue.line).isEqualTo(0.75f); // 0.95 - margin_vertical
+    assertThat(seventhClue.size).isEqualTo(0.9f); // 1 - margin_right - margin_left
+
+    // Position override {\pos(640,180)} -> ignore margins
     Cue eighthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(14)));
-    assertThat(eighthClue.position).isEqualTo(0.95f);
+    assertThat(eighthClue.position).isEqualTo(0.5f);
     assertThat(eighthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(eighthClue.line).isEqualTo(0.5f);
-    // Margin applied from top because of top alignment.
+    assertThat(eighthClue.line).isEqualTo(0.25f);
+
+    // Alignment override {\an5}, position = (0.5f, 0.5f) -> ignore margins
     Cue ninthClue = Iterables.getOnlyElement(subtitle.getCues(subtitle.getEventTime(16)));
-    assertThat(ninthClue.position).isEqualTo(0.95f);
+    assertThat(ninthClue.position).isEqualTo(0.5f);
     assertThat(ninthClue.lineType).isEqualTo(Cue.LINE_TYPE_FRACTION);
-    assertThat(ninthClue.line).isEqualTo(0.25f);
+    assertThat(ninthClue.line).isEqualTo(0.5f);
   }
 
   private static void assertTypicalCue1(Subtitle subtitle, int eventIndex) {

--- a/testdata/src/test/assets/media/ssa/invalid_positioning
+++ b/testdata/src/test/assets/media/ssa/invalid_positioning
@@ -6,7 +6,7 @@ PlayResY: 200
 [V4+ Styles]
 ! Alignment is set to 4 - i.e. middle-left
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Default,Open Sans Semibold,36,&H00FFFFFF,&H000000FF,&H00020713,&H00000000,-1,0,0,0,100,100,0,0,1,1.7,0,4,0,0,28,1
+Style: Default,Open Sans Semibold,36,&H00FFFFFF,&H000000FF,&H00020713,&H00000000,-1,0,0,0,100,100,0,0,1,1.7,0,4,0,0,0,1
 
 [Events]
 Format: Layer, Start, End, Style, Name, Text

--- a/testdata/src/test/assets/media/ssa/style_margin
+++ b/testdata/src/test/assets/media/ssa/style_margin
@@ -7,21 +7,24 @@ PlayResY: 720
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: MarginLeft             ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,0,0   ,1
-Style: MarginRight            ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,128,0   ,1
-Style: MarginVertical         ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,0,144   ,1
-Style: MarginMixed            ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,0,144 ,1
-Style: MarginVerticalAn6      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,6, 0,0,144   ,1
-Style: MarginVerticalAn9      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,9, 0,0,144   ,1
+Style: AlignmentLeft          ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,1, 128,256,0 ,1
+Style: AlignmentRight         ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,6, 128,256,0 ,1
+Style: AlignmentCenter        ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,256,0 ,1
+Style: AlignmentMiddle        ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,5, 0,0,144   ,1
+Style: AlignmentBottom        ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,0,144   ,1
+Style: AlignmentTop           ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,9, 0,0,144   ,1
+Style: DialogueMargin         ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,0,0     ,1
+Style: PositionOverride       ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,144,0 ,1
+Style: AlignmentOverride      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,144,0 ,1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
-Dialogue: 0,0:00:00.95,0:00:02.11,MarginLeft        ,Arnold,0,0,0,,	     Line with margin left
-Dialogue: 0,0:00:03.50,0:00:05.50,MarginRight       ,Arnold,0,0,0,,	     Line with margin right
-Dialogue: 0,0:00:07.50,0:00:10.00,MarginVertical    ,Arnold,0,0,0,,	     Line with margin vertical
-Dialogue: 0,0:00:11.50,0:00:14.00,MarginMixed       ,Arnold,0,0,0,,	     Line with margin vertical and left
-Dialogue: 0,0:00:15.50,0:00:17.00,MarginLeft        ,Arnold,-128,0,144,,  Line margin defined in dialogue
-Dialogue: 0,0:00:18.50,0:00:20.00,MarginLeft        ,Arnold,200,0,0,,     {\pos(640,180)} Line with fixed position
-Dialogue: 0,0:00:21.00,0:00:22.00,MarginLeft        ,Arnold,0,200,0,,     {\an5} Line with alignment override
-Dialogue: 0,0:00:23.00,0:00:25.00,MarginVerticalAn6 ,Arnold,0,0,0,,       Alignment middle, ignore vertical margin
-Dialogue: 0,0:00:26.00,0:00:27.00,MarginVerticalAn9 ,Arnold,0,0,0,,       Alignment top, apply margin from top
+Dialogue: 0,0:00:00.95,0:00:02.11,AlignmentLeft     ,Arnold,0,0,0,,	     Margin with alignment left - long text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text
+Dialogue: 0,0:00:02.20,0:00:03.40,AlignmentRight    ,Arnold,0,0,0,,	     Margin with alignment right - long text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text
+Dialogue: 0,0:00:03.45,0:00:04.40,AlignmentCenter   ,Arnold,0,0,0,,	     Margin with alignment center - long text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text ong text long text long text long text long text long text long text text long text long text
+Dialogue: 0,0:00:04.50,0:00:06.50,AlignmentMiddle   ,Arnold,0,0,0,,	     Middle alignment - ignore vertical margin
+Dialogue: 0,0:00:07.50,0:00:10.00,AlignmentBottom   ,Arnold,0,0,0,,	     Bottom alignment - apply vertical margin from bottom
+Dialogue: 0,0:00:11.50,0:00:14.00,AlignmentTop      ,Arnold,0,0,0,,	     Top alignment - apply vertical margin from top
+Dialogue: 0,0:00:15.50,0:00:17.00,DialogueMargin    ,Arnold,128,0,144,,  Margin defined in dialogue
+Dialogue: 0,0:00:18.50,0:00:20.00,PositionOverride  ,Arnold,0,0,0,,      {\pos(640,180)} Position override - ignore margins
+Dialogue: 0,0:00:21.00,0:00:22.00,AlignmentOverride ,Arnold,0,0,0,,      {\an5} Alignment override - ignore margins

--- a/testdata/src/test/assets/media/ssa/style_margin
+++ b/testdata/src/test/assets/media/ssa/style_margin
@@ -7,17 +7,21 @@ PlayResY: 720
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: MarginLeft       ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,0,0   ,1
-Style: MarginRight      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,128,0   ,1
-Style: MarginVertical   ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,0,144   ,1
-Style: MarginMixed      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,0,144 ,1
+Style: MarginLeft             ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,0,0   ,1
+Style: MarginRight            ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,128,0   ,1
+Style: MarginVertical         ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,0,144   ,1
+Style: MarginMixed            ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,0,144 ,1
+Style: MarginVerticalAn6      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,6, 0,0,144   ,1
+Style: MarginVerticalAn9      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,9, 0,0,144   ,1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
-Dialogue: 0,0:00:00.95,0:00:02.11,MarginLeft      ,Arnold,0,0,0,,	    Line with margin left
-Dialogue: 0,0:00:03.50,0:00:05.50,MarginRight     ,Arnold,0,0,0,,	    Line with margin right
-Dialogue: 0,0:00:07.50,0:00:10.00,MarginVertical  ,Arnold,0,0,0,,	    Line with margin vertical
-Dialogue: 0,0:00:11.50,0:00:14.00,MarginMixed     ,Arnold,0,0,0,,	    Line with margin vertical and left
-Dialogue: 0,0:00:15.50,0:00:17.00,MarginLeft      ,Arnold,-128,0,144,,Line margin defined in dialogue
-Dialogue: 0,0:00:18.50,0:00:20.00,MarginLeft      ,Arnold,200,0,0,,   {\pos(640,180)} Line with fixed position
-Dialogue: 0,0:00:21.00,0:00:22.00,MarginLeft      ,Arnold,0,200,0,,   {\an5} Line with alignment override
+Dialogue: 0,0:00:00.95,0:00:02.11,MarginLeft        ,Arnold,0,0,0,,	     Line with margin left
+Dialogue: 0,0:00:03.50,0:00:05.50,MarginRight       ,Arnold,0,0,0,,	     Line with margin right
+Dialogue: 0,0:00:07.50,0:00:10.00,MarginVertical    ,Arnold,0,0,0,,	     Line with margin vertical
+Dialogue: 0,0:00:11.50,0:00:14.00,MarginMixed       ,Arnold,0,0,0,,	     Line with margin vertical and left
+Dialogue: 0,0:00:15.50,0:00:17.00,MarginLeft        ,Arnold,-128,0,144,,  Line margin defined in dialogue
+Dialogue: 0,0:00:18.50,0:00:20.00,MarginLeft        ,Arnold,200,0,0,,     {\pos(640,180)} Line with fixed position
+Dialogue: 0,0:00:21.00,0:00:22.00,MarginLeft        ,Arnold,0,200,0,,     {\an5} Line with alignment override
+Dialogue: 0,0:00:23.00,0:00:25.00,MarginVerticalAn6 ,Arnold,0,0,0,,       Alignment middle, ignore vertical margin
+Dialogue: 0,0:00:26.00,0:00:27.00,MarginVerticalAn9 ,Arnold,0,0,0,,       Alignment top, apply margin from top

--- a/testdata/src/test/assets/media/ssa/style_margin
+++ b/testdata/src/test/assets/media/ssa/style_margin
@@ -1,0 +1,23 @@
+[Script Info]
+Title: SSA/ASS Test
+Original Script: Arnold Szabo
+Script Type: V4.00+
+PlayResX: 1280
+PlayResY: 720
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: MarginLeft       ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,0,0   ,1
+Style: MarginRight      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,128,0   ,1
+Style: MarginVertical   ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 0,0,144   ,1
+Style: MarginMixed      ,Roboto,30,&H000000FF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,0,2, 128,0,144 ,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:00.95,0:00:02.11,MarginLeft      ,Arnold,0,0,0,,	    Line with margin left
+Dialogue: 0,0:00:03.50,0:00:05.50,MarginRight     ,Arnold,0,0,0,,	    Line with margin right
+Dialogue: 0,0:00:07.50,0:00:10.00,MarginVertical  ,Arnold,0,0,0,,	    Line with margin vertical
+Dialogue: 0,0:00:11.50,0:00:14.00,MarginMixed     ,Arnold,0,0,0,,	    Line with margin vertical and left
+Dialogue: 0,0:00:15.50,0:00:17.00,MarginLeft      ,Arnold,-128,0,144,,Line margin defined in dialogue
+Dialogue: 0,0:00:18.50,0:00:20.00,MarginLeft      ,Arnold,200,0,0,,   {\pos(640,180)} Line with fixed position
+Dialogue: 0,0:00:21.00,0:00:22.00,MarginLeft      ,Arnold,0,200,0,,   {\an5} Line with alignment override


### PR DESCRIPTION
This PR is about adding support for `MarginL`, `MarginR`, `MarginV` from both the `Style` and `Dialogue` lines. I've used VLC as reference.

- Non-zero margins defined in `Dialogue` lines takes priority over the margins in `Style` lines.
- In case we have a `{\pos}` override, then no margins will be applied neither from `Dialogue` or `Style` (same as in VLC).
- In case we have a `{\an}` override, then VLC ignores the `Dialogue` margin but applies the `Style` margin which makes no sense for me, so in our case I've just ignored both `Dialogue` and `Style` margins (same as `{\pos}` case).

_Suggestion_: maybe we could update the `https://storage.googleapis.com/exoplayer-test-media-1/ssa/test-subs-position.ass` subtitle file with these new lines, then no need for a new media in `media.exolist.json`.