### PR TITLE
Stop requirements watcher when download manager is released

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadManager.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DownloadManager.java
@@ -531,6 +531,7 @@ public final class DownloadManager {
         Thread.currentThread().interrupt();
       }
       applicationHandler.removeCallbacksAndMessages(/* token= */ null);
+      requirementsWatcher.stop();
       // Reset state.
       downloads = Collections.emptyList();
       pendingMessages = 0;


### PR DESCRIPTION
Stop RequirementsWatcher when release is called to unregister from receivers and callbacks.