### PR TITLE
Add support for ID3v2.4 multi-value tags

### DIFF
--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaServerSideAdInsertionMediaSource.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaServerSideAdInsertionMediaSource.java
@@ -811,7 +811,7 @@ public final class ImaServerSideAdInsertionMediaSource extends CompositeMediaSou
         if (entry instanceof TextInformationFrame) {
           TextInformationFrame textFrame = (TextInformationFrame) entry;
           if ("TXXX".equals(textFrame.id)) {
-            streamPlayer.triggerUserTextReceived(textFrame.values[0]);
+            streamPlayer.triggerUserTextReceived(textFrame.values.get(0));
           }
         } else if (entry instanceof EventMessage) {
           EventMessage eventMessage = (EventMessage) entry;

--- a/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaServerSideAdInsertionMediaSource.java
+++ b/extensions/ima/src/main/java/com/google/android/exoplayer2/ext/ima/ImaServerSideAdInsertionMediaSource.java
@@ -824,7 +824,7 @@ public final class ImaServerSideAdInsertionMediaSource extends CompositeMediaSou
         if (entry instanceof TextInformationFrame) {
           TextInformationFrame textFrame = (TextInformationFrame) entry;
           if ("TXXX".equals(textFrame.id)) {
-            streamPlayer.triggerUserTextReceived(textFrame.value);
+            streamPlayer.triggerUserTextReceived(textFrame.values[0]);
           }
         } else if (entry instanceof EventMessage) {
           EventMessage eventMessage = (EventMessage) entry;

--- a/library/core/src/test/java/com/google/android/exoplayer2/ExoPlayerTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/ExoPlayerTest.java
@@ -10395,7 +10395,7 @@ public final class ExoPlayerTest {
                 new Metadata(
                     new BinaryFrame(/* id= */ "", /* data= */ new byte[0]),
                     new TextInformationFrame(
-                        /* id= */ "TT2", /* description= */ null, /* value= */ "title")))
+                        /* id= */ "TT2", /* description= */ null, /* value= */ Collections.singletonList("title"))))
             .build();
 
     // Set multiple values together.

--- a/library/core/src/test/java/com/google/android/exoplayer2/metadata/MetadataRendererTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/metadata/MetadataRendererTest.java
@@ -107,7 +107,7 @@ public class MetadataRendererTest {
     assertThat(metadata).hasSize(1);
     assertThat(metadata.get(0).length()).isEqualTo(1);
     TextInformationFrame expectedId3Frame =
-        new TextInformationFrame("TXXX", "Test description", "Test value");
+        new TextInformationFrame("TXXX", "Test description", new String[] { "Test value" });
     assertThat(metadata.get(0).get(0)).isEqualTo(expectedId3Frame);
   }
 

--- a/library/core/src/test/java/com/google/android/exoplayer2/metadata/MetadataRendererTest.java
+++ b/library/core/src/test/java/com/google/android/exoplayer2/metadata/MetadataRendererTest.java
@@ -107,7 +107,7 @@ public class MetadataRendererTest {
     assertThat(metadata).hasSize(1);
     assertThat(metadata.get(0).length()).isEqualTo(1);
     TextInformationFrame expectedId3Frame =
-        new TextInformationFrame("TXXX", "Test description", new String[] { "Test value" });
+        new TextInformationFrame("TXXX", "Test description", Collections.singletonList("Test value"));
     assertThat(metadata.get(0).get(0)).isEqualTo(expectedId3Frame);
   }
 

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp3/Mp3Extractor.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp3/Mp3Extractor.java
@@ -592,7 +592,7 @@ public final class Mp3Extractor implements Extractor {
         Metadata.Entry entry = metadata.get(i);
         if (entry instanceof TextInformationFrame
             && ((TextInformationFrame) entry).id.equals("TLEN")) {
-          return Util.msToUs(Long.parseLong(((TextInformationFrame) entry).values[0]));
+          return Util.msToUs(Long.parseLong(((TextInformationFrame) entry).values.get(0)));
         }
       }
     }

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp3/Mp3Extractor.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp3/Mp3Extractor.java
@@ -592,7 +592,7 @@ public final class Mp3Extractor implements Extractor {
         Metadata.Entry entry = metadata.get(i);
         if (entry instanceof TextInformationFrame
             && ((TextInformationFrame) entry).id.equals("TLEN")) {
-          return Util.msToUs(Long.parseLong(((TextInformationFrame) entry).value));
+          return Util.msToUs(Long.parseLong(((TextInformationFrame) entry).values[0]));
         }
       }
     }

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/MetadataUtil.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/MetadataUtil.java
@@ -31,6 +31,7 @@ import com.google.android.exoplayer2.metadata.id3.TextInformationFrame;
 import com.google.android.exoplayer2.metadata.mp4.MdtaMetadataEntry;
 import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.ParsableByteArray;
+import java.util.Collections;
 import org.checkerframework.checker.nullness.compatqual.NullableType;
 
 /** Utilities for handling metadata in MP4. */
