### PR TITLE
Fixed initial bitrate estimates in DefaultBandwidthMeter for India

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultBandwidthMeter.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/upstream/DefaultBandwidthMeter.java
@@ -587,7 +587,7 @@ public final class DefaultBandwidthMeter implements BandwidthMeter, TransferList
       case "IL":
         return new int[] {1, 2, 2, 2, 3, 2};
       case "IN":
-        return new int[] {1, 1, 3, 2, 3, 3};
+        return new int[] {1, 1, 2, 2, 3, 2};
       case "IQ":
         return new int[] {3, 2, 2, 3, 2, 2};
       case "IR":


### PR DESCRIPTION
Initial bitrate estimates now for India:

Network Type | Initial Bitrate Estimate 
-- | -- |
Wifi | 3100000
5G_NSA | 1800000
5G_SA | 1100000
4G | 1400000
3G | 910000
2G | 1000000

New proposed initial bitrate estimates for India:
Network Type | Initial Bitrate Estimate 
-- | -- |
Wifi | 3100000
5G_NSA | 1800000
5G_SA | 1600000
4G | 1400000
3G | 1100000
2G | 1000000