### PR TITLE
Subsequent `selectTracks() after prepare does not override position

### DIFF
--- a/library/core/src/main/java/com/google/android/exoplayer2/source/MaskingMediaPeriod.java
+++ b/library/core/src/main/java/com/google/android/exoplayer2/source/MaskingMediaPeriod.java
@@ -187,8 +187,8 @@ public final class MaskingMediaPeriod implements MediaPeriod, MediaPeriod.Callba
       long positionUs) {
     if (preparePositionOverrideUs != C.TIME_UNSET && positionUs == preparePositionUs) {
       positionUs = preparePositionOverrideUs;
-      preparePositionOverrideUs = C.TIME_UNSET;
     }
+    preparePositionOverrideUs = C.TIME_UNSET;
     return castNonNull(mediaPeriod)
         .selectTracks(selections, mayRetainStreamFlags, streams, streamResetFlags, positionUs);
   }


### PR DESCRIPTION
The MaskingMediaPeriod.onChildSourceInfoRefreshed() already has the position correct from the initial timeline update, since the `preparePositionUs` is 0 the second condition in the if:

```
    if (preparePositionOverrideUs != C.TIME_UNSET && positionUs == preparePositionUs) {
	...
```
is false, so the `preparePositionUs` is not reset.  This causes it to be used incorrectly on subsequent `selectTracks()` calls where `positionUs` does match `preparePositionUs`

The fix simply resets the `preparePositionOverrideUs` unconditionally, as only the initial `selectTracks()` after the prepared transition should use the override