### PR TITLE
Tunneling mode Audio stall detection logic

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecRenderer.java
@@ -1154,6 +1154,24 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
     return outputIndex >= 0;
   }
 
+  /**
+   * Check if the renderer has one or more output frames queued to render.  For non-tunneled
+   * mode MediaCodecRenderer's this is true if the codec has returned a frame ready to render
+   * (that is {@see #hasOutputBuffer() is true}.
+   *
+   * This factors into the ready {@link com.google.android.exoplayer2.Renderer#isReady()} decision
+   *
+   * @return
+   */
+  protected boolean hasOutputReady() {
+    return hasOutputBuffer();
+  }
+
+  /** Returns the largest queued input presentation time, in microseconds */
+  protected final long getLargestQueuedPresentationTimeUs() {
+    return largestQueuedPresentationTimeUs;
+  }
+
   private void resetInputBuffer() {
     inputIndex = C.INDEX_UNSET;
     buffer.data = null;
@@ -1645,7 +1663,7 @@ public abstract class MediaCodecRenderer extends BaseRenderer {
   public boolean isReady() {
     return inputFormat != null
         && (isSourceReady()
-            || hasOutputBuffer()
+            || hasOutputReady()
             || (codecHotswapDeadlineMs != C.TIME_UNSET
                 && SystemClock.elapsedRealtime() < codecHotswapDeadlineMs));
   }


### PR DESCRIPTION
This is the pull request for bug #10615
In tunneling mode, when audio stalls the playback is not failing. Video freezes or start playing with very slow rate. In this pull request we are attempting to fix that by tweaking isReady() in MediaCodecRenderer. The MediaCodecAudioRenderer reports not ready when the decoder FIFO is empty. This code is active only in Tunneling mode.

Test stream to reproduce was sent to exoplayer dev email with "**Missing Audio Segments**"
In this test stream audio is missing after 100th segment. Each segment is 6 second long. Without this fix, playback freezes after 10 minutes. With this fix, playback error is seen after 10 minutes.

To reproduce the issue, build the demo App with tunneling mode enabled. i.e. change PlayerActivity.java -
```
//trackSelectionParameters = new TrackSelectionParameters.Builder(/* context= */ this).build();
      trackSelectionParameters = new DefaultTrackSelector.ParametersBuilder(/* context= */ this).setTunnelingEnabled(true).build();
```

There is another stream we generated to evaluate video stall detection. Link to this test stream was sent to exoplayer dev email with "**Missing Video Segments**".  In this stream video is missing after 100th segment. Playback failure is reported after 10 minutes for this stream (expected result). So, Video stall detection seem to work fine.

In non-tunneling mode, audio and video stalls are detected and playback fails after 10 minutes for the above 2 test streams (expected result). 

Please suggest if there is a better way to handle this situation. Thank you.