### PR TITLE
Crash android.database.sqlite.SQLiteDatabaseLockedException

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/offline/DefaultDownloadIndex.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/offline/DefaultDownloadIndex.java
@@ -19,9 +19,7 @@ import static com.google.android.exoplayer2.util.Assertions.checkNotNull;
 
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteException;
 import android.net.Uri;
 import android.text.TextUtils;
 import androidx.annotation.GuardedBy;
@@ -187,7 +185,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       }
       cursor.moveToNext();
       return getDownloadForCurrentRow(cursor);
-    } catch (SQLiteException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -205,7 +203,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
     try {
       SQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
       putDownloadInternal(download, writableDatabase);
-    } catch (SQLiteException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -215,7 +213,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
     ensureInitialized();
     try {
       databaseProvider.getWritableDatabase().delete(tableName, WHERE_ID_EQUALS, new String[] {id});
-    } catch (SQLiteException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -228,7 +226,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       values.put(COLUMN_STATE, Download.STATE_QUEUED);
       SQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
       writableDatabase.update(tableName, values, WHERE_STATE_IS_DOWNLOADING, /* whereArgs= */ null);
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -244,7 +242,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       values.put(COLUMN_FAILURE_REASON, Download.FAILURE_REASON_NONE);
       SQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
       writableDatabase.update(tableName, values, /* whereClause= */ null, /* whereArgs= */ null);
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -257,7 +255,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
       values.put(COLUMN_STOP_REASON, stopReason);
       SQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
       writableDatabase.update(tableName, values, WHERE_STATE_IS_TERMINAL, /* whereArgs= */ null);
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -274,7 +272,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
           values,
           WHERE_STATE_IS_TERMINAL + " AND " + WHERE_ID_EQUALS,
           new String[] {id});
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -306,7 +304,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
           }
         }
         initialized = true;
-      } catch (SQLException e) {
+      } catch (Throwable e) {
         throw new DatabaseIOException(e);
       }
     }
@@ -400,7 +398,7 @@ public final class DefaultDownloadIndex implements WritableDownloadIndex {
               /* groupBy= */ null,
               /* having= */ null,
               sortOrder);
-    } catch (SQLiteException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }

--- a/library/database/src/main/java/com/google/android/exoplayer2/database/DatabaseIOException.java
+++ b/library/database/src/main/java/com/google/android/exoplayer2/database/DatabaseIOException.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 /** An {@link IOException} whose cause is an {@link SQLException}. */
 public final class DatabaseIOException extends IOException {
 
-  public DatabaseIOException(SQLException cause) {
+  public DatabaseIOException(Throwable cause) {
     super(cause);
   }
 

--- a/library/database/src/main/java/com/google/android/exoplayer2/database/DatabaseProvider.java
+++ b/library/database/src/main/java/com/google/android/exoplayer2/database/DatabaseProvider.java
@@ -35,9 +35,10 @@ public interface DatabaseProvider {
    * method to fail, but future attempts may succeed if the problem is fixed.
    *
    * @throws SQLiteException If the database cannot be opened for writing.
+   * @throws Throwable If database inoperable.
    * @return A read/write database object.
    */
-  SQLiteDatabase getWritableDatabase();
+  SQLiteDatabase getWritableDatabase() throws Throwable;
 
   /**
    * Creates and/or opens a database. This will be the same object returned by {@link
@@ -50,7 +51,8 @@ public interface DatabaseProvider {
    * need to read from the database.
    *
    * @throws SQLiteException If the database cannot be opened.
+   * @throws Throwable If database inoperable.
    * @return A database object valid until {@link #getWritableDatabase()} is called.
    */
-  SQLiteDatabase getReadableDatabase();
+  SQLiteDatabase getReadableDatabase()  throws Throwable;
 }

--- a/library/database/src/test/java/com/google/android/exoplayer2/database/VersionTableTest.java
+++ b/library/database/src/test/java/com/google/android/exoplayer2/database/VersionTableTest.java
@@ -37,7 +37,7 @@ public class VersionTableTest {
   private SQLiteDatabase database;
 
   @Before
-  public void setUp() {
+  public void setUp() throws Throwable {
     databaseProvider = TestUtil.getInMemoryDatabaseProvider();
     database = databaseProvider.getWritableDatabase();
   }

--- a/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/CacheFileMetadataIndex.java
+++ b/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/CacheFileMetadataIndex.java
@@ -19,7 +19,6 @@ import static com.google.android.exoplayer2.util.Assertions.checkNotNull;
 
 import android.content.ContentValues;
 import android.database.Cursor;
-import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import androidx.annotation.WorkerThread;
 import com.google.android.exoplayer2.database.DatabaseIOException;
@@ -89,7 +88,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       } finally {
         writableDatabase.endTransaction();
       }
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -131,7 +130,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
           writableDatabase.endTransaction();
         }
       }
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -156,7 +155,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
         fileMetadata.put(name, new CacheFileMetadata(length, lastTouchTimestamp));
       }
       return fileMetadata;
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -181,7 +180,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       values.put(COLUMN_LENGTH, length);
       values.put(COLUMN_LAST_TOUCH_TIMESTAMP, lastTouchTimestamp);
       writableDatabase.replaceOrThrow(tableName, /* nullColumnHack= */ null, values);
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -200,7 +199,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
     try {
       SQLiteDatabase writableDatabase = databaseProvider.getWritableDatabase();
       writableDatabase.delete(tableName, WHERE_NAME_EQUALS, new String[] {name});
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
@@ -227,12 +226,12 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
       } finally {
         writableDatabase.endTransaction();
       }
-    } catch (SQLException e) {
+    } catch (Throwable e) {
       throw new DatabaseIOException(e);
     }
   }
 
-  private Cursor getCursor() {
+  private Cursor getCursor() throws Throwable {
     Assertions.checkNotNull(tableName);
     return databaseProvider
         .getReadableDatabase()

--- a/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/SimpleCache.java
+++ b/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/SimpleCache.java
@@ -298,7 +298,7 @@ public final class SimpleCache implements Cache {
     removeStaleSpans();
     try {
       contentIndex.store();
-    } catch (IOException e) {
+    } catch (Throwable e) {
       Log.e(TAG, "Storing index file failed", e);
     } finally {
       unlockFolder(cacheDir);
@@ -458,7 +458,7 @@ public final class SimpleCache implements Cache {
     addSpan(span);
     try {
       contentIndex.store();
-    } catch (IOException e) {
+    } catch (Throwable e) {
       throw new CacheException(e);
     }
     notifyAll();
@@ -536,7 +536,7 @@ public final class SimpleCache implements Cache {
     contentIndex.applyContentMetadataMutations(key, mutations);
     try {
       contentIndex.store();
-    } catch (IOException e) {
+    } catch (Throwable e) {
       throw new CacheException(e);
     }
   }
@@ -588,7 +588,7 @@ public final class SimpleCache implements Cache {
       } else {
         loadDirectory(cacheDir, /* isRoot= */ true, files, /* fileMetadata= */ null);
       }
-    } catch (IOException e) {
+    } catch (Throwable e) {
       String message = "Failed to initialize cache indices: " + cacheDir;
       Log.e(TAG, message, e);
       initializationException = new CacheException(message, e);
@@ -598,7 +598,7 @@ public final class SimpleCache implements Cache {
     contentIndex.removeEmpty();
     try {
       contentIndex.store();
-    } catch (IOException e) {
+    } catch (Throwable e) {
       Log.e(TAG, "Storing index file failed", e);
     }
   }


### PR DESCRIPTION
Fatal Exception: android.database.sqlite.SQLiteDatabaseLockedException: database is locked (Sqlite code 5 SQLITE_BUSY), (OS error - 2:No such file or directory)
       at android.database.sqlite.SQLiteConnection.nativeExecuteForLong(SQLiteConnection.java)
       at android.database.sqlite.SQLiteConnection.executeForLong(SQLiteConnection.java:735)
       at android.database.sqlite.SQLiteSession.executeForLong(SQLiteSession.java:674)
       at android.database.sqlite.SQLiteStatement.simpleQueryForLong(SQLiteStatement.java:109)
       at android.database.DatabaseUtils.longForQuery(DatabaseUtils.java:935)
       at android.database.DatabaseUtils.longForQuery(DatabaseUtils.java:923)
       at android.database.sqlite.SQLiteDatabase.getVersion(SQLiteDatabase.java:1025)
       at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:409)
       at android.database.sqlite.SQLiteOpenHelper.getReadableDatabase(SQLiteOpenHelper.java:356)
       at com.google.android.exoplayer2.upstream.cache.CachedContentIndex$DatabaseStorage.exists(SourceFile:5)
       at com.google.android.exoplayer2.upstream.cache.CachedContentIndex.initialize(SourceFile:5)
       at com.google.android.exoplayer2.upstream.cache.SimpleCache.SimpleCache.initialize(SourceFile:107)
                                                               access$000
       at com.google.android.exoplayer2.upstream.cache.SimpleCache$1.run(SourceFile:3)