### PR TITLE
Fix "setMediaDrmSession failed: session not opened" when next between…

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -2073,6 +2073,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     }
 
     // Note: Both oldSession and newSession are non-null, and they are different sessions.
+   if(!newSession.getSchemeUuid().equals(oldSession.getSchemeUuid())) return true;
 
     if (Util.SDK_INT < 23) {
       // MediaCrypto.setMediaDrmSession is only available from API level 23, so re-initialization is


### PR DESCRIPTION
… WV and ClearKey MediaItem

Exception when next or prev between MediaItem Widevine and ClearKey

I created a playlist by adding each MediaItem, there is an error related to DrmSession:
```
setMediaDrmSession failed: session not opened
```

Here is the example code:
```
MediaItem.DrmConfiguration.Builder configBuilder1 = new MediaItem.DrmConfiguration.Builder(C.WIDEVINE_UUID);
configBuilder1.setLicenseUri("http://example.com");
configBuilder1.setMultiSession(true);
MediaItem.Builder mediaItemBuilder1 =  new MediaItem.Builder();
mediaItemBuilder1.setDrmConfiguration(configBuilder1.build());
mediaItemBuilder1.setUri("http://excample.com");

MediaItem.DrmConfiguration.Builder configBuilder2 = new MediaItem.DrmConfiguration.Builder(C.CLEARKEY_UUID);
configBuilder2.setLicenseUri("http://example.com");
configBuilder2.setMultiSession(true);
MediaItem.Builder mediaItemBuilder2 =  new MediaItem.Builder();
mediaItemBuilder2.setDrmConfiguration(configBuilder2.build());
mediaItemBuilder2.setUri("http://excample.com");

ExoPlayer player = new ExoPlayer.Builder(context).build();
player.addMediaItem(mediaItemBuilder1.build());
player.addMediaItem(mediaItemBuilder2.build());
```

My solution is change following function
https://github.com/thucngv/ExoPlayer/commit/6ffa8e2fd18e72ba37a0300aa0b455196bf4fa7e