### PR TITLE
Handle SQLiteDatabaseLockedException in CachedContentIndex

### DIFF
--- a/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/CachedContentIndex.java
+++ b/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/CachedContentIndex.java
@@ -794,11 +794,15 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
     @Override
     public boolean exists() throws DatabaseIOException {
-      return VersionTable.getVersion(
-              databaseProvider.getReadableDatabase(),
-              VersionTable.FEATURE_CACHE_CONTENT_METADATA,
-              checkNotNull(hexUid))
-          != VersionTable.VERSION_UNSET;
+      try {
+        return VersionTable.getVersion(
+            databaseProvider.getReadableDatabase(),
+            VersionTable.FEATURE_CACHE_CONTENT_METADATA,
+            checkNotNull(hexUid))
+            != VersionTable.VERSION_UNSET;
+      } catch (SQLiteException e) {
+        throw new DatabaseIOException(e);
+      }
     }
 
     @Override


### PR DESCRIPTION
SQLiteException is not caught and converted to IOException when trying to access `databaseProvider.getReadableDatabase()`. Hence exoplayer is not handling this cache related exception and crashing. Similar exception is properly handled [here](https://github.com/google/ExoPlayer/blob/dev-v2/library/datasource/src/main/java/com/google/android/exoplayer2/upstream/cache/CacheFileMetadataIndex.java#L117).

**Stacktrace:**
```
android.database.sqlite.SQLiteDatabaseLockedException: database is locked (code 5)
	at android.database.sqlite.SQLiteConnection.nativeExecuteForLong()(SQLiteConnection.java:-2)
	at android.database.sqlite.SQLiteConnection.executeForLong()(SQLiteConnection.java:598)
	at android.database.sqlite.SQLiteSession.executeForLong()(SQLiteSession.java:652)
	at android.database.sqlite.SQLiteStatement.simpleQueryForLong()(SQLiteStatement.java:107)
	at android.database.DatabaseUtils.longForQuery()(DatabaseUtils.java:825)
	at android.database.DatabaseUtils.longForQuery()(DatabaseUtils.java:813)
	at android.database.sqlite.SQLiteDatabase.getVersion()(SQLiteDatabase.java:864)
	at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked()(SQLiteOpenHelper.java:241)
	at android.database.sqlite.SQLiteOpenHelper.getReadableDatabase()(SQLiteOpenHelper.java:187)
	at com.google.android.exoplayer2.upstream.cache.CachedContentIndex$DatabaseStorage.exists()(CachedContentIndex.java:2)
	at com.google.android.exoplayer2.upstream.cache.CachedContentIndex.initialize()(CachedContentIndex.java:4)
	at com.google.android.exoplayer2.upstream.cache.SimpleCache.initialize()(SimpleCache.java:13)
	at com.google.android.exoplayer2.upstream.cache.SimpleCache.access$000()(SimpleCache.java:1)
	at com.google.android.exoplayer2.upstream.cache.SimpleCache$1.run()(SimpleCache.java:3)
```

This particular crash happens a lot in firetv specifically incomparison to Android tv and mobile.