### PR TITLE
Fix skipShortTermRefPicSets in ts/H265Reader

### DIFF
--- a/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ts/H265Reader.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/extractor/ts/H265Reader.java
@@ -433,11 +433,15 @@ public final class H265Reader implements ElementaryStreamReader {
       if (interRefPicSetPredictionFlag) {
         bitArray.skipBit(); // delta_rps_sign
         bitArray.readUnsignedExpGolombCodedInt(); // abs_delta_rps_minus1
+        int numDeltaPocs = 0;
         for (int j = 0; j <= previousNumDeltaPocs; j++) {
-          if (bitArray.readBit()) { // used_by_curr_pic_flag[j]
-            bitArray.skipBit(); // use_delta_flag[j]
+          if (!bitArray.readBit()) { // !used_by_curr_pic_flag[j]
+            if (bitArray.readBit()) numDeltaPocs++; // use_delta_flag[j]
+          } else {
+            numDeltaPocs++;
           }
         }
+        previousNumDeltaPocs = numDeltaPocs;
       } else {
         numNegativePics = bitArray.readUnsignedExpGolombCodedInt();
         numPositivePics = bitArray.readUnsignedExpGolombCodedInt();


### PR DESCRIPTION
This PR try to resolve issue androidx/media#303

The attached [media file](https://github.com/androidx/media/files/11178000/h265_playback_failed.zip) can be played by ffplay, but cause ExoPlayer throw exception during parse the SPS header from `skipShortTermRefPicSets`. 

`skipShortTermRefPicSets` is a simplified version which only used for parse SPS. The full version see H.265/HEVC 7.3.7. and [FFmpeg code](https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/hevc_ps.c#L144) and [HM code](https://vcgit.hhi.fraunhofer.de/jvet/HM/-/blob/master/source/Lib/TLibDecoder/TDecCAVLC.cpp#L106) . 

There are two bugs (or over-simplified) in the function `skipShortTermRefPicSets`, which cause this issue:

1.  Should read `use_delta_flag[j]` when `used_by_curr_pic_flag[j]` is 0. 
2.  `NumDeltaPocs` in each RefPicSet(RPS) maybe different, `previousNumDeltaPocs`  needs to be updated for predicted RPS too.

Although each RPS always predict from previous one, but the number of deltaPocs of current RPS depends on the values of `use_delta_flag[j]` and `used_by_curr_pic_flag[j]`. Currently `previousNumDeltaPocs`  only updated for non-predicted RPS.