@@ -452,7 +453,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
     if (atomType == Atom.TYPE_data) {
       data.skipBytes(8); // version (1), flags (3), empty (4)
       String value = data.readNullTerminatedString(atomSize - 16);
-      return new TextInformationFrame(id, /* description= */ null, value);
+      return new TextInformationFrame(id, /* description= */ null, Collections.singletonList(value));
     }
     Log.w(TAG, "Failed to parse text attribute: " + Atom.getAtomTypeString(type));
     return null;
@@ -484,7 +485,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
     }
     if (value >= 0) {
       return isTextInformationFrame
-          ? new TextInformationFrame(id, /* description= */ null, Integer.toString(value))
+          ? new TextInformationFrame(id, /* description= */ null, Collections.singletonList(Integer.toString(value)))
           : new CommentFrame(C.LANGUAGE_UNDETERMINED, id, Integer.toString(value));
     }
     Log.w(TAG, "Failed to parse uint8 attribute: " + Atom.getAtomTypeString(type));
@@ -505,7 +506,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
         if (count > 0) {
           value += "/" + count;
         }
-        return new TextInformationFrame(attributeName, /* description= */ null, value);
+        return new TextInformationFrame(attributeName, /* description= */ null, Collections.singletonList(value));
       }
     }
     Log.w(TAG, "Failed to parse index/count attribute: " + Atom.getAtomTypeString(type));
@@ -521,7 +522,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
             ? STANDARD_GENRES[genreCode - 1]
             : null;
     if (genreString != null) {
-      return new TextInformationFrame("TCON", /* description= */ null, genreString);
+      return new TextInformationFrame("TCON", /* description= */ null, Collections.singletonList(genreString));
     }
     Log.w(TAG, "Failed to parse standard genre code");
     return null;

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/Id3Decoder.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/Id3Decoder.java
@@ -464,6 +464,10 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
     ArrayList<String> values = new ArrayList<>();
 
     int valueStartIndex = descriptionEndIndex + delimiterLength(encoding);
+    if (valueStartIndex >= data.length) {
+      return new TextInformationFrame("TXXX", description, new String[0]);
+    }
+
     int valueEndIndex = indexOfTerminator(data, valueStartIndex, encoding);
     while (valueStartIndex < valueEndIndex) {
       String value = decodeStringIfValid(data, valueStartIndex, valueEndIndex, charset);
@@ -496,6 +500,10 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
     ArrayList<String> values = new ArrayList<>();
 
     int valueStartIndex = 0;
+    if (valueStartIndex >= data.length) {
+      return new TextInformationFrame(id, null, new String[0]);
+    }
+
     int valueEndIndex = indexOfTerminator(data, valueStartIndex, encoding);
     while (valueStartIndex < valueEndIndex) {
       String value = decodeStringIfValid(data, valueStartIndex, valueEndIndex, charset);

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/Id3Decoder.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/Id3Decoder.java
@@ -459,10 +459,10 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
 
     int descriptionEndIndex = indexOfEos(data, 0, encoding);
     String description = new String(data, 0, descriptionEndIndex, charset);
-
-    // Text information frames can contain multiple values delimited by a null terminator.
-    // Thus, we after each "end of stream" marker we actually need to keep looking for more
-    // data, at least until the index is equal to the data length.
+    
+    // In ID3v2.4, text information frames can contain multiple values delimited by a null
+    // terminator. Thus, we after each "end of stream" marker we actually need to keep looking
+    // for more data, at least until the index is equal to the data length.
     ArrayList<String> values = new ArrayList<>();
 
     int valueStartIndex = descriptionEndIndex + delimiterLength(encoding);
@@ -474,7 +474,6 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
       valueStartIndex = valueEndIndex + delimiterLength(encoding);
       valueEndIndex = indexOfEos(data, valueStartIndex, encoding);
     }
-
 
     return new TextInformationFrame("TXXX", description, values.toArray(new String[0]));
   }
@@ -493,9 +492,9 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
     byte[] data = new byte[frameSize - 1];
     id3Data.readBytes(data, 0, frameSize - 1);
 
-    // Text information frames can contain multiple values delimited by a null terminator.
-    // Thus, we after each "end of stream" marker we actually need to keep looking for more
-    // data, at least until the index is equal to the data length.
+    // In ID3v2.4, text information frames can contain multiple values delimited by a null
+    // terminator. Thus, we after each "end of stream" marker we actually need to keep looking
+    // for more data, at least until the index is equal to the data length.
     ArrayList<String> values = new ArrayList<>();
 
     int valueStartIndex = 0;

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/Id3Decoder.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/Id3Decoder.java
@@ -489,12 +489,9 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
     ArrayList<String> values = new ArrayList<>();
 
     if (index >= data.length) {
-      return Collections.emptyList();
+      return Collections.singletonList("");
     }
 
-    // In ID3v2.4, text information frames can contain multiple values delimited by a null
-    // terminator. Thus, we after each "end of stream" marker we actually need to keep looking
-    // for more data, at least until the index is equal to the data length.
     String charset = getCharsetName(encoding);
     int valueStartIndex = index;
     int valueEndIndex = indexOfTerminator(data, valueStartIndex, encoding);
@@ -506,7 +503,11 @@ public final class Id3Decoder extends SimpleMetadataDecoder {
       valueEndIndex = indexOfTerminator(data, valueStartIndex, encoding);
     }
 
