### PR TITLE
Route the logs to custom logger

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/CustomLogger.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/CustomLogger.java
@@ -1,0 +1,36 @@
+package com.google.android.exoplayer2.util;
+
+/**
+ * Interface to be implemented by a custom logger if logging required is other than simple {@link android.util.Log}
+ * <p>
+ * {@link Log.setCustomLogger(CustomLogger)} should be used to provide the implementation
+ */
+public interface CustomLogger {
+    /**
+     * Analogous to {@link android.util.Log#d(String, String)}
+     *
+     * @see android.util.Log#d(String, String)
+     */
+    void d(String tag, String message);
+
+    /**
+     * Analogous to {@link android.util.Log#i(String, String)}
+     *
+     * @see android.util.Log#i(String, String)
+     */
+    void i(String tag, String message);
+
+    /**
+     * Analogous to {@link android.util.Log#w(String, String)}
+     *
+     * @see android.util.Log#w(String, String)
+     */
+    void w(String tag, String message);
+
+    /**
+     * Analogous to {@link android.util.Log#e(String, String)}
+     *
+     * @see android.util.Log#e(String, String)
+     */
+    void e(String tag, String message);
+}

--- a/library/common/src/main/java/com/google/android/exoplayer2/util/Log.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/Log.java
@@ -72,6 +72,16 @@ public final class Log {
   }
 
   /**
+   * Sets a custom logger for the ExoPlayer logs.
+   * Logs are routed to this logger once this is initialized.
+   *
+   * @param customLogger - a {@link CustomLogger} implementation
+   */
+  public static void setCustomLogger(@Nullable CustomLogger customLogger) {
+    Log.customLogger = customLogger;
+  }
+
+  /**
    * Sets whether stack traces of {@link Throwable}s will be logged to logcat. Stack trace logging
    * is enabled by default.
    *
@@ -87,6 +97,9 @@ public final class Log {
   @Pure
   public static void d(@Size(max = 23) String tag, String message) {
     if (logLevel == LOG_LEVEL_ALL) {
+      if (customLogger != null) {
+        customLogger.d(tag, message);
+      }
       android.util.Log.d(tag, message);
     }
   }
@@ -105,6 +118,9 @@ public final class Log {
   @Pure
   public static void i(@Size(max = 23) String tag, String message) {
     if (logLevel <= LOG_LEVEL_INFO) {
+      if (customLogger != null) {
+        customLogger.i(tag, message);
+      }
       android.util.Log.i(tag, message);
     }
   }
@@ -123,6 +139,9 @@ public final class Log {
   @Pure
   public static void w(@Size(max = 23) String tag, String message) {
     if (logLevel <= LOG_LEVEL_WARNING) {
+      if (customLogger != null) {
+        customLogger.w(tag, message);
+      }
       android.util.Log.w(tag, message);
     }
   }
@@ -141,6 +160,9 @@ public final class Log {
   @Pure
   public static void e(@Size(max = 23) String tag, String message) {
     if (logLevel <= LOG_LEVEL_ERROR) {
+      if (customLogger != null) {
+        customLogger.e(tag, message);
+      }
       android.util.Log.e(tag, message);
     }
   }
@@ -203,4 +225,5 @@ public final class Log {
     }
     return false;
   }
+
 }


### PR DESCRIPTION
Use Case:
In the release mode of the app we can capture the logs and send it across(crashlyltics).

Proposed solution:
Set custom logger in release mode so that the logs can be diverted from standard console logging.

Solution to feature: https://github.com/google/ExoPlayer/issues/9752