### PR TITLE
Fixing Period Switch Ref Update Issue in Manifest Parsing

### DIFF
--- a/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaPeriod.java
+++ b/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/DashMediaPeriod.java
@@ -369,7 +369,21 @@ import org.checkerframework.checker.nullness.compatqual.NullableType;
     int[] streamIndexToTrackGroupIndex = new int[selections.length];
     for (int i = 0; i < selections.length; i++) {
       if (selections[i] != null) {
-        streamIndexToTrackGroupIndex[i] = trackGroups.indexOf(selections[i].getTrackGroup());
+        int trackIndex = trackGroups.indexOf(selections[i].getTrackGroup());
+
+        // fallback in case we could not find map trackGroups through reference
+        if(trackIndex == C.INDEX_UNSET) {
+          for(int y = 0; y < trackGroups.length; y++) {
+            String trackFormatId = trackGroups.get(y).getFormat(0).id;
+            String selectionFormatId = selections[i].getTrackGroup().getFormat(0).id;
+
+            if(trackFormatId.equals(selectionFormatId)) {
+              trackIndex = y;
+              break;
+            }
+          }
+        }
+        streamIndexToTrackGroupIndex[i] = trackIndex;
       } else {
         streamIndexToTrackGroupIndex[i] = C.INDEX_UNSET;
       }


### PR DESCRIPTION
This merge request addresses a critical issue in the manifest parsing functionality, specifically related to period transitions. The problem arises from the failure to update references correctly when encountering a period switch during parsing.

Previously, the parser would generate objects for each period with specific references. However, upon transitioning to a new period, these references were not appropriately updated since it creates a new tracks object with a new reference . Consequently, subsequent attempts to utilize the `getStreamIndexToTrackGroupIndex` function to retrieve track group information would employ outdated references. As a result, the parser failed to locate the necessary data, leading to application crashes.

To rectify this issue, this merge request introduces a fix that ensures the accurate updating of references during period switches. The fix involves identifying the group index using the track ID, thereby ensuring the retrieval of correct track group information across period transitions.

This enhancement aims to enhance the stability and reliability of the manifest parsing process, preventing crashes and ensuring seamless functionality, particularly during period switches.