### PR TITLE
setPlaybackParameters() not overwriten by live adjusment

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -527,7 +527,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
           reselectTracksInternal();
           break;
         case MSG_PLAYBACK_PARAMETERS_CHANGED_INTERNAL:
-          handlePlaybackParameters((PlaybackParameters) msg.obj, /* acknowledgeCommand= */ false);
+          PlaybackParameters updatedParameters = (PlaybackParameters) msg.obj;
+          reportPlaybackParametersUpdateInternally(updatedParameters, updatedParameters.speed);
           break;
         case MSG_SEND_MESSAGE:
           sendMessageInternal((PlayerMessage) msg.obj);
@@ -2290,6 +2291,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
       }
       playbackInfo = playbackInfo.copyWithPlaybackParameters(playbackParameters);
     }
+    reportPlaybackParametersUpdateInternally(playbackParameters, currentPlaybackSpeed);
+  }
+
+  private void reportPlaybackParametersUpdateInternally(PlaybackParameters playbackParameters, float currentPlaybackSpeed)
+      throws ExoPlaybackException {
     updateTrackSelectionPlaybackSpeed(playbackParameters.speed);
     for (Renderer renderer : renderers) {
       if (renderer != null) {


### PR DESCRIPTION
There are multiple sequences of handler messages which can cause a user request to update playback speed to be overwritten by the `LivePlaybackSpeedControl` value.

All the sequeunces share a common feature that:

1. a queued `MSG_PLAYBACK_PARAMETERS_CHANGED_INTERNAL` executes after the `MSG_SET_PLAYBACK_PARAMETERS`
2. The `PlaybackParameters` in this internal change are not the intended speed.

The easiest way to reproduce this is with AC-3 pass-thru audio, in this case the audio renderer does not properly support speed change, see bug:
  https://github.com/google/ExoPlayer/issues/10865

According to this commit,

 [Add back support for setting audio pitch](https://github.com/google/ExoPlayer/commit/74c493f51e) [andrewlewis]

This callback to report the internal speed change is needed for the renderers to run slow motion properly.

In any event, there is no reason to propegate this internal speed change to the user speed setting (`ExoPlayerImplInternal.playbackParameters`). The change simply fixes `MSG_PLAYBACK_PARAMETERS_CHANGED_INTERNAL` not to update the user setting.