### PR TITLE
Add Direct Passthrough Playback Support For DTS Audio.

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/MimeTypes.java
@@ -565,6 +565,10 @@ public final class MimeTypes {
         return C.ENCODING_DTS;
       case MimeTypes.AUDIO_DTS_HD:
         return C.ENCODING_DTS_HD;
+      case MimeTypes.AUDIO_DTS_EXPRESS:
+        return C.ENCODING_DTS; // This should be ENCODING_DTS_HD when IC platforms support it.
+      case MimeTypes.AUDIO_DTS_X:
+        return C.ENCODING_DTS; // This should be ENCODING_DTS_UHD_P2 when IC platforms support it.
       case MimeTypes.AUDIO_TRUEHD:
         return C.ENCODING_DOLBY_TRUEHD;
       case MimeTypes.AUDIO_OPUS:

--- a/library/common/src/main/java/com/google/android/exoplayer2/util/Util.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/Util.java
@@ -1780,6 +1780,14 @@ public final class Util {
         return AudioFormat.CHANNEL_OUT_5POINT1 | AudioFormat.CHANNEL_OUT_BACK_CENTER;
       case 8:
         return AudioFormat.CHANNEL_OUT_7POINT1_SURROUND;
+      case 10:
+        if (Util.SDK_INT > 31) {
+          return AudioFormat.CHANNEL_OUT_5POINT1POINT4;
+        } else {
+          // This is used by DTS:X P2 with Direct Passthrough Playback.
+          // Specifying the audio format as 7.1 for 10 channels does not affect the playback.
+          return AudioFormat.CHANNEL_OUT_7POINT1_SURROUND;
+        }
       case 12:
         return AudioFormat.CHANNEL_OUT_7POINT1POINT4;
       default:

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/AudioCapabilities.java
@@ -54,8 +54,9 @@ public final class AudioCapabilities {
   @SuppressWarnings("InlinedApi")
   private static final AudioCapabilities EXTERNAL_SURROUND_SOUND_CAPABILITIES =
       new AudioCapabilities(
-          new int[] {
-            AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3
+          new int[]{
+              AudioFormat.ENCODING_PCM_16BIT, AudioFormat.ENCODING_AC3, AudioFormat.ENCODING_E_AC3,
+              AudioFormat.ENCODING_DTS, AudioFormat.ENCODING_DTS_HD
           },
           DEFAULT_MAX_CHANNEL_COUNT);
 
@@ -210,7 +211,14 @@ public final class AudioCapabilities {
       channelCount = getMaxSupportedChannelCountForPassthrough(encoding, sampleRate);
     } else {
       channelCount = format.channelCount;
-      if (channelCount > maxChannelCount) {
+
+      if (format.sampleMimeType == MimeTypes.AUDIO_DTS_X) {
+        if (channelCount > 10) {
+          // To fix wrong reporting from device. ChannelCount is reported as 8 for DTS:X P2
+          // on some devices.
+          return null;
+        }
+      } else if (channelCount > maxChannelCount) {
         return null;
       }
     }

--- a/library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/audio/DefaultAudioSink.java
@@ -674,6 +674,7 @@ public final class DefaultAudioSink implements AudioSink {
       return SINK_FORMAT_SUPPORTED_DIRECTLY;
     }
     if (audioCapabilities.isPassthroughPlaybackSupported(format)) {
+      Log.d(TAG, "Playing back audio via Direct Passthrough.");
       return SINK_FORMAT_SUPPORTED_DIRECTLY;
     }
     return SINK_FORMAT_UNSUPPORTED;

--- a/library/extractor/src/main/java/com/google/android/exoplayer2/audio/DtsUtil.java
+++ b/library/extractor/src/main/java/com/google/android/exoplayer2/audio/DtsUtil.java
@@ -39,6 +39,9 @@ public final class DtsUtil {
   private static final int SYNC_VALUE_14B_BE = 0x1FFFE800;
   private static final int SYNC_VALUE_LE = 0xFE7F0180;
   private static final int SYNC_VALUE_14B_LE = 0xFF1F00E8;
+  private static final int SYNC_EXT_SUB_LE = 0x25205864;
+  private static final int SYNC_FTOC_LE = 0xF21B4140;
+  private static final int SYNC_FTOC_NON_SYNC_LE = 0xE842C471;
   private static final byte FIRST_BYTE_BE = (byte) (SYNC_VALUE_BE >>> 24);
   private static final byte FIRST_BYTE_14B_BE = (byte) (SYNC_VALUE_14B_BE >>> 24);
   private static final byte FIRST_BYTE_LE = (byte) (SYNC_VALUE_LE >>> 24);
@@ -147,6 +150,17 @@ public final class DtsUtil {
    * @return The number of audio samples represented by the syncframe.
    */
   public static int parseDtsAudioSampleCount(ByteBuffer buffer) {
+    // Check for sync or non sync word for DTS:X Profile 2.
+    // DTS:X Profile 2's FrameSize = 1024.
+    if ((buffer.getInt(0) == SYNC_FTOC_LE) || (buffer.getInt(0) == SYNC_FTOC_NON_SYNC_LE)) {
+      return 1024;
+    }
+    // Check for sync word for DTS Express.
+    // DTS Express's FrameSize = 4096.
+    else if (buffer.getInt(0) == SYNC_EXT_SUB_LE) {
+      return 4096;
+    }
+
     // See ETSI TS 102 114 subsection 5.4.1.
     int position = buffer.position();
     int nblks;

--- a/media3-migration.sh
+++ b/media3-migration.sh
@@ -217,9 +217,9 @@ function validate_string_patterns {
     'The MediaSessionConnector is integrated in androidx.media3.session.MediaSession'
 }
 
-SED_CMD_INPLACE='sed -i '
+SED_CMD_INPLACE='sed --in-place=.bak '
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  SED_CMD_INPLACE="sed -i '' "
+  SED_CMD_INPLACE="sed -i .bak "
 fi
 
 MIGRATE_FILES='1'
@@ -322,12 +322,9 @@ then
   exit 0
 fi
 
-PWD=$(pwd)
 if [[ ! -z $NO_CLEAN ]];
 then
-  cd "$PROJECT_ROOT"
   ./gradlew clean
-  cd "$PWD"
 fi
 
 # create expressions for class renamings
@@ -367,6 +364,7 @@ do
   echo "migrating $file"
   expr="$renaming_expressions $classes_expressions $packages_expressions"
   $SED_CMD_INPLACE $expr $file
+  rm ${file}.bak
 done <<< "$files"
 
 # create expressions for dependencies in gradle files
@@ -385,4 +383,5 @@ while read -r build_file;
 do
   echo "migrating build file $build_file"
   $SED_CMD_INPLACE $dependency_expressions $build_file
+  rm ${build_file}.bak
 done <<< "$(find . -type f -name 'build\.gradle')"


### PR DESCRIPTION
This adds DTS Audio Support for Direct Passthrough playback. This is required for Tunnel mode playback on Android TVs that supports tunnel mode playback (e.g. MTK and Realtek based TVs). Test streams will be provided during the review if required.
Thanks.