### PR TITLE
[Issue #10685] Do not send content complete if any midroll is skipped

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/AdTagLoader.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/AdTagLoader.java
@@ -1122,12 +1122,17 @@ import java.util.Map;
   }
 
   private void ensureSentContentCompleteIfAtEndOfStream() {
-    if (!sentContentComplete
-        && contentDurationMs != C.TIME_UNSET
-        && pendingContentPositionMs == C.TIME_UNSET
-        && getContentPeriodPositionMs(checkNotNull(player), timeline, period)
-                + THRESHOLD_END_OF_CONTENT_MS
-            >= contentDurationMs) {
+
+    if (sentContentComplete
+        || contentDurationMs == C.TIME_UNSET
+        || pendingContentPositionMs != C.TIME_UNSET) {
+      return;
+    }
+
+    long contentPeriodPositionMs = getContentPeriodPositionMs(checkNotNull(player), timeline, period);
+    int pendingAdGroupIndex = adPlaybackState.getAdGroupIndexAfterPositionUs(contentPeriodPositionMs, contentDurationMs);
+    if (!adPlaybackState.getAdGroup(pendingAdGroupIndex).shouldPlayAdGroup()
+        && contentPeriodPositionMs + THRESHOLD_END_OF_CONTENT_MS >= contentDurationMs) {
       sendContentComplete();
     }
   }


### PR DESCRIPTION
Let Google IMA SDK handle the event if the user seeks to the very end of the content and skips any midrolls.

This fix will ensure that Exoplayer will behave the same way as [the Google IMA sample application.](https://github.com/googleads/googleads-ima-android/) i.e. Play the last of the skipped midrolls before sending content complete / playing post roll.