### PR TITLE
Add support for custom float audio processors

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/SilenceSkippingAudioProcessor.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/SilenceSkippingAudioProcessor.java
@@ -143,17 +143,16 @@ public final class SilenceSkippingAudioProcessor extends BaseAudioProcessor {
   // AudioProcessor implementation.
 
   @Override
-  public AudioFormat onConfigure(AudioFormat inputAudioFormat)
-      throws UnhandledAudioFormatException {
+  public AudioFormat onConfigure(AudioFormat inputAudioFormat) {
     if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT) {
-      throw new UnhandledAudioFormatException(inputAudioFormat);
+      return AudioFormat.NOT_SET;
     }
-    return enabled ? inputAudioFormat : AudioFormat.NOT_SET;
+    return inputAudioFormat;
   }
 
   @Override
   public boolean isActive() {
-    return enabled;
+    return super.isActive() && enabled;
   }
 
   @Override

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/SonicAudioProcessor.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/SonicAudioProcessor.java
@@ -140,9 +140,9 @@ public final class SonicAudioProcessor implements AudioProcessor {
   }
 
   @Override
-  public AudioFormat configure(AudioFormat inputAudioFormat) throws UnhandledAudioFormatException {
+  public AudioFormat configure(AudioFormat inputAudioFormat) {
     if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT) {
-      throw new UnhandledAudioFormatException(inputAudioFormat);
+      return AudioFormat.NOT_SET;
     }
     int outputSampleRateHz =
         pendingOutputSampleRate == SAMPLE_RATE_NO_CHANGE


### PR DESCRIPTION
### The problem

My app leverages audio processing in multiple locations. However, it is also in a category of apps that benefit from having HD audio output. With the current float output implementation, I cannot implement both of these features simultaneously without one having to be dropped.

### What this PR does

This PR reworks `DefaultAudioSink` to use a single audio processor chain. This way, custom audio processors can receive float output if enabled.

### What this PR does not do

This PR does not change `SilenceSkippingAudioProcessor` or `SonicAudioProcessor` to handle float audio. This is primarily because I am not familiar with the functionality of either, and because there are seemingly API limitations stopping this according to https://github.com/google/ExoPlayer/issues/6749#issuecomment-603833018. Since `enableFloatOutput` is still not enabled by default, I feel like it would be best to leave this as a task for the maintainers that know more about how to do this.

Feel free to raise any concerns with my change.

Resolves #10516