### PR TITLE
check all renderer mapped TrackGroups

### DIFF
--- a/library/core/src/test/java/com/google/android/exoplayer2/trackselection/MappingTrackSelectorTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/trackselection/MappingTrackSelectorTest.java
@@ -109,6 +109,8 @@ public final class MappingTrackSelectorTest {
 
     trackSelector.assertMappedTrackGroups(0, videoGroup0, videoGroup1);
     trackSelector.assertMappedTrackGroups(1, audioGroup0, audioGroup1);
+    trackSelector.assertMappedTrackGroups(/* rendererIndex= */ 2);
+    trackSelector.assertMappedTrackGroups(/* rendererIndex= */ 3);
   }
 
   @Test


### PR DESCRIPTION
as MappingTrackSelectorTest#selectTracks_multipleVideoAndAudioTracks_mappedToSameRenderer defined 4 renderers, 2 video renderers two audio renderers, for better, check all renderer mapped TrackGroups