### PR TITLE
Add DTSUHDSpecificBox (udts) support to parseAudioSampleEntry().

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/Atom.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/Atom.java
@@ -177,6 +177,9 @@ import java.util.List;
   public static final int TYPE_ddts = 0x64647473;
 
   @SuppressWarnings("ConstantCaseForConstants")
+  public static final int TYPE_udts = 0x75647473;
+
+  @SuppressWarnings("ConstantCaseForConstants")
   public static final int TYPE_tfdt = 0x74666474;
 
   @SuppressWarnings("ConstantCaseForConstants")

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -1560,7 +1560,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
         // because these streams can carry simultaneously multiple representations of the same
         // audio. Use stereo by default.
         channelCount = 2;
-      } else if (childAtomType == Atom.TYPE_ddts) {
+      } else if ((childAtomType == Atom.TYPE_ddts) || (childAtomType == Atom.TYPE_udts)) {
         out.format =
             new Format.Builder()
                 .setId(trackId)


### PR DESCRIPTION
Add DTSUHDSpecificBox (udts) support to parseAudioSampleEntry(). 'udts' box is defined in Table B-2 of
ETSI TS 103 491 V1.2.1 (2019-05) DTS-UHD Audio Format; Delivery of Channels, Objects and Ambisonic Sound Fields.