-    return values;
+    if (values.isEmpty()) {
+      return Collections.singletonList("");
+    } else {
+      return values;
+    }
   }
 
   @Nullable

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
@@ -36,19 +36,18 @@ public final class TextInformationFrame extends Id3Frame {
   @Deprecated
   public final String value;
 
+  /** The text values of this frame. Will always have at least one element. */
   @NonNull
   public final List<String> values;
 
   public TextInformationFrame(String id, @Nullable String description, @NonNull List<String> values) {
     super(id);
-    this.description = description;
-    
-    if( values.size() > 0 ) {
-      this.values = ImmutableList.copyOf(values);
-    } else {
-      this.values = ImmutableList.of("");
+    if (values.isEmpty()) {
+      throw new IllegalArgumentException("Text information frames must have at least one value");
     }
-    
+
+    this.description = description;
+    this.values = ImmutableList.copyOf(values);
     this.value = this.values.get(0);
   }
 

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
@@ -19,6 +19,7 @@ import static com.google.android.exoplayer2.util.Util.castNonNull;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.MediaMetadata;
 import com.google.android.exoplayer2.util.Util;
@@ -36,17 +37,19 @@ public final class TextInformationFrame extends Id3Frame {
   @Deprecated
   public final String value;
 
+  @NonNull
   public final String[] values;
 
-  public TextInformationFrame(String id, @Nullable String description, String[] values) {
+  public TextInformationFrame(String id, @Nullable String description, @NonNull String[] values) {
     super(id);
-    if (values.length == 0) {
-      throw new IllegalArgumentException("A text information frame must have at least one value.");
-    }
-
     this.description = description;
     this.values = values;
-    this.value = values[0];
+
+    if (values.length > 0) {
+      this.value = values[0];
+    } else {
+      this.value = null;
+    }
   }
 
   /** @deprecated Use {@code TextInformationFrame(String id, String description, String[] values} instead */
@@ -58,8 +61,7 @@ public final class TextInformationFrame extends Id3Frame {
   /* package */ TextInformationFrame(Parcel in) {
     super(castNonNull(in.readString()));
     description = in.readString();
-    values = new String[] {};
-    in.readStringArray(values);
+    values = in.createStringArray();
     this.value = values[0];
   }
 
@@ -181,7 +183,7 @@ public final class TextInformationFrame extends Id3Frame {
     TextInformationFrame other = (TextInformationFrame) obj;
     return Util.areEqual(id, other.id)
         && Util.areEqual(description, other.description)
-        && Util.areEqual(values, other.values);
+        && Arrays.equals(values, other.values);
   }
 
   @Override
@@ -195,7 +197,7 @@ public final class TextInformationFrame extends Id3Frame {
 
   @Override
   public String toString() {
-    return id + ": description=" + description + ": values=" + String.join(MULTI_VALUE_DELIMITER, values);
+    return id + ": description=" + description + ": value=" + String.join(MULTI_VALUE_DELIMITER, values);
   }
 
   // Parcelable implementation.

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
@@ -25,6 +25,7 @@ import com.google.android.exoplayer2.MediaMetadata;
 import com.google.android.exoplayer2.util.Util;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /** Text information ID3 frame. */
@@ -38,11 +39,11 @@ public final class TextInformationFrame extends Id3Frame {
   @NonNull
   public final ImmutableList<String> values;
 
-  public TextInformationFrame(String id, @Nullable String description, @NonNull String[] values) {
+  public TextInformationFrame(String id, @Nullable String description, @NonNull List<String> values) {
     super(id);
     this.description = description;
     
-    if( values.length > 0 ) {
+    if( values.size() > 0 ) {
       this.values = ImmutableList.copyOf(values);
     } else {
       this.values = ImmutableList.of("");
@@ -54,7 +55,7 @@ public final class TextInformationFrame extends Id3Frame {
   /** @deprecated Use {@code TextInformationFrame(String id, String description, String[] values} instead */
   @Deprecated
   public TextInformationFrame(String id, @Nullable String description, String value) {
-    this(id, description, new String[] {value } );
+    this(id, description, Collections.singletonList(value) );
   }
 
   /* package */ TextInformationFrame(Parcel in) {

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
@@ -37,7 +37,7 @@ public final class TextInformationFrame extends Id3Frame {
   public final String value;
 
   @NonNull
-  public final ImmutableList<String> values;
+  public final List<String> values;
 
   public TextInformationFrame(String id, @Nullable String description, @NonNull List<String> values) {
     super(id);

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrame.java
@@ -23,48 +23,71 @@ import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.MediaMetadata;
 import com.google.android.exoplayer2.util.Util;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /** Text information ID3 frame. */
 public final class TextInformationFrame extends Id3Frame {
+  private final static String MULTI_VALUE_DELIMITER = ", ";
 
   @Nullable public final String description;
+
+  /** @deprecated Use {@code values} instead. */
+  @Deprecated
   public final String value;
 
-  public TextInformationFrame(String id, @Nullable String description, String value) {
+  public final String[] values;
+
+  public TextInformationFrame(String id, @Nullable String description, String[] values) {
     super(id);
+    if (values.length == 0) {
+      throw new IllegalArgumentException("A text information frame must have at least one value.");
+    }
+
     this.description = description;
-    this.value = value;
+    this.values = values;
+    this.value = values[0];
+  }
+
+  /** @deprecated Use {@code TextInformationFrame(String id, String description, String[] values} instead */
+  @Deprecated
+  public TextInformationFrame(String id, @Nullable String description, String value) {
+    this(id, description, new String[] {value } );
   }
 
   /* package */ TextInformationFrame(Parcel in) {
     super(castNonNull(in.readString()));
     description = in.readString();
-    value = castNonNull(in.readString());
+    values = new String[] {};
+    in.readStringArray(values);
+    this.value = values[0];
   }
 
   @Override
   public void populateMediaMetadata(MediaMetadata.Builder builder) {
+    // Depending on the context this frame is in, we either take the first value of a multi-value
+    // frame because multiple values make no sense, or we join the values together with a comma
+    // when multiple values do make sense.
     switch (id) {
       case "TT2":
       case "TIT2":
-        builder.setTitle(value);
+        builder.setTitle(values[0]);
         break;
       case "TP1":
       case "TPE1":
-        builder.setArtist(value);
+        builder.setArtist(String.join(MULTI_VALUE_DELIMITER, values));
         break;
       case "TP2":
       case "TPE2":
-        builder.setAlbumArtist(value);
+        builder.setAlbumArtist(String.join(MULTI_VALUE_DELIMITER, values));
         break;
       case "TAL":
       case "TALB":
-        builder.setAlbumTitle(value);
+        builder.setAlbumTitle(values[0]);
         break;
       case "TRK":
       case "TRCK":
-        String[] trackNumbers = Util.split(value, "/");
+        String[] trackNumbers = Util.split(values[0], "/");
         try {
           int trackNumber = Integer.parseInt(trackNumbers[0]);
           @Nullable
@@ -78,7 +101,7 @@ public final class TextInformationFrame extends Id3Frame {
       case "TYE":
       case "TYER":
         try {
-          builder.setRecordingYear(Integer.parseInt(value));
+          builder.setRecordingYear(Integer.parseInt(values[0]));
         } catch (NumberFormatException e) {
           // Do nothing, invalid input.
         }
@@ -86,15 +109,16 @@ public final class TextInformationFrame extends Id3Frame {
       case "TDA":
       case "TDAT":
         try {
-          int month = Integer.parseInt(value.substring(2, 4));
-          int day = Integer.parseInt(value.substring(0, 2));
+          String date = values[0];
+          int month = Integer.parseInt(date.substring(2, 4));
+          int day = Integer.parseInt(date.substring(0, 2));
           builder.setRecordingMonth(month).setRecordingDay(day);
         } catch (NumberFormatException | StringIndexOutOfBoundsException e) {
           // Do nothing, invalid input.
         }
         break;
       case "TDRC":
-        List<Integer> recordingDate = parseId3v2point4TimestampFrameForDate(value);
+        List<Integer> recordingDate = parseId3v2point4TimestampFrameForDate(values[0]);
         switch (recordingDate.size()) {
           case 3:
             builder.setRecordingDay(recordingDate.get(2));
@@ -112,7 +136,7 @@ public final class TextInformationFrame extends Id3Frame {
         }
         break;
       case "TDRL":
-        List<Integer> releaseDate = parseId3v2point4TimestampFrameForDate(value);
+        List<Integer> releaseDate = parseId3v2point4TimestampFrameForDate(values[0]);
         switch (releaseDate.size()) {
           case 3:
             builder.setReleaseDay(releaseDate.get(2));
@@ -131,15 +155,15 @@ public final class TextInformationFrame extends Id3Frame {
         break;
       case "TCM":
       case "TCOM":
-        builder.setComposer(value);
+        builder.setComposer(String.join(MULTI_VALUE_DELIMITER, values));
         break;
       case "TP3":
       case "TPE3":
-        builder.setConductor(value);
+        builder.setConductor(String.join(MULTI_VALUE_DELIMITER, values));
         break;
       case "TXT":
       case "TEXT":
-        builder.setWriter(value);
+        builder.setWriter(String.join(MULTI_VALUE_DELIMITER, values));
         break;
       default:
         break;
@@ -157,7 +181,7 @@ public final class TextInformationFrame extends Id3Frame {
     TextInformationFrame other = (TextInformationFrame) obj;
     return Util.areEqual(id, other.id)
         && Util.areEqual(description, other.description)
-        && Util.areEqual(value, other.value);
+        && Util.areEqual(values, other.values);
   }
 
   @Override
@@ -165,13 +189,13 @@ public final class TextInformationFrame extends Id3Frame {
     int result = 17;
     result = 31 * result + id.hashCode();
     result = 31 * result + (description != null ? description.hashCode() : 0);
-    result = 31 * result + (value != null ? value.hashCode() : 0);
+    result = 31 * result + Arrays.hashCode(values);
     return result;
   }
 
   @Override
   public String toString() {
-    return id + ": description=" + description + ": value=" + value;
+    return id + ": description=" + description + ": values=" + String.join(MULTI_VALUE_DELIMITER, values);
   }
 
   // Parcelable implementation.
@@ -180,7 +204,7 @@ public final class TextInformationFrame extends Id3Frame {
   public void writeToParcel(Parcel dest, int flags) {
     dest.writeString(id);
     dest.writeString(description);
-    dest.writeString(value);
+    dest.writeStringArray(values);
   }
 
   public static final Parcelable.Creator<TextInformationFrame> CREATOR =

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/Id3DecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/Id3DecoderTest.java
@@ -52,7 +52,7 @@ public final class Id3DecoderTest {
     TextInformationFrame textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TXXX");
     assertThat(textInformationFrame.description).isEmpty();
-    assertThat(textInformationFrame.value).isEqualTo("mdialog_VINDICO1527664_start");
+    assertThat(textInformationFrame.values[0]).isEqualTo("mdialog_VINDICO1527664_start");
 
     // Test UTF-16.
     rawId3 =
@@ -67,7 +67,7 @@ public final class Id3DecoderTest {
     textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TXXX");
     assertThat(textInformationFrame.description).isEqualTo("Hello World");
-    assertThat(textInformationFrame.value).isEmpty();
+    assertThat(textInformationFrame.values).isEmpty();
 
     // Test empty.
     rawId3 = buildSingleFrameTag("TXXX", new byte[0]);
@@ -81,7 +81,7 @@ public final class Id3DecoderTest {
     textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TXXX");
     assertThat(textInformationFrame.description).isEmpty();
-    assertThat(textInformationFrame.value).isEmpty();
+    assertThat(textInformationFrame.values).isEmpty();
   }
 
   @Test
@@ -95,7 +95,8 @@ public final class Id3DecoderTest {
     TextInformationFrame textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TIT2");
     assertThat(textInformationFrame.description).isNull();
-    assertThat(textInformationFrame.value).isEqualTo("Hello World");
+    assertThat(textInformationFrame.values.length).isEqualTo(1);
+    assertThat(textInformationFrame.values[0]).isEqualTo("Hello World");
 
     // Test empty.
     rawId3 = buildSingleFrameTag("TIT2", new byte[0]);
@@ -109,7 +110,7 @@ public final class Id3DecoderTest {
     textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TIT2");
     assertThat(textInformationFrame.description).isNull();
-    assertThat(textInformationFrame.value).isEmpty();
+    assertThat(textInformationFrame.values).isEmpty();
   }
 
   @Test

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/Id3DecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/Id3DecoderTest.java
@@ -52,7 +52,7 @@ public final class Id3DecoderTest {
     TextInformationFrame textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TXXX");
     assertThat(textInformationFrame.description).isEmpty();
-    assertThat(textInformationFrame.values[0]).isEqualTo("mdialog_VINDICO1527664_start");
+    assertThat(textInformationFrame.values.get(0)).isEqualTo("mdialog_VINDICO1527664_start");
 
     // Test UTF-16.
     rawId3 =
@@ -67,7 +67,8 @@ public final class Id3DecoderTest {
     textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TXXX");
     assertThat(textInformationFrame.description).isEqualTo("Hello World");
-    assertThat(textInformationFrame.values).isEmpty();
+    assertThat(textInformationFrame.values.size()).isEqualTo(1);
+    assertThat(textInformationFrame.values.get(0)).isEqualTo("");
 
     // Test multiple values.
     rawId3 = buildSingleFrameTag(
@@ -80,9 +81,9 @@ public final class Id3DecoderTest {
     assertThat(metadata.length()).isEqualTo(1);
     textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.description).isEqualTo("Hello World");
-    assertThat(textInformationFrame.values.length).isEqualTo(2);
-    assertThat(textInformationFrame.values[0]).isEqualTo("Foo");
-    assertThat(textInformationFrame.values[1]).isEqualTo("Bar");
+    assertThat(textInformationFrame.values.size()).isEqualTo(2);
+    assertThat(textInformationFrame.values.get(0)).isEqualTo("Foo");
+    assertThat(textInformationFrame.values.get(1)).isEqualTo("Bar");
 
     // Test empty.
     rawId3 = buildSingleFrameTag("TXXX", new byte[0]);
@@ -96,7 +97,8 @@ public final class Id3DecoderTest {
     textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TXXX");
     assertThat(textInformationFrame.description).isEmpty();
-    assertThat(textInformationFrame.values).isEmpty();
+    assertThat(textInformationFrame.values.size()).isEqualTo(1);
+    assertThat(textInformationFrame.values.get(0)).isEqualTo("");
   }
 
   @Test
@@ -110,17 +112,17 @@ public final class Id3DecoderTest {
     TextInformationFrame textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TIT2");
     assertThat(textInformationFrame.description).isNull();
-    assertThat(textInformationFrame.values.length).isEqualTo(1);
-    assertThat(textInformationFrame.values[0]).isEqualTo("Hello World");
+    assertThat(textInformationFrame.values.size()).isEqualTo(1);
+    assertThat(textInformationFrame.values.get(0)).isEqualTo("Hello World");
 
     // Test multiple values.
     rawId3 = buildSingleFrameTag("TIT2", new byte[] {3, 70, 111, 111, 0, 66, 97, 114, 0});
     metadata = decoder.decode(rawId3, rawId3.length);
     assertThat(metadata.length()).isEqualTo(1);
     textInformationFrame = (TextInformationFrame) metadata.get(0);
-    assertThat(textInformationFrame.values.length).isEqualTo(2);
-    assertThat(textInformationFrame.values[0]).isEqualTo("Foo");
-    assertThat(textInformationFrame.values[1]).isEqualTo("Bar");
+    assertThat(textInformationFrame.values.size()).isEqualTo(2);
+    assertThat(textInformationFrame.values.get(0)).isEqualTo("Foo");
+    assertThat(textInformationFrame.values.get(1)).isEqualTo("Bar");
 
     // Test empty.
     rawId3 = buildSingleFrameTag("TIT2", new byte[0]);
@@ -134,7 +136,8 @@ public final class Id3DecoderTest {
     textInformationFrame = (TextInformationFrame) metadata.get(0);
     assertThat(textInformationFrame.id).isEqualTo("TIT2");
     assertThat(textInformationFrame.description).isNull();
-    assertThat(textInformationFrame.values).isEmpty();
+    assertThat(textInformationFrame.values.size()).isEqualTo(1);
+    assertThat(textInformationFrame.values.get(0)).isEqualTo("");
   }
 
   @Test

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/Id3DecoderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/Id3DecoderTest.java
@@ -69,6 +69,21 @@ public final class Id3DecoderTest {
     assertThat(textInformationFrame.description).isEqualTo("Hello World");
     assertThat(textInformationFrame.values).isEmpty();
 
+    // Test multiple values.
+    rawId3 = buildSingleFrameTag(
+            "TXXX",
+            new byte[] {
+              1, 0, 72, 0, 101, 0, 108, 0, 108, 0, 111, 0, 32, 0, 87, 0, 111, 0, 114, 0, 108, 0,
+              100, 0, 0, 0, 70, 0, 111, 0, 111, 0, 0, 0, 66, 0, 97, 0, 114, 0, 0
+            });
+    metadata = decoder.decode(rawId3, rawId3.length);
+    assertThat(metadata.length()).isEqualTo(1);
+    textInformationFrame = (TextInformationFrame) metadata.get(0);
+    assertThat(textInformationFrame.description).isEqualTo("Hello World");
+    assertThat(textInformationFrame.values.length).isEqualTo(2);
+    assertThat(textInformationFrame.values[0]).isEqualTo("Foo");
+    assertThat(textInformationFrame.values[1]).isEqualTo("Bar");
+
     // Test empty.
     rawId3 = buildSingleFrameTag("TXXX", new byte[0]);
     metadata = decoder.decode(rawId3, rawId3.length);
@@ -97,6 +112,15 @@ public final class Id3DecoderTest {
     assertThat(textInformationFrame.description).isNull();
     assertThat(textInformationFrame.values.length).isEqualTo(1);
     assertThat(textInformationFrame.values[0]).isEqualTo("Hello World");
+
+    // Test multiple values.
+    rawId3 = buildSingleFrameTag("TIT2", new byte[] {3, 70, 111, 111, 0, 66, 97, 114, 0});
+    metadata = decoder.decode(rawId3, rawId3.length);
+    assertThat(metadata.length()).isEqualTo(1);
+    textInformationFrame = (TextInformationFrame) metadata.get(0);
+    assertThat(textInformationFrame.values.length).isEqualTo(2);
+    assertThat(textInformationFrame.values[0]).isEqualTo("Foo");
+    assertThat(textInformationFrame.values[1]).isEqualTo("Bar");
 
     // Test empty.
     rawId3 = buildSingleFrameTag("TIT2", new byte[0]);

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrameTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrameTest.java
@@ -65,27 +65,27 @@ public class TextInformationFrameTest {
         ImmutableList.of(
             new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* value= */
                 Collections.singletonList(title)),
-            new TextInformationFrame(/* id= */ "TP1", /* description= */ null, /* values= */ Collections.singletonList( artist )),
+            new TextInformationFrame(/* id= */ "TP1", /* description= */ null, /* values= */ Collections.singletonList(artist)),
             new TextInformationFrame(
-                /* id= */ "TAL", /* description= */ null, /* values= */ Collections.singletonList( albumTitle )),
+                /* id= */ "TAL", /* description= */ null, /* values= */ Collections.singletonList(albumTitle)),
             new TextInformationFrame(
-                /* id= */ "TP2", /* description= */ null, /* values= */ Collections.singletonList( albumArtist )),
+                /* id= */ "TP2", /* description= */ null, /* values= */ Collections.singletonList(albumArtist)),
             new TextInformationFrame(
-                /* id= */ "TRK", /* description= */ null, /* values= */ Collections.singletonList( trackNumberInfo)),
+                /* id= */ "TRK", /* description= */ null, /* values= */ Collections.singletonList(trackNumberInfo)),
             new TextInformationFrame(
-                /* id= */ "TYE", /* description= */ null, /* values= */ Collections.singletonList( recordingYear )),
+                /* id= */ "TYE", /* description= */ null, /* values= */ Collections.singletonList(recordingYear)),
             new TextInformationFrame(
                 /* id= */ "TDA",
                 /* description= */ null,
                 /* value= */ Collections.singletonList( recordingDay + recordingMonth )),
             new TextInformationFrame(
-                /* id= */ "TDRL", /* description= */ null, /* values= */ Collections.singletonList( releaseDate )),
+                /* id= */ "TDRL", /* description= */ null, /* values= */ Collections.singletonList(releaseDate)),
             new TextInformationFrame(
-                /* id= */ "TCM", /* description= */ null, /* values= */ Collections.singletonList( composer )),
+                /* id= */ "TCM", /* description= */ null, /* values= */ Collections.singletonList(composer)),
             new TextInformationFrame(
-                /* id= */ "TP3", /* description= */ null, /* values= */ Collections.singletonList( conductor )),
+                /* id= */ "TP3", /* description= */ null, /* values= */ Collections.singletonList(conductor)),
             new TextInformationFrame(
-                /* id= */ "TXT", /* description= */ null, /* values= */ Collections.singletonList( writer )));
+                /* id= */ "TXT", /* description= */ null, /* values= */ Collections.singletonList(writer)));
     MediaMetadata.Builder builder = MediaMetadata.EMPTY.buildUpon();
 
     for (Metadata.Entry entry : entries) {

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrameTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrameTest.java
@@ -22,6 +22,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.google.android.exoplayer2.MediaMetadata;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.common.collect.ImmutableList;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +33,7 @@ public class TextInformationFrameTest {
 
   @Test
   public void parcelable() {
-    TextInformationFrame textInformationFrameToParcel = new TextInformationFrame("", "", "");
+    TextInformationFrame textInformationFrameToParcel = new TextInformationFrame("", "", Collections.singletonList(""));
 
     Parcel parcel = Parcel.obtain();
     textInformationFrameToParcel.writeToParcel(parcel, 0);
@@ -62,28 +63,29 @@ public class TextInformationFrameTest {
 
     List<Metadata.Entry> entries =
         ImmutableList.of(
-            new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* value= */ new String[] { title }),
-            new TextInformationFrame(/* id= */ "TP1", /* description= */ null, /* value= */ new String[] { artist }),
+            new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* value= */
+                Collections.singletonList(title)),
+            new TextInformationFrame(/* id= */ "TP1", /* description= */ null, /* values= */ Collections.singletonList( artist )),
             new TextInformationFrame(
-                /* id= */ "TAL", /* description= */ null, /* value= */ new String[] { albumTitle }),
+                /* id= */ "TAL", /* description= */ null, /* values= */ Collections.singletonList( albumTitle )),
             new TextInformationFrame(
-                /* id= */ "TP2", /* description= */ null, /* value= */ new String[] { albumArtist }),
+                /* id= */ "TP2", /* description= */ null, /* values= */ Collections.singletonList( albumArtist )),
             new TextInformationFrame(
-                /* id= */ "TRK", /* description= */ null, /* value= */ new String[] { trackNumberInfo}),
+                /* id= */ "TRK", /* description= */ null, /* values= */ Collections.singletonList( trackNumberInfo)),
             new TextInformationFrame(
-                /* id= */ "TYE", /* description= */ null, /* value= */ new String[] { recordingYear }),
+                /* id= */ "TYE", /* description= */ null, /* values= */ Collections.singletonList( recordingYear )),
             new TextInformationFrame(
                 /* id= */ "TDA",
                 /* description= */ null,
-                /* value= */ new String[] { recordingDay + recordingMonth }),
+                /* value= */ Collections.singletonList( recordingDay + recordingMonth )),
             new TextInformationFrame(
-                /* id= */ "TDRL", /* description= */ null, /* value= */ new String[] { releaseDate }),
+                /* id= */ "TDRL", /* description= */ null, /* values= */ Collections.singletonList( releaseDate )),
             new TextInformationFrame(
-                /* id= */ "TCM", /* description= */ null, /* value= */ new String[] { composer }),
+                /* id= */ "TCM", /* description= */ null, /* values= */ Collections.singletonList( composer )),
             new TextInformationFrame(
-                /* id= */ "TP3", /* description= */ null, /* value= */ new String[] { conductor }),
+                /* id= */ "TP3", /* description= */ null, /* values= */ Collections.singletonList( conductor )),
             new TextInformationFrame(
-                /* id= */ "TXT", /* description= */ null, /* value= */ new String[] { writer }));
+                /* id= */ "TXT", /* description= */ null, /* values= */ Collections.singletonList( writer )));
     MediaMetadata.Builder builder = MediaMetadata.EMPTY.buildUpon();
 
     for (Metadata.Entry entry : entries) {
@@ -110,8 +112,8 @@ public class TextInformationFrameTest {
 
     // Test empty value array
     entries =
-        ImmutableList.of(
-            new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* value= */ new String[0])
+        Collections.singletonList(
+            new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* values= */ Collections.emptyList())
         );
 
     builder = MediaMetadata.EMPTY.buildUpon();

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrameTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrameTest.java
@@ -62,28 +62,28 @@ public class TextInformationFrameTest {
 
     List<Metadata.Entry> entries =
         ImmutableList.of(
-            new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* value= */ title),
-            new TextInformationFrame(/* id= */ "TP1", /* description= */ null, /* value= */ artist),
+            new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* value= */ new String[] { title }),
+            new TextInformationFrame(/* id= */ "TP1", /* description= */ null, /* value= */ new String[] { artist }),
             new TextInformationFrame(
-                /* id= */ "TAL", /* description= */ null, /* value= */ albumTitle),
+                /* id= */ "TAL", /* description= */ null, /* value= */ new String[] { albumTitle }),
             new TextInformationFrame(
-                /* id= */ "TP2", /* description= */ null, /* value= */ albumArtist),
+                /* id= */ "TP2", /* description= */ null, /* value= */ new String[] { albumArtist }),
             new TextInformationFrame(
-                /* id= */ "TRK", /* description= */ null, /* value= */ trackNumberInfo),
+                /* id= */ "TRK", /* description= */ null, /* value= */ new String[] { trackNumberInfo}),
             new TextInformationFrame(
-                /* id= */ "TYE", /* description= */ null, /* value= */ recordingYear),
+                /* id= */ "TYE", /* description= */ null, /* value= */ new String[] { recordingYear }),
             new TextInformationFrame(
                 /* id= */ "TDA",
                 /* description= */ null,
-                /* value= */ recordingDay + recordingMonth),
+                /* value= */ new String[] { recordingDay + recordingMonth }),
             new TextInformationFrame(
-                /* id= */ "TDRL", /* description= */ null, /* value= */ releaseDate),
+                /* id= */ "TDRL", /* description= */ null, /* value= */ new String[] { releaseDate }),
             new TextInformationFrame(
-                /* id= */ "TCM", /* description= */ null, /* value= */ composer),
+                /* id= */ "TCM", /* description= */ null, /* value= */ new String[] { composer }),
             new TextInformationFrame(
-                /* id= */ "TP3", /* description= */ null, /* value= */ conductor),
+                /* id= */ "TP3", /* description= */ null, /* value= */ new String[] { conductor }),
             new TextInformationFrame(
-                /* id= */ "TXT", /* description= */ null, /* value= */ writer));
+                /* id= */ "TXT", /* description= */ null, /* value= */ new String[] { writer }));
     MediaMetadata.Builder builder = MediaMetadata.EMPTY.buildUpon();
 
     for (Metadata.Entry entry : entries) {
@@ -107,5 +107,21 @@ public class TextInformationFrameTest {
     assertThat(mediaMetadata.composer.toString()).isEqualTo(composer);
     assertThat(mediaMetadata.conductor.toString()).isEqualTo(conductor);
     assertThat(mediaMetadata.writer.toString()).isEqualTo(writer);
+
+    // Test empty value array
+    entries =
+        ImmutableList.of(
+            new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* value= */ new String[0])
+        );
+
+    builder = MediaMetadata.EMPTY.buildUpon();
+
+    for (Metadata.Entry entry : entries) {
+      entry.populateMediaMetadata(builder);
+    }
+
+    mediaMetadata = builder.build();
+
+    assertThat(mediaMetadata.title.toString()).isEqualTo("");
   }
 }

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrameTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/metadata/id3/TextInformationFrameTest.java
@@ -109,21 +109,5 @@ public class TextInformationFrameTest {
     assertThat(mediaMetadata.composer.toString()).isEqualTo(composer);
     assertThat(mediaMetadata.conductor.toString()).isEqualTo(conductor);
     assertThat(mediaMetadata.writer.toString()).isEqualTo(writer);
-
-    // Test empty value array
-    entries =
-        Collections.singletonList(
-            new TextInformationFrame(/* id= */ "TT2", /* description= */ null, /* values= */ Collections.emptyList())
-        );
-
-    builder = MediaMetadata.EMPTY.buildUpon();
-
-    for (Metadata.Entry entry : entries) {
-      entry.populateMediaMetadata(builder);
-    }
-
-    mediaMetadata = builder.build();
-
-    assertThat(mediaMetadata.title.toString()).isEqualTo("");
   }
 }


### PR DESCRIPTION
#### The problem

My app uses ExoPlayer's metadata parser to work around issues with `MediaStore`'s metadata handling. However, recent developments have required me to start handling multi-value tags, as many users want my app to support multiple artist/genre entries.

While the vorbis extractor supports multiple instances of the tag, the ID3v2 extractor does not, even though ID3v2.4 specifies that text information frames can have multiple values in them if delimited by a null terminator. This worsens the user experience with multi-value tags.

#### What this PR does

This PR deprecates the `value` field in `TextInformationFrame` and replaces it with a new array field called `values`. `Id3Decoder` populates this field with multiple values if it finds multiple tags delimited by null terminators. The now-deprecated `value` field is populated with the first item in `values`, to retain compatibility with the old implementation that would parse the first value only. 

This new algorithm should be backwards compatible with ID3v2.3 and ID3v2.2, as they only leverage null terminators as an informal shortcut to make serializing to C strings easier.

#### Further notes

I've modified other parts of the codebase to use the non-deprecated value to the most backwards-compatible extent possible. I have also added tests into `Id3Decoder` to handle the new functionality.
