### PR TITLE
CacheDataSource chunking fix

### DIFF
--- a/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/CacheDataSource.java
+++ b/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/CacheDataSource.java
@@ -630,8 +630,7 @@ public final class CacheDataSource implements DataSource {
           bytesRemaining -= bytesRead;
         }
       } else if (isReadingFromUpstream()
-          && (currentDataSpec.length == C.LENGTH_UNSET
-              || currentDataSourceBytesRead < currentDataSpec.length)) {
+          && (currentDataSpec.length == C.LENGTH_UNSET)) {
         // We've encountered RESULT_END_OF_INPUT from the upstream DataSource at a position not
         // imposed by the current DataSpec. This must mean that we've reached the end of the
         // resource.


### PR DESCRIPTION
## Background
Caching data source logic has been changed recently.

ExoPlayer corrupts cache in case the upstream data source doesn't read the requested bytes.
That allows us to specify the chunk size.

We at Snapchat might decide to issue multiple requests.

New behavior changes the content length property in case upstream decides to split the player request into multiple pieces which causes cache corruption for us.