### PR TITLE
Removes liveOffsetTarget override on seek to live edge

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/ExoPlayerImplInternal.java
@@ -1248,7 +1248,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
             /* newPeriodId= */ periodId,
             /* oldTimeline= */ playbackInfo.timeline,
             /* oldPeriodId= */ playbackInfo.periodId,
-            /* positionForTargetOffsetOverrideUs= */ requestedContentPositionUs);
+            /* positionForTargetOffsetOverrideUs= */ requestedContentPositionUs,
+            /* positionRequestedBySeek */true);
+
       }
     } finally {
       playbackInfo =
@@ -1897,7 +1899,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
           /* oldPeriodId= */ playbackInfo.periodId,
           /* positionForTargetOffsetOverrideUs */ positionUpdate.setTargetLiveOffset
               ? newPositionUs
-              : C.TIME_UNSET);
+              : C.TIME_UNSET,
+          /* positionRequestedBySeek */false);
       if (periodPositionChanged
           || newRequestedContentPositionUs != playbackInfo.requestedContentPositionUs) {
         Object oldPeriodUid = playbackInfo.periodId.periodUid;
@@ -1935,7 +1938,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
       MediaPeriodId newPeriodId,
       Timeline oldTimeline,
       MediaPeriodId oldPeriodId,
-      long positionForTargetOffsetOverrideUs)
+      long positionForTargetOffsetOverrideUs,
+      boolean positionRequestedBySeek)
       throws ExoPlaybackException {
     if (!shouldUseLivePlaybackSpeedControl(newTimeline, newPeriodId)) {
       // Live playback speed control is unused for the current period, reset speed to user-defined
@@ -1965,8 +1969,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
         int oldWindowIndex = oldTimeline.getPeriodByUid(oldPeriodId.periodUid, period).windowIndex;
         oldWindowUid = oldTimeline.getWindow(oldWindowIndex, window).uid;
       }
-      if (!Util.areEqual(oldWindowUid, windowUid)) {
-        // Reset overridden target live offset to media values if window changes.
+      if (!Util.areEqual(oldWindowUid, windowUid) || positionRequestedBySeek) {
+        // Reset overridden target live offset to media values if window changes or if seekTo
+        // default live position.
         livePlaybackSpeedControl.setTargetLiveOffsetOverrideUs(C.TIME_UNSET);
       }
     }
@@ -2089,7 +2094,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
         /* newPeriodId= */ readingPeriodHolder.info.id,
         /* oldTimeline= */ playbackInfo.timeline,
         /* oldPeriodId= */ oldReadingPeriodHolder.info.id,
-        /* positionForTargetOffsetOverrideUs= */ C.TIME_UNSET);
+        /* positionForTargetOffsetOverrideUs= */ C.TIME_UNSET,
+        /* positionRequestedBySeek */false);
 
     if (readingPeriodHolder.prepared
         && readingPeriodHolder.mediaPeriod.readDiscontinuity() != C.TIME_UNSET) {


### PR DESCRIPTION
Any calls that issue a `seekTo()` where the position is `TIME_UNSET` will now restore the live offset target to the MediaItem set default.

The code handles an intra-period seek in the same timeline by simply updating or removing the `setTargetLiveOffsetOverrideUs()`.  Other cases call the original code.

This fixes issue #11050