### PR TITLE
Amlogic

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/video/MediaCodecVideoRenderer.java
@@ -1703,6 +1703,10 @@ public class MediaCodecVideoRenderer extends MediaCodecRenderer {
       // Google OMX decoders are not known to have this issue on any API level.
       return false;
     }
+    if (name.indexOf("amlogic") != -1) {
+      // Amlogic decoder also do not support switching from SurfaceTexture to SurfaceView after init.
+      return true;
+    }
     synchronized (MediaCodecVideoRenderer.class) {
       if (!evaluatedDeviceNeedsSetOutputSurfaceWorkaround) {
         deviceNeedsSetOutputSurfaceWorkaround = evaluateDeviceNeedsSetOutputSurfaceWorkaround();


### PR DESCRIPTION
 fix play video use osd display at mistaken
    
    Problem:
    Exoplayer will create a dummySurface use Surface Texture
    if do not use Surface when configCodec, After Surface have
    created will setSurfce with New SurfaceView, But our omx
    do not supprt switch SurfaceTexture to SurfaceView after inited.
    
    Solution:
    use exoplayer codecNeedsSetOutputSurfaceWorkaround release codec
    and reinit codec when the new Surface come.