### PR TITLE
SEEK_NEAREST does not adjust based on stale playlists

### DIFF
--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/HlsChunkSource.java
@@ -259,9 +259,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     @Nullable
     HlsMediaPlaylist mediaPlaylist =
         selectedIndex < playlistUrls.length && selectedIndex != C.INDEX_UNSET
-            ? playlistTracker.getPlaylistSnapshot(
-                playlistUrls[trackSelection.getSelectedIndexInTrackGroup()],
-                /* isForPlayback= */ true)
+            ? playlistTracker.getFreshPrimaryPlaylist(playlistUrls[trackSelection.getSelectedIndexInTrackGroup()])
             : null;
 
     if (mediaPlaylist == null

--- a/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
+++ b/library/hls/src/main/java/com/google/android/exoplayer2/source/hls/playlist/HlsPlaylistTracker.java
@@ -176,6 +176,22 @@ public interface HlsPlaylistTracker {
   HlsMediaPlaylist getPlaylistSnapshot(Uri url, boolean isForPlayback);
 
   /**
+   * Returns the current snapshot of the playlist referenced by the provided {@link
+   * Uri} iff
+   * <ol>
+   *   <li>The playlist is current primary playlist</li>
+   *   <li>It has recently loaded (last load < the target duration * 2</li>
+   * </ol>
+   *
+   * @param url The {@link Uri} corresponding to the requested media playlist.
+   * @return Most recent snapshot of the primary playlist or null if the url is not the
+   *     current primary or it is not yet loaded.
+   */
+  @Nullable
+  HlsMediaPlaylist getFreshPrimaryPlaylist(Uri url);
+
+
+  /**
    * Returns the start time of the first loaded primary playlist, or {@link C#TIME_UNSET} if no
    * media playlist has been loaded.
    */

--- a/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsChunkSourceTest.java
+++ b/library/hls/src/test/java/com/google/android/exoplayer2/source/hls/HlsChunkSourceTest.java
@@ -74,7 +74,7 @@ public class HlsChunkSourceTest {
             ApplicationProvider.getApplicationContext(), PLAYLIST_INDEPENDENT_SEGMENTS);
     HlsMediaPlaylist playlist =
         (HlsMediaPlaylist) new HlsPlaylistParser().parse(PLAYLIST_URI, inputStream);
-    when(mockPlaylistTracker.getPlaylistSnapshot(eq(PLAYLIST_URI), anyBoolean()))
+    when(mockPlaylistTracker.getFreshPrimaryPlaylist(eq(PLAYLIST_URI)))
         .thenReturn(playlist);
 
     testChunkSource =
@@ -156,7 +156,7 @@ public class HlsChunkSourceTest {
         TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), PLAYLIST);
     HlsMediaPlaylist playlist =
         (HlsMediaPlaylist) new HlsPlaylistParser().parse(PLAYLIST_URI, inputStream);
-    when(mockPlaylistTracker.getPlaylistSnapshot(eq(PLAYLIST_URI), anyBoolean()))
+    when(mockPlaylistTracker.getFreshPrimaryPlaylist(eq(PLAYLIST_URI)))
         .thenReturn(playlist);
 
     long adjustedPositionUs =
@@ -172,7 +172,7 @@ public class HlsChunkSourceTest {
         TestUtil.getInputStream(ApplicationProvider.getApplicationContext(), PLAYLIST_EMPTY);
     HlsMediaPlaylist playlist =
         (HlsMediaPlaylist) new HlsPlaylistParser().parse(PLAYLIST_URI, inputStream);
-    when(mockPlaylistTracker.getPlaylistSnapshot(eq(PLAYLIST_URI), anyBoolean()))
+    when(mockPlaylistTracker.getFreshPrimaryPlaylist(eq(PLAYLIST_URI)))
         .thenReturn(playlist);
 
     long adjustedPositionUs =
@@ -180,6 +180,13 @@ public class HlsChunkSourceTest {
             playlistTimeToPeriodTimeUs(100_000_000), SeekParameters.EXACT);
 
     assertThat(periodTimeToPlaylistTimeUs(adjustedPositionUs)).isEqualTo(100_000_000);
+  }
+
+  @Test
+  public void getAdjustedSeekPositionUs_StalePlaylist() {
+    when(mockPlaylistTracker.getFreshPrimaryPlaylist(eq(PLAYLIST_URI))).thenReturn(null);
+    long adjusted = testChunkSource.getAdjustedSeekPositionUs(playlistTimeToPeriodTimeUs(100_000_000), SeekParameters.CLOSEST_SYNC);
+    assertThat(periodTimeToPlaylistTimeUs(adjusted)).isEqualTo(100_000_000);
   }
 
   private static long playlistTimeToPeriodTimeUs(long playlistTimeUs) {


### PR DESCRIPTION
`getAdjustedSeekPosition()` fails to return a valid value if a track selection
updates the selected track followed by a seek operation, but before the
updated track has issued the first playlist refersh.

This occurs because the playlist for the new selected track has not yet been:

1. established as the primary playlist (`getNextChunk()` will do this)
2. Performed an initial load
3. Reported the `onPrimaryPlaylistRefreshed()` up to the main playback thread

The old code used `getPlaylistSnapshot()` can return a cached but potentially quite stale playlist
that is unsuitable for resolving a seek position.

The fix is to introduce a method, `HlsPlaylistTracker.getFreshPrimaryPlaylist()` that only returns
a playlist snapshot that is currently primary and recently loaded.