### PR TITLE
[Issue #10728] Set network type initial value using context

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/NetworkTypeObserver.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/NetworkTypeObserver.java
@@ -90,7 +90,7 @@ public final class NetworkTypeObserver {
     mainHandler = new Handler(Looper.getMainLooper());
     listeners = new CopyOnWriteArrayList<>();
     networkTypeLock = new Object();
-    networkType = C.NETWORK_TYPE_UNKNOWN;
+    networkType = getNetworkTypeFromConnectivityManager(context);
     IntentFilter filter = new IntentFilter();
     filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
     context.registerReceiver(/* receiver= */ new Receiver(), filter);


### PR DESCRIPTION
The network type is initialised to `C.NETWORK_TYPE_UNKNOWN`, which causes any overrides in the `DefaultBandwidthMeter` to not work for the first playback. Since the network observer is a static entity, it gets reset to the actual value for the second playback and would not be a problem thereafter. However, the network type will always be `NETWORK_TYPE_UNKNOWN` for the first playback after creating the context.

This can be fixed by initialising the network type using the context and not default it to `C.NETWORK_TYPE_UNKNOWN`.

(Reproduction steps and code snippet provided in the issue)