### PR TITLE
Fix VP9 color space parsing in MP4 atom parser

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -1173,6 +1173,17 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
       } else if (childAtomType == Atom.TYPE_vpcC) {
         ExtractorUtil.checkContainerInput(mimeType == null, /* message= */ null);
         mimeType = (atomType == Atom.TYPE_vp08) ? MimeTypes.VIDEO_VP8 : MimeTypes.VIDEO_VP9;
+        parent.setPosition(childStartPosition + Atom.HEADER_SIZE);
+        // vpcC atom parsing based on FFmpeg implementation
+        // see https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/vpcc.c
+        parent.skipBytes(6);
+        boolean fullRangeFlag = (parent.readUnsignedByte() & 1) != 0;
+        int colorPrimaries = parent.readUnsignedByte();
+        int transferCharacteristics = parent.readUnsignedByte();
+        colorSpace = ColorInfo.isoColorPrimariesToColorSpace(colorPrimaries);
+        colorRange = fullRangeFlag ? C.COLOR_RANGE_FULL : C.COLOR_RANGE_LIMITED;
+        colorTransfer =
+            ColorInfo.isoTransferCharacteristicsToColorTransfer(transferCharacteristics);
       } else if (childAtomType == Atom.TYPE_av1C) {
         ExtractorUtil.checkContainerInput(mimeType == null, /* message= */ null);
         mimeType = MimeTypes.VIDEO_AV1;

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/mp4/AtomParsers.java
@@ -1173,10 +1173,10 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
       } else if (childAtomType == Atom.TYPE_vpcC) {
         ExtractorUtil.checkContainerInput(mimeType == null, /* message= */ null);
         mimeType = (atomType == Atom.TYPE_vp08) ? MimeTypes.VIDEO_VP8 : MimeTypes.VIDEO_VP9;
-        parent.setPosition(childStartPosition + Atom.HEADER_SIZE);
-        // vpcC atom parsing based on FFmpeg implementation
-        // see https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/vpcc.c
-        parent.skipBytes(6);
+        // See vpcC atom syntax: https://www.webmproject.org/vp9/mp4/#syntax_1
+        // Skip FullBox header, and profile and level fields
+        parent.setPosition(childStartPosition + Atom.FULL_HEADER_SIZE);
+        parent.skipBytes(2);
         boolean fullRangeFlag = (parent.readUnsignedByte() & 1) != 0;
         int colorPrimaries = parent.readUnsignedByte();
         int transferCharacteristics = parent.readUnsignedByte();


### PR DESCRIPTION
This adds VP9 color space parsing in MP4 vpcC atom.

Please refer to VP9 MP4 atom syntax documentation: https://www.webmproject.org/vp9/mp4/#syntax_1

This fix is needed to have correct color space parsing in vpcC atom because Instagram serves HDR VP9 encodings in MP4 containers.