### PR TITLE
Add SimpleMediaSource

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaServerSideAdInsertionMediaSource.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaServerSideAdInsertionMediaSource.java
@@ -75,6 +75,7 @@ import com.google.android.exoplayer2.source.DefaultMediaSourceFactory;
 import com.google.android.exoplayer2.source.ForwardingTimeline;
 import com.google.android.exoplayer2.source.MediaPeriod;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.SimpleMediaSource;
 import com.google.android.exoplayer2.source.ads.AdPlaybackState;
 import com.google.android.exoplayer2.source.ads.ServerSideAdInsertionMediaSource;
 import com.google.android.exoplayer2.source.ads.ServerSideAdInsertionMediaSource.AdPlaybackStateUpdater;
@@ -106,7 +107,7 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 /** MediaSource for IMA server side inserted ad streams. */
-public final class ImaServerSideAdInsertionMediaSource extends CompositeMediaSource<Void> {
+public final class ImaServerSideAdInsertionMediaSource extends SimpleMediaSource {
 
   /**
    * Factory for creating {@link ImaServerSideAdInsertionMediaSource
@@ -519,8 +520,7 @@ public final class ImaServerSideAdInsertionMediaSource extends CompositeMediaSou
   }
 
   @Override
-  protected void onChildSourceInfoRefreshed(
-      Void id, MediaSource mediaSource, Timeline newTimeline) {
+  protected void onChildSourceInfoRefreshed(MediaSource mediaSource, Timeline newTimeline) {
     refreshSourceInfo(
         new ForwardingTimeline(newTimeline) {
           @Override

--- a/library/core/src/main/java/com/google/android/exoplayer2/source/ClippingMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/ClippingMediaSource.java
@@ -39,7 +39,7 @@ import java.util.ArrayList;
  * {@link MediaSource} that wraps a source and clips its timeline based on specified start/end
  * positions. The wrapped source must consist of a single period.
  */
-public final class ClippingMediaSource extends CompositeMediaSource<Void> {
+public final class ClippingMediaSource extends SimpleMediaSource {
 
   /** Thrown when a {@link ClippingMediaSource} cannot clip its wrapped source. */
   public static final class IllegalClippingException extends IOException {
@@ -240,7 +240,7 @@ public final class ClippingMediaSource extends CompositeMediaSource<Void> {
   }
 
   @Override
-  protected void onChildSourceInfoRefreshed(Void id, MediaSource mediaSource, Timeline timeline) {
+  protected void onChildSourceInfoRefreshed(MediaSource mediaSource, Timeline timeline) {
     if (clippingError != null) {
       return;
     }

--- a/library/core/src/main/java/com/google/android/exoplayer2/source/LoopingMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/LoopingMediaSource.java
@@ -41,7 +41,7 @@ import java.util.Map;
  *     times.
  */
 @Deprecated
-public final class LoopingMediaSource extends CompositeMediaSource<Void> {
+public final class LoopingMediaSource extends SimpleMediaSource {
 
   private final MaskingMediaSource maskingMediaSource;
   private final int loopCount;
@@ -121,7 +121,7 @@ public final class LoopingMediaSource extends CompositeMediaSource<Void> {
   }
 
   @Override
-  protected void onChildSourceInfoRefreshed(Void id, MediaSource mediaSource, Timeline timeline) {
+  protected void onChildSourceInfoRefreshed(MediaSource mediaSource, Timeline timeline) {
     Timeline loopingTimeline =
         loopCount != Integer.MAX_VALUE
             ? new LoopingTimeline(timeline, loopCount)

--- a/library/core/src/main/java/com/google/android/exoplayer2/source/MaskingMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/MaskingMediaSource.java
@@ -35,7 +35,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
  * A {@link MediaSource} that masks the {@link Timeline} with a placeholder until the actual media
  * structure is known.
  */
-public final class MaskingMediaSource extends CompositeMediaSource<Void> {
+public final class MaskingMediaSource extends SimpleMediaSource {
 
   private final MediaSource mediaSource;
   private final boolean useLazyPreparation;
@@ -135,8 +135,7 @@ public final class MaskingMediaSource extends CompositeMediaSource<Void> {
   }
 
   @Override
-  protected void onChildSourceInfoRefreshed(
-      Void id, MediaSource mediaSource, Timeline newTimeline) {
+  protected void onChildSourceInfoRefreshed(MediaSource mediaSource, Timeline newTimeline) {
     @Nullable MediaPeriodId idForMaskingPeriodPreparation = null;
     if (isPrepared) {
       timeline = timeline.cloneWithUpdatedTimeline(newTimeline);

--- a/library/core/src/main/java/com/google/android/exoplayer2/source/SimpleMediaSource.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/SimpleMediaSource.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.exoplayer2.source;
+
+import com.google.android.exoplayer2.Timeline;
+
+/**
+ * Single-source {@link MediaSource}.
+ */
+public abstract class SimpleMediaSource extends CompositeMediaSource<Void> {
+
+  @Override
+  protected final void onChildSourceInfoRefreshed(
+      Void id, MediaSource mediaSource, Timeline timeline
+  ) {
+    onChildSourceInfoRefreshed(mediaSource, timeline);
+  }
+
+  /**
+   * Called when the source info of a the source has been refreshed.
+   *
+   * @param mediaSource The source whose source info has been refreshed.
+   * @param timeline The timeline of the source.
+   */
+  protected abstract void onChildSourceInfoRefreshed(MediaSource mediaSource, Timeline timeline);
+}

--- a/library/core/src/test/java/com/google/android/exoplayer2/ExoPlayerTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/ExoPlayerTest.java
@@ -114,6 +114,7 @@ import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.MediaSource.MediaPeriodId;
 import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.source.ShuffleOrder;
+import com.google.android.exoplayer2.source.SimpleMediaSource;
 import com.google.android.exoplayer2.source.SinglePeriodTimeline;
 import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
@@ -3931,8 +3932,8 @@ public final class ExoPlayerTest {
             new TimelineWindowDefinition(
                 /* isSeekable= */ true, /* isDynamic= */ false, /* durationUs= */ 10_000_000));
     final ConcatenatingMediaSource underlyingSource = new ConcatenatingMediaSource();
-    CompositeMediaSource<Void> delegatingMediaSource =
-        new CompositeMediaSource<Void>() {
+    SimpleMediaSource delegatingMediaSource =
+        new SimpleMediaSource() {
           @Override
           public void prepareSourceInternal(@Nullable TransferListener mediaTransferListener) {
             super.prepareSourceInternal(mediaTransferListener);
@@ -3955,8 +3956,7 @@ public final class ExoPlayerTest {
           }
 
           @Override
-          protected void onChildSourceInfoRefreshed(
-              Void id, MediaSource mediaSource, Timeline timeline) {
+          protected void onChildSourceInfoRefreshed(MediaSource mediaSource, Timeline timeline) {
             refreshSourceInfo(timeline);
           }
 


### PR DESCRIPTION
This is a `CompositeMediaSource<Void>` with a slightly simpler API. I thought it was a bit more readable than the current usage of `CompositeMediaSource<Void>` to signify a single-source one.