### PR TITLE
Save state throwsWhenUsingWrongThread when ListenerSet::copy()

### DIFF
--- a/library/common/src/main/java/com/google/android/exoplayer2/util/ListenerSet.java
+++ b/library/common/src/main/java/com/google/android/exoplayer2/util/ListenerSet.java
@@ -97,14 +97,16 @@ public final class ListenerSet<T extends @NonNull Object> {
    *     during one {@link Looper} message queue iteration were handled by the listeners.
    */
   public ListenerSet(Looper looper, Clock clock, IterationFinishedEvent<T> iterationFinishedEvent) {
-    this(/* listeners= */ new CopyOnWriteArraySet<>(), looper, clock, iterationFinishedEvent);
+    this(/* listeners= */ new CopyOnWriteArraySet<>(), looper, clock, iterationFinishedEvent, true);
   }
 
   private ListenerSet(
       CopyOnWriteArraySet<ListenerHolder<T>> listeners,
       Looper looper,
       Clock clock,
-      IterationFinishedEvent<T> iterationFinishedEvent) {
+      IterationFinishedEvent<T> iterationFinishedEvent,
+      Boolean throwsWhenUsingWrongThread
+      ) {
     this.clock = clock;
     this.listeners = listeners;
     this.iterationFinishedEvent = iterationFinishedEvent;
@@ -115,7 +117,7 @@ public final class ListenerSet<T extends @NonNull Object> {
     @SuppressWarnings("nullness:methodref.receiver.bound")
     HandlerWrapper handler = clock.createHandler(looper, this::handleMessage);
     this.handler = handler;
-    throwsWhenUsingWrongThread = true;
+    this.throwsWhenUsingWrongThread = throwsWhenUsingWrongThread;
   }
 
   /**
@@ -147,7 +149,7 @@ public final class ListenerSet<T extends @NonNull Object> {
   @CheckResult
   public ListenerSet<T> copy(
       Looper looper, Clock clock, IterationFinishedEvent<T> iterationFinishedEvent) {
-    return new ListenerSet<>(listeners, looper, clock, iterationFinishedEvent);
+    return new ListenerSet<>(listeners, looper, clock, iterationFinishedEvent, throwsWhenUsingWrongThread);
   }
 
   /**


### PR DESCRIPTION
`ListenerSet::copy()` does not save the state `throwsWhenUsingWrongThread`. This PR is to address that issue.