### PR TITLE
Fix ffmpeg jni wrapper returning invalid result codes

### DIFF
--- a/extensions/ffmpeg/src/main/jni/ffmpeg_jni.cc
+++ b/extensions/ffmpeg/src/main/jni/ffmpeg_jni.cc
@@ -283,7 +283,8 @@ int decodePacket(AVCodecContext *context, AVPacket *packet,
         break;
       }
       logError("avcodec_receive_frame", result);
-      return result;
+      return result == AVERROR_INVALIDDATA ? AUDIO_DECODER_ERROR_INVALID_DATA
+                                           : AUDIO_DECODER_ERROR_OTHER;
     }
 
     // Resample output.
@@ -330,7 +331,8 @@ int decodePacket(AVCodecContext *context, AVPacket *packet,
     av_frame_free(&frame);
     if (result < 0) {
       logError("swr_convert", result);
-      return result;
+      return result == AVERROR_INVALIDDATA ? AUDIO_DECODER_ERROR_INVALID_DATA
+                                           : AUDIO_DECODER_ERROR_OTHER;
     }
     int available = swr_get_out_samples(resampleContext, 0);
     if (available != 0) {


### PR DESCRIPTION
This ensure that ffmpeg error code are properly translated to values that the ExoPlayer decoder understand. 
The main gain is that it allows the decoder to properly ignore more cases of invalid data and recover.
The second gain is that the other errors are now proper ExoPlayer errors and no more obscure buffer ones.

Fixes: #10760 