### PR TITLE
Ogg fixes

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/DefaultOggSeeker.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/DefaultOggSeeker.java
@@ -69,6 +69,7 @@ import java.io.IOException;
    */
   public DefaultOggSeeker(
       StreamReader streamReader,
+      long streamSerialNumber,
       long payloadStartPosition,
       long payloadEndPosition,
       long firstPayloadPageSize,
@@ -86,7 +87,7 @@ import java.io.IOException;
     } else {
       state = STATE_SEEK_TO_END;
     }
-    pageHeader = new OggPageHeader();
+    pageHeader = new OggPageHeader(streamSerialNumber);
   }
 
   @Override

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/FlacReader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/FlacReader.java
@@ -42,6 +42,10 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
   @Nullable private FlacStreamMetadata streamMetadata;
   @Nullable private FlacOggSeeker flacOggSeeker;
 
+  public FlacReader(long streamSerialNumber) {
+    super(streamSerialNumber);
+  }
+
   public static boolean verifyBitstreamType(ParsableByteArray data) {
     return data.bytesLeft() >= 5
         && data.readUnsignedByte() == 0x7F

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/OggExtractor.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/OggExtractor.java
@@ -90,7 +90,7 @@ public class OggExtractor implements Extractor {
 
   @EnsuresNonNullIf(expression = "streamReader", result = true)
   private boolean sniffInternal(ExtractorInput input) throws IOException {
-    OggPageHeader header = new OggPageHeader();
+    OggPageHeader header = new OggPageHeader(-1L);
 
     while (header.populate(input, true) && (header.type & 0x02) == 0x02) {
       int length = min(header.bodySize, MAX_VERIFICATION_BYTES);
@@ -98,13 +98,13 @@ public class OggExtractor implements Extractor {
       input.peekFully(scratch.getData(), 0, length);
 
       if (FlacReader.verifyBitstreamType(resetPosition(scratch))) {
-        streamReader = new FlacReader();
+        streamReader = new FlacReader(header.streamSerialNumber);
         return true;
       } else if (VorbisReader.verifyBitstreamType(resetPosition(scratch))) {
-        streamReader = new VorbisReader();
+        streamReader = new VorbisReader(header.streamSerialNumber);
         return true;
       } else if (OpusReader.verifyBitstreamType(resetPosition(scratch))) {
-        streamReader = new OpusReader();
+        streamReader = new OpusReader(header.streamSerialNumber);
         return true;
       }
       try {

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/OggExtractor.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/OggExtractor.java
@@ -91,24 +91,31 @@ public class OggExtractor implements Extractor {
   @EnsuresNonNullIf(expression = "streamReader", result = true)
   private boolean sniffInternal(ExtractorInput input) throws IOException {
     OggPageHeader header = new OggPageHeader();
-    if (!header.populate(input, true) || (header.type & 0x02) != 0x02) {
-      return false;
+
+    while (header.populate(input, true) && (header.type & 0x02) == 0x02) {
+      int length = min(header.bodySize, MAX_VERIFICATION_BYTES);
+      ParsableByteArray scratch = new ParsableByteArray(length);
+      input.peekFully(scratch.getData(), 0, length);
+
+      if (FlacReader.verifyBitstreamType(resetPosition(scratch))) {
+        streamReader = new FlacReader();
+        return true;
+      } else if (VorbisReader.verifyBitstreamType(resetPosition(scratch))) {
+        streamReader = new VorbisReader();
+        return true;
+      } else if (OpusReader.verifyBitstreamType(resetPosition(scratch))) {
+        streamReader = new OpusReader();
+        return true;
+      }
+      try {
+        input.skip((int) input.getPeekPosition());
+        header.skipToNextPage(input);
+      } catch (IOException e) {
+        return false;
+      }
     }
 
-    int length = min(header.bodySize, MAX_VERIFICATION_BYTES);
-    ParsableByteArray scratch = new ParsableByteArray(length);
-    input.peekFully(scratch.getData(), 0, length);
-
-    if (FlacReader.verifyBitstreamType(resetPosition(scratch))) {
-      streamReader = new FlacReader();
-    } else if (VorbisReader.verifyBitstreamType(resetPosition(scratch))) {
-      streamReader = new VorbisReader();
-    } else if (OpusReader.verifyBitstreamType(resetPosition(scratch))) {
-      streamReader = new OpusReader();
-    } else {
-      return false;
-    }
-    return true;
+    return false;
   }
 
   private static ParsableByteArray resetPosition(ParsableByteArray scratch) {

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/OggPacket.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/OggPacket.java
@@ -29,7 +29,11 @@ import java.util.Arrays;
 /** OGG packet class. */
 /* package */ final class OggPacket {
 
-  private final OggPageHeader pageHeader = new OggPageHeader();
+  private final OggPageHeader pageHeader;
+  public OggPacket(long streamSerialNumber) {
+    pageHeader = new OggPageHeader(streamSerialNumber);
+  }
+
   private final ParsableByteArray packetArray =
       new ParsableByteArray(new byte[OggPageHeader.MAX_PAGE_PAYLOAD], 0);
 

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/OpusReader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/OpusReader.java
@@ -38,6 +38,10 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
     'O', 'p', 'u', 's', 'T', 'a', 'g', 's'
   };
 
+  public OpusReader(long streamSerialNumber) {
+    super(streamSerialNumber);
+  }
+
   private boolean firstCommentHeaderSeen;
 
   public static boolean verifyBitstreamType(ParsableByteArray data) {

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/StreamReader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/StreamReader.java
@@ -62,8 +62,11 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
   private boolean seekMapSet;
   private boolean formatSet;
 
-  public StreamReader() {
-    oggPacket = new OggPacket();
+  private long streamSerialNumber;
+
+  public StreamReader(long streamSerialNumber) {
+    this.streamSerialNumber = streamSerialNumber;
+    oggPacket = new OggPacket(streamSerialNumber);
     setupData = new SetupData();
   }
 
@@ -182,6 +185,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
       oggSeeker =
           new DefaultOggSeeker(
               /* streamReader= */ this,
+              streamSerialNumber,
               payloadStartPosition,
               input.getLength(),
               firstPayloadPageHeader.headerSize + firstPayloadPageHeader.bodySize,

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/VorbisReader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/VorbisReader.java
@@ -43,6 +43,10 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
   @Nullable private VorbisUtil.VorbisIdHeader vorbisIdHeader;
   @Nullable private VorbisUtil.CommentHeader commentHeader;
 
+  public VorbisReader(long streamSerialNumber) {
+    super(streamSerialNumber);
+  }
+
   public static boolean verifyBitstreamType(ParsableByteArray data) {
     try {
       return VorbisUtil.verifyVorbisHeaderCapturePattern(/* headerType= */ 0x01, data, true);

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/VorbisReader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ogg/VorbisReader.java
@@ -140,7 +140,11 @@ import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
     }
 
     if (commentHeader == null) {
-      commentHeader = VorbisUtil.readVorbisCommentHeader(scratch);
+      // The comment header can be in a future page
+      if (VorbisUtil.verifyVorbisHeaderCapturePattern(/* headerType= */ 0x03, scratch, /* quiet= */ true)) {
+        scratch.setPosition(scratch.getPosition() - 7);
+        commentHeader = VorbisUtil.readVorbisCommentHeader(scratch);
+      }
       return null;
     }
     VorbisUtil.VorbisIdHeader vorbisIdHeader = this.vorbisIdHeader;

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/extractor/ogg/DefaultOggSeekerTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/extractor/ogg/DefaultOggSeekerTest.java
@@ -41,7 +41,8 @@ public final class DefaultOggSeekerTest {
   public void setupWithUnsetEndPositionFails() {
     try {
       new DefaultOggSeeker(
-          /* streamReader= */ new TestStreamReader(),
+          /* streamReader= */ new TestStreamReader(-1),
+          -1L,
           /* payloadStartPosition= */ 0,
           /* payloadEndPosition= */ C.LENGTH_UNSET,
           /* firstPayloadPageSize= */ 1,
@@ -64,16 +65,17 @@ public final class DefaultOggSeekerTest {
     int lastPayloadPageGranuleCount = 20806;
 
     FakeExtractorInput input = new FakeExtractorInput.Builder().setData(data).build();
-    TestStreamReader streamReader = new TestStreamReader();
+    TestStreamReader streamReader = new TestStreamReader(-1L);
     DefaultOggSeeker oggSeeker =
         new DefaultOggSeeker(
             streamReader,
+            -1L,
             /* payloadStartPosition= */ 0,
             /* payloadEndPosition= */ data.length,
             firstPayloadPageSize,
             /* firstPayloadPageGranulePosition= */ firstPayloadPageGranuleCount,
             /* firstPayloadPageIsLastPage= */ false);
-    OggPageHeader pageHeader = new OggPageHeader();
+    OggPageHeader pageHeader = new OggPageHeader(-1);
 
     while (true) {
       long nextSeekPosition = oggSeeker.read(input);
@@ -156,7 +158,8 @@ public final class DefaultOggSeekerTest {
       throws IOException {
     DefaultOggSeeker oggSeeker =
         new DefaultOggSeeker(
-            /* streamReader= */ new FlacReader(),
+            /* streamReader= */ new FlacReader(-1L),
+            -1L,
             /* payloadStartPosition= */ 0,
             /* payloadEndPosition= */ input.getLength(),
             /* firstPayloadPageSize= */ 1,
@@ -208,6 +211,11 @@ public final class DefaultOggSeekerTest {
   }
 
   private static class TestStreamReader extends StreamReader {
+
+    public TestStreamReader(long streamSerialNumber) {
+      super(streamSerialNumber);
+    }
+
     @Override
     protected long preparePayload(ParsableByteArray packet) {
       return 0;

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/extractor/ogg/OggPacketTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/extractor/ogg/OggPacketTest.java
@@ -36,7 +36,7 @@ public final class OggPacketTest {
   private static final String TEST_FILE = "media/ogg/bear.opus";
 
   private final Random random = new Random(/* seed= */ 0);
-  private final OggPacket oggPacket = new OggPacket();
+  private final OggPacket oggPacket = new OggPacket(-1L);
 
   @Test
   public void readPacketsWithEmptyPage() throws Exception {

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/extractor/ogg/OggPageHeaderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/extractor/ogg/OggPageHeaderTest.java
@@ -48,7 +48,7 @@ public final class OggPageHeaderTest {
                 new byte[] {'O', 'g', 'g', 'S'},
                 TestUtil.buildTestData(20, random)),
             /* simulateUnknownLength= */ false);
-    OggPageHeader oggHeader = new OggPageHeader();
+    OggPageHeader oggHeader = new OggPageHeader(-1L);
 
     boolean result = retrySimulatedIOException(() -> oggHeader.skipToNextPage(input));
 
@@ -61,7 +61,7 @@ public final class OggPageHeaderTest {
     FakeExtractorInput input =
         createInput(
             Bytes.concat(TestUtil.buildTestData(20, random)), /* simulateUnknownLength= */ false);
-    OggPageHeader oggHeader = new OggPageHeader();
+    OggPageHeader oggHeader = new OggPageHeader(-1L);
 
     boolean result = retrySimulatedIOException(() -> oggHeader.skipToNextPage(input));
 
@@ -78,7 +78,7 @@ public final class OggPageHeaderTest {
                 new byte[] {'O', 'g', 'g', 'S'},
                 TestUtil.buildTestData(20, random)),
             /* simulateUnknownLength= */ false);
-    OggPageHeader oggHeader = new OggPageHeader();
+    OggPageHeader oggHeader = new OggPageHeader(-1L);
 
     boolean result = retrySimulatedIOException(() -> oggHeader.skipToNextPage(input, 10));
 
@@ -92,7 +92,7 @@ public final class OggPageHeaderTest {
         getByteArray(ApplicationProvider.getApplicationContext(), "media/ogg/page_header");
 
     FakeExtractorInput input = createInput(data, /* simulateUnknownLength= */ true);
-    OggPageHeader header = new OggPageHeader();
+    OggPageHeader header = new OggPageHeader(-1L);
 
     boolean result = retrySimulatedIOException(() -> header.populate(input, /* quiet= */ false));
 
@@ -113,7 +113,7 @@ public final class OggPageHeaderTest {
       throws Exception {
     FakeExtractorInput input =
         createInput(TestUtil.createByteArray(2, 2), /* simulateUnknownLength= */ false);
-    OggPageHeader header = new OggPageHeader();
+    OggPageHeader header = new OggPageHeader(-1L);
 
     boolean result = retrySimulatedIOException(() -> header.populate(input, /* quiet= */ true));
 
@@ -127,7 +127,7 @@ public final class OggPageHeaderTest {
     // change from 'O' to 'o'
     data[0] = 'o';
     FakeExtractorInput input = createInput(data, /* simulateUnknownLength= */ false);
-    OggPageHeader header = new OggPageHeader();
+    OggPageHeader header = new OggPageHeader(-1L);
 
     boolean result = retrySimulatedIOException(() -> header.populate(input, /* quiet= */ true));
 
@@ -141,7 +141,7 @@ public final class OggPageHeaderTest {
     // change revision from 0 to 1
     data[4] = 0x01;
     FakeExtractorInput input = createInput(data, /* simulateUnknownLength= */ false);
-    OggPageHeader header = new OggPageHeader();
+    OggPageHeader header = new OggPageHeader(-1L);
 
     boolean result = retrySimulatedIOException(() -> header.populate(input, /* quiet= */ true));
 

--- a/library/extractor/src/test/java/com/google/android/exoplayer2/extractor/ogg/VorbisReaderTest.java
+++ b/library/extractor/src/test/java/com/google/android/exoplayer2/extractor/ogg/VorbisReaderTest.java
@@ -70,7 +70,7 @@ public final class VorbisReaderTest {
             .setSimulatePartialReads(true)
             .build();
 
-    VorbisReader reader = new VorbisReader();
+    VorbisReader reader = new VorbisReader(-1L);
     VorbisReader.VorbisSetup vorbisSetup = readSetupHeaders(reader, input);
 
     assertThat(vorbisSetup.idHeader).isNotNull();
@@ -104,7 +104,7 @@ public final class VorbisReaderTest {
 
   private static VorbisSetup readSetupHeaders(VorbisReader reader, ExtractorInput input)
       throws IOException {
-    OggPacket oggPacket = new OggPacket();
+    OggPacket oggPacket = new OggPacket(-1L);
     while (true) {
       try {
         if (!oggPacket.populate(input)) {


### PR DESCRIPTION
Improve ogg support by supporting multistream container and selecting the first supported.

Properly support comment headers present in a future page.
Properly only decode a single stream when selected by the extractor.